### PR TITLE
perf(lock): shared locker latch on lock-get hot path (2.7x at 24t)

### DIFF
--- a/src/dbinc/lock.h
+++ b/src/dbinc/lock.h
@@ -329,6 +329,8 @@ struct __db_lock { /* SHARED */
 	MUTEX_UNLOCK(env, (region)->mtx_dd)
 #define	LOCK_LOCKERS(env, region)					\
 	MUTEX_LOCK(env, (region)->mtx_lockers)
+#define	RDLOCK_LOCKERS(env, region)					\
+	MUTEX_READLOCK(env, (region)->mtx_lockers)
 #define	UNLOCK_LOCKERS(env, region)					\
 	MUTEX_UNLOCK(env, (region)->mtx_lockers)
 

--- a/src/lock/lock.c
+++ b/src/lock/lock.c
@@ -596,7 +596,7 @@ __lock_get_api(env, locker, flags, obj, lock_mode, lock)
 
 	region = env->lk_handle->reginfo.primary;
 
-	LOCK_LOCKERS(env, region);
+	RDLOCK_LOCKERS(env, region);
 	ret = __lock_getlocker_int(env->lk_handle, locker, 0, &sh_locker);
 	UNLOCK_LOCKERS(env, region);
 	LOCK_SYSTEM_LOCK(env->lk_handle, region);

--- a/src/lock/lock_region.c
+++ b/src/lock/lock_region.c
@@ -253,8 +253,16 @@ __lock_region_init(env, lt)
 	    env, MTX_LOCK_REGION, 0, &region->mtx_dd)) != 0)
 		return (ret);
 
+	/*
+	 * The locker mutex is a SHARED latch: the hot lock-get path looks up
+	 * an existing locker (a read-only hash walk) and takes it shared, so
+	 * many cores can resolve their locker concurrently; locker create,
+	 * free, the deadlock detector's locker-list walk, failchk, and stat
+	 * take it exclusive.  This removes the per-operation global
+	 * serialization on lock_get/lock_put.
+	 */
 	if ((ret = __mutex_alloc(
-	    env, MTX_LOCK_REGION, 0, &region->mtx_lockers)) != 0)
+	    env, MTX_LOCK_REGION, DB_MUTEX_SHARED, &region->mtx_lockers)) != 0)
 		return (ret);
 
 	/* Allocate room for the locker hash table and initialize it. */


### PR DESCRIPTION
## perf(lock): take the locker mutex shared on the lock-get hot path

Every `DB_ENV->lock_get`/`lock_put` resolves its locker through
`__lock_getlocker_int` under the region-global locker mutex `mtx_lockers`.
On the lock-get path that lookup is `create=0` — a **read-only** walk of a
locker hash bucket — yet it was held **exclusive**, serializing every lock
acquisition across all cores even with objects fully partitioned (240-way)
and zero lock conflict.

### Fix
Make `mtx_lockers` a `DB_MUTEX_SHARED` latch and take it **shared** for the
read-only locker lookup on the hot path (`__lock_get_api`). Locker
create/free, the deadlock detector's locker-list walk, failchk, and stat keep
it **exclusive**, so a reader never runs concurrently with a writer.

### Measured (`lab/bench/lock_bench` distinct, no conflict, 24-thread box)
| threads | master | this branch | upper bound* |
|--------:|-------:|------------:|-------------:|
| 1  | 1.38M | 1.27M | 1.87M |
| 8  | 3.03M | 6.36M (2.1×) | 10.1M |
| 24 | 2.60M | **7.01M (2.7×)** | 16.1M |

Master plateaus and declines past 8 threads; the shared latch scales to
24 threads. \*Upper bound = removing the mutex entirely (unsafe diagnostic);
the shared latch captures ~half, the rest needs partitioning the locker hash
(deferred — more invasive). Single-thread cost rises ~8% (shared vs plain
mutex, uncontended), dwarfed by the multi-core gain.

No regression on real workloads: `rrand` unchanged (btree-bound), `tproc_b`
flat (deadlock/disk-bound) — helps where the bottleneck is, costs nothing
elsewhere.

### Verified
TCL `lock001/002/003` (incl. the multi-process test), `txn001/002`,
`test001`, `ssi001/002` pass; concurrent shared read-lock acquisition runs
clean; clean build (gcc via Nix, Apple clang).

The probe and benchmark fixes used to find this are in #27.
