### PR TITLE
fix(hotbackup): bound home-path construction with snprintf

### DIFF
--- a/build_vxworks/util/db_hotbackup.c
+++ b/build_vxworks/util/db_hotbackup.c
@@ -452,7 +452,7 @@ db_hotbackup_env_init(dbenvp, home, log_dirp, data_dirp, passwd, which, verbose)
 			 * trim the home directory from the data directory
 			 * passed in.
 			 */
-			(void) sprintf(buf, "%s/%s", home, home);
+			(void)snprintf(buf, sizeof(buf), "%s/%s", home, home);
 			homehome = 0;
 			(void)__os_exists(dbenv->env, buf, &homehome);
 				

--- a/util/db_hotbackup.c
+++ b/util/db_hotbackup.c
@@ -437,7 +437,7 @@ env_init(dbenvp, home, log_dirp, data_dirp, passwd, which, verbose)
 			 * trim the home directory from the data directory
 			 * passed in.
 			 */
-			(void) sprintf(buf, "%s/%s", home, home);
+			(void)snprintf(buf, sizeof(buf), "%s/%s", home, home);
 			homehome = 0;
 			(void)__os_exists(dbenv->env, buf, &homehome);
 				


### PR DESCRIPTION
## What

`db_hotbackup` built a probe path with `sprintf(buf, "%s/%s", home, home)`
into a fixed `char buf[DB_MAXPATHLEN]` stack buffer. A `-h` argument longer
than ~`DB_MAXPATHLEN/2` overflows `buf`.

Replace with `snprintf(buf, sizeof(buf), ...)`, matching the already-bounded
`snprintf` call later in the same function. Applied to the canonical
`util/db_hotbackup.c` and the checked-in `build_vxworks/util/db_hotbackup.c`
copy.

## Impact

`db_hotbackup` is a local command-line utility run by the operator, not a
remotely reachable surface, so the practical severity is limited (an operator
overflowing their own tool's stack). It is still a real unbounded write and
worth fixing.

## Verification

- Builds clean (`make db_hotbackup`, no new warnings).
- Functional check: `db_hotbackup -h <4096 'A's>` now fails cleanly with
  "File name too long" instead of crashing; previously the `sprintf` wrote
  ~8KB into a `DB_MAXPATHLEN` buffer.

## Note

Supersedes #23, which targeted the right line but patched only the generated
`build_vxworks/` copy and shipped a standalone regression test that exercised
a local `snprintf` rather than the actual code path. This change fixes the
canonical source (and the vxworks copy) and verifies the real utility.
