### PR TITLE
perf: multi-core scaling baseline + empirical bottleneck (per-page pin on hot pages)

### DIFF
--- a/docs/design/scaling-findings.md
+++ b/docs/design/scaling-findings.md
@@ -1,0 +1,97 @@
+# Empirical multi-core scaling findings
+
+Measured on **meh** (Linux 6.12, Xeon E5-2697 v2, 12c/24t, single socket) with
+`lab/bench/scale_bench.c` against a stock Autoconf build of `master`. All data
+fit in a 512 MB cache (no device I/O on the read paths).
+
+## Throughput vs threads
+
+Read-random, in-cache point gets on a 200k-key B-tree:
+
+| threads | ops/sec | scaling vs 1t |
+|--------:|--------:|--------------:|
+| 1 | 200,010 | 1.0x |
+| 2 | 234,004 | 1.2x |
+| 4 | 399,883 | 2.0x |
+| 8 | **464,661** | 2.3x (peak) |
+| 12 | 448,775 | — |
+| 16 | 416,366 | — |
+| 24 | 408,518 | **negative** |
+
+Read throughput **peaks at ~8 threads and then declines** — on a 24-thread box
+we get ~2.3x, not ~12-24x.
+
+## Where the time goes (perf, rrand @ 24t, self-time)
+
+```
+66.70%  [kernel] (futex)                 <- threads blocked in the kernel
+35.43%  __db_pthread_mutex_lock
+31.58%  __db_pthread_mutex_unlock
+30.55%  __lll_lock_wait / 28% __lll_lock_wake
+26.33%  __memp_fget        22.55%  __memp_fput
+21.90%  __atomic_inc       20.91%  __atomic_dec
+48.56%  __bam_search (B-tree descent; calls __memp_fget per level)
+```
+
+BDB's own wait counters (`lockpart%`, `mpoolhash%`, region waits) are **near
+zero** — the contention does not show up there because it is the **per-page
+buffer mutex** (a pthread mutex → futex) and the **page reference count** atomic,
+not a lock-region/partition mutex.
+
+## Root cause
+
+Every B-tree search descends through the **root and internal pages**. Each
+`__memp_fget` (a) takes that buffer header's mutex and (b) atomically increments
+its pin/reference count; `__memp_fput` reverses it. Because the **root page is
+fetched by every operation on every thread**, its mutex and refcount cache line
+become a single global serialization point:
+
+- under the pthread-mutex build, that mutex goes to the kernel → the **66.7%
+  futex** storm (and negative scaling past the point where futex contention
+  dominates);
+- the refcount atomic inc/dec (~43% combined self-time) ping-pongs one cache
+  line across all cores.
+
+## Workload contrasts (confirming the cause)
+
+- **rhot** (all threads read ONE key): adds lock-manager **partition-mutex**
+  contention — `lockpart%` rises 13% (4t) → 37.5% (24t) — because every read
+  takes a *page read lock* on the single hot page. Reads don't conflict
+  (`conflict%=0`) but acquiring the read lock latches the partition. Page-level
+  read locking is pure overhead for read-mostly workloads.
+- **wrand** (random writes, auto-commit): ~**733 ops/sec single-threaded** —
+  fsync-per-commit bound — and the **lock region mutex** is heavily contended
+  (`lockreg_w` in the thousands). Writes need group commit.
+
+## What this means for the ROADMAP (data-driven re-prioritization)
+
+1. **#2 latch-free / contention-free buffer-header access is the #1 read-scaling
+   fix.** The dominant cost is the per-page mutex + refcount on hot (root /
+   internal) pages. Directions: don't take a kernel-bound mutex to pin a
+   resident page (optimistic/version-validated reads, LeanStore-style), shard or
+   bias-lock the pin count, and avoid pinning hot internal pages on the read
+   path.
+2. **#7 cache-line / false-sharing** is the close-second cost (the refcount
+   atomic). Splitting/aligning the pin counter pairs directly with #2.
+3. **#3 group-commit WAL** is the clear write-path win (writes are fsync-bound),
+   plus the lock-region mutex needs attention under writes.
+4. **#4 lock manager**: page-level read locks are needless overhead for
+   read-mostly access (snapshot/SI reads already skip them — see SSI) and are
+   the hot-key bottleneck.
+5. **Lower priority than the ROADMAP assumed on these boxes:** the mpool **hash**
+   mutex and lock **partitions** are *not* contended here (~0 wait), and both
+   hosts are single-socket so NUMA placement (part of #1) can't be validated.
+   The sharded-buffer-pool hash work matters less than the per-page-pin work
+   until we test on a multi-socket NUMA box.
+
+**Next target: #2 (+#7).** Prototype a contention-free pin for resident pages
+and re-run this sweep to confirm the 8-thread ceiling lifts.
+
+## Reproduce
+
+```sh
+# on a build host:
+cc -O2 -pthread lab/bench/scale_bench.c -Ibuild_unix -Lbuild_unix/.libs -ldb-5.3 -o scale_bench
+LD_LIBRARY_PATH=build_unix/.libs ./scale_bench rrand 200000 3 1 2 4 8 12 16 24
+#   workloads: rrand | rhot | wrand
+```

--- a/lab/bench/Makefile
+++ b/lab/bench/Makefile
@@ -1,0 +1,6 @@
+# Build against an Autoconf build tree: make BDB=../../build_unix
+BDB ?= ../../build_unix
+CFLAGS ?= -O2 -pthread
+scale_bench: scale_bench.c
+	$(CC) $(CFLAGS) scale_bench.c -I$(BDB) -L$(BDB)/.libs -ldb-5.3 -o $@
+clean:; rm -f scale_bench

--- a/lab/bench/scale_bench.c
+++ b/lab/bench/scale_bench.c
@@ -1,0 +1,187 @@
+/*-
+ * libdb scaling probe: drive a shared environment from T threads and read
+ * BDB's own wait counters to see which subsystem serializes as cores scale.
+ *
+ * Workloads:
+ *   rrand  - read random keys      (exposes lock-mgr read locks + mpool hash)
+ *   rhot   - read ONE hot key       (forces single-page / single-bucket contention)
+ *   wrand  - write random keys      (exposes log region + write locks + mpool)
+ *
+ * For each (workload, threads) run it resets the mpool/lock/mutex stats, runs
+ * for a fixed wall-clock, then prints throughput and the wait ratios so the
+ * bottleneck is visible.
+ *
+ *   cc -O2 -pthread scale_bench.c -I<build> -L<build>/.libs -ldb-5.3 -o scale_bench
+ *   ./scale_bench <workload> <nkeys> <secs> <t1> [t2 ...]
+ */
+#include <sys/types.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "db.h"
+
+static DB_ENV *env;
+static DB *db;
+static volatile int stop;
+static pthread_barrier_t barrier;
+static int g_workload;	/* 0=rrand 1=rhot 2=wrand */
+static uint32_t g_nkeys;
+
+enum { W_RRAND = 0, W_RHOT = 1, W_WRAND = 2 };
+
+static double
+now_sec(void)
+{
+	struct timespec ts;
+	clock_gettime(CLOCK_MONOTONIC, &ts);
+	return (ts.tv_sec + ts.tv_nsec / 1e9);
+}
+
+static void
+fill_key(DBT *k, uint32_t *kb, uint32_t v)
+{
+	*kb = v;
+	memset(k, 0, sizeof(*k));
+	k->data = kb;
+	k->size = sizeof(*kb);
+}
+
+typedef struct { uint64_t ops; unsigned seed; } targ_t;
+
+static void *
+worker(void *a)
+{
+	targ_t *t = a;
+	DBT key, data;
+	uint32_t kb, vbuf[32];
+	char wbuf[100];
+	int ret;
+
+	memset(wbuf, 'x', sizeof(wbuf));
+	pthread_barrier_wait(&barrier);
+	while (!stop) {
+		uint32_t k = (g_workload == W_RHOT) ? 0 :
+		    (uint32_t)(rand_r(&t->seed) % g_nkeys);
+		fill_key(&key, &kb, k);
+		if (g_workload == W_WRAND) {
+			memset(&data, 0, sizeof(data));
+			data.data = wbuf; data.size = sizeof(wbuf);
+			ret = db->put(db, NULL, &key, &data, 0);
+		} else {
+			memset(&data, 0, sizeof(data));
+			data.data = vbuf; data.ulen = sizeof(vbuf);
+			data.flags = DB_DBT_USERMEM;
+			ret = db->get(db, NULL, &key, &data, 0);
+			if (ret == DB_BUFFER_SMALL) ret = 0;
+		}
+		if (ret != 0 && ret != DB_NOTFOUND) {
+			env->err(env, ret, "op k=%u", k);
+			return (NULL);
+		}
+		t->ops++;
+	}
+	return (NULL);
+}
+
+static void
+run(int nthreads, double secs)
+{
+	pthread_t th[256];
+	targ_t ta[256];
+	DB_MPOOL_STAT *mp;
+	DB_LOCK_STAT *lk;
+	DB_MUTEX_STAT *mx;
+	double t0, dur;
+	uint64_t total = 0;
+	int i;
+
+	/* Reset wait counters. */
+	(void)env->memp_stat(env, &mp, NULL, DB_STAT_CLEAR); free(mp);
+	(void)env->lock_stat(env, &lk, DB_STAT_CLEAR); free(lk);
+	(void)env->mutex_stat(env, &mx, DB_STAT_CLEAR); free(mx);
+
+	stop = 0;
+	pthread_barrier_init(&barrier, NULL, (unsigned)nthreads + 1);
+	for (i = 0; i < nthreads; i++) {
+		ta[i].ops = 0; ta[i].seed = (unsigned)(i * 2654435761u + 1);
+		pthread_create(&th[i], NULL, worker, &ta[i]);
+	}
+	pthread_barrier_wait(&barrier);
+	t0 = now_sec();
+	struct timespec sl = { (time_t)secs, (long)((secs - (long)secs) * 1e9) };
+	nanosleep(&sl, NULL);
+	stop = 1;
+	for (i = 0; i < nthreads; i++) { pthread_join(th[i], NULL); total += ta[i].ops; }
+	dur = now_sec() - t0;
+
+	(void)env->memp_stat(env, &mp, NULL, 0);
+	(void)env->lock_stat(env, &lk, 0);
+	(void)env->mutex_stat(env, &mx, 0);
+
+#define PCT(w, nw) (((w) + (nw)) ? 100.0 * (double)(w) / ((double)(w) + (double)(nw)) : 0.0)
+	printf("%-6s %3d %12.0f  conflict%%=%4.1f lockpart%%=%4.1f "
+	    "mpoolhash%%=%4.1f objs%%=%4.1f lockers%%=%4.1f  "
+	    "lockreg_w=%llu mpoolreg_w=%llu mtxreg_w=%llu npart=%u\n",
+	    g_workload == W_RRAND ? "rrand" : g_workload == W_RHOT ? "rhot" : "wrand",
+	    nthreads, total / dur,
+	    PCT(lk->st_lock_wait, lk->st_lock_nowait),
+	    PCT(lk->st_part_wait, lk->st_part_nowait),
+	    PCT(mp->st_hash_wait, mp->st_hash_nowait),
+	    PCT(lk->st_objs_wait, lk->st_objs_nowait),
+	    PCT(lk->st_lockers_wait, lk->st_lockers_nowait),
+	    (unsigned long long)lk->st_region_wait,
+	    (unsigned long long)mp->st_region_wait,
+	    (unsigned long long)mx->st_region_wait,
+	    lk->st_partitions);
+	fflush(stdout);
+	free(mp); free(lk); free(mx);
+}
+
+int
+main(int argc, char **argv)
+{
+	DBT key, data;
+	uint32_t kb, i;
+	char vbuf[100];
+	int ret, ai;
+
+	if (argc < 5) {
+		fprintf(stderr, "usage: %s <rrand|rhot|wrand> <nkeys> <secs> <t..>\n", argv[0]);
+		return (1);
+	}
+	g_workload = strcmp(argv[1], "rhot") == 0 ? W_RHOT :
+	    strcmp(argv[1], "wrand") == 0 ? W_WRAND : W_RRAND;
+	g_nkeys = (uint32_t)atoi(argv[2]);
+	double secs = atof(argv[3]);
+
+	system("rm -rf ./SCALEDB && mkdir ./SCALEDB");
+	if ((ret = db_env_create(&env, 0)) != 0) { fprintf(stderr, "env_create %d\n", ret); return 1; }
+	env->set_errfile(env, stderr);
+	env->set_cachesize(env, 0, 512 * 1024 * 1024, 1);	/* 512MB: all in cache */
+	if ((ret = env->open(env, "./SCALEDB",
+	    DB_CREATE | DB_INIT_MPOOL | DB_INIT_LOCK | DB_INIT_TXN | DB_INIT_LOG |
+	    DB_THREAD, 0)) != 0) { env->err(env, ret, "env open"); return 1; }
+	if ((ret = db_create(&db, env, 0)) != 0) { env->err(env, ret, "db_create"); return 1; }
+	if ((ret = db->open(db, NULL, "bench.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT | DB_THREAD, 0)) != 0) { env->err(env, ret, "db open"); return 1; }
+
+	memset(vbuf, 'v', sizeof(vbuf));
+	for (i = 0; i < g_nkeys; i++) {
+		fill_key(&key, &kb, i);
+		memset(&data, 0, sizeof(data)); data.data = vbuf; data.size = sizeof(vbuf);
+		if ((ret = db->put(db, NULL, &key, &data, 0)) != 0) { env->err(env, ret, "load"); return 1; }
+	}
+	printf("# loaded %u keys; workload=%s secs=%.1f\n", g_nkeys, argv[1], secs);
+	printf("# wkld  thr      ops/sec  contention signals\n");
+
+	for (ai = 4; ai < argc; ai++)
+		run(atoi(argv[ai]), secs);
+
+	db->close(db, 0);
+	env->close(env, 0);
+	return (0);
+}


### PR DESCRIPTION
Empirical answer to *what makes BDB slow down as cores increase*, measured on `meh` (24t, single socket) with a new harness (`lab/bench/scale_bench.c`).

**Finding:** read-random throughput **peaks at ~8 threads then declines** (24t < 8t). `perf` self-time: **66.7% in the kernel futex**, `__db_pthread_mutex_lock` 35%, `__memp_fget`/`__memp_fput` 26%/22%, `__atomic_inc`/`dec` ~43% combined. BDB's own wait counters (`lockpart%`, `mpoolhash%`, region waits) are ~0.

**Root cause:** every B-tree search pins the **root + internal pages** via `__memp_fget`, which takes that page's **buffer-header mutex** (pthread → futex) and bumps its **atomic refcount**. The root is fetched by every op on every thread → one mutex + one cache line serialize the whole workload.

**Contrasts:** hot-key reads add lock-**partition** latch contention (page read locks; `lockpart%`→37.5%); random writes are fsync-bound (~733 ops/s/thread) with heavy lock-**region** mutex contention.

**Data-driven priority:** **#2 latch-free buffer-header access (+#7 cache-line)** is the top read-scaling fix; **#3 group commit** for writes. The mpool **hash** mutex and lock **partitions** are *not* contended here, and both test hosts are single-socket — so #1's hash-shard/NUMA work ranks lower until we have a multi-socket box. Full write-up in `docs/design/scaling-findings.md`.