### PR TITLE
build(atomic): detect GCC/Clang __atomic builtins, enabling native atomics

### DIFF
--- a/dist/aclocal/mutex.m4
+++ b/dist/aclocal/mutex.m4
@@ -1010,6 +1010,8 @@ AH_TEMPLATE(HAVE_ATOMIC_SOLARIS,
     [Define to 1 to use Solaris library routes for atomic operations.])
 AH_TEMPLATE(HAVE_ATOMIC_BUILTINS,
     [Define to 1 to use GCC __atomic_* builtins for atomic operations.])
+AH_TEMPLATE(HAVE_ATOMIC_GCC_BUILTIN,
+    [Define to 1 when the GCC/Clang __atomic_* builtin tier is selected.])
 AH_TEMPLATE(HAVE_SYNC_BUILTINS,
     [Define to 1 to use GCC __sync_* builtins for atomic operations.])
 AH_TEMPLATE(HAVE_ATOMIC_AARCH64,
@@ -1030,11 +1032,24 @@ if test "$db_cv_mingw" = yes; then
 fi
 
 if test "$db_cv_atomic" = no; then
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <stdint.h>]], [[
+	uint32_t val32 = 1;
+	uint32_t exp32 = 1;
+	intptr_t valp = 1;
+	intptr_t expp = 1;
+	__atomic_add_fetch(&val32, 1, __ATOMIC_SEQ_CST);
+	__atomic_compare_exchange_n(&val32, &exp32, 2, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	__atomic_compare_exchange_n(&valp, &expp, 2, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+]])], [db_cv_atomic="gcc/__atomic"])
+fi
+
+if test "$db_cv_atomic" = no; then
 	AC_COMPILE_IFELSE([AC_LANG_PROGRAM(, [[
 	#if ((defined(i386) || defined(__i386__)) && defined(__GNUC__))
-		exit(0);
+		(void)0;
 	#elif ((defined(x86_64) || defined(__x86_64__)) && defined(__GNUC__))
-		exit(0);
+		(void)0;
 	#else
 		FAIL TO COMPILE/LINK
 	#endif
@@ -1053,6 +1068,12 @@ fi
 ])
 
 case "$db_cv_atomic" in
+	gcc/__atomic)
+		AC_DEFINE(HAVE_ATOMIC_SUPPORT)
+		AC_DEFINE(HAVE_ATOMIC_BUILTINS)
+		AC_DEFINE(HAVE_ATOMIC_GCC_BUILTIN)
+		;;
+
 	x86/gcc-assembly)
 		AC_DEFINE(HAVE_ATOMIC_SUPPORT)
 		AC_DEFINE(HAVE_ATOMIC_X86_GCC_ASSEMBLY)
@@ -1085,6 +1106,16 @@ fi
 AC_CACHE_CHECK([for 64-bit atomic operations], db_cv_atomic_64bit, [
 db_cv_atomic_64bit=no
 case "$db_cv_atomic" in
+	gcc/__atomic)
+		AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <stdint.h>]], [[
+	int64_t val = 1;
+	int64_t exp = 1;
+	__atomic_add_fetch(&val, 1, __ATOMIC_SEQ_CST);
+	__atomic_sub_fetch(&val, 1, __ATOMIC_SEQ_CST);
+	__atomic_compare_exchange_n(&val, &exp, 2, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+]])], [db_cv_atomic_64bit=yes])
+		;;
 	x86/gcc-assembly)
 		AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdint.h>]], [[

--- a/dist/config.hin
+++ b/dist/config.hin
@@ -64,6 +64,9 @@
 /* Define to 1 to use GCC __atomic_* builtins for atomic operations. */
 #undef HAVE_ATOMIC_BUILTINS
 
+/* Define to 1 when the GCC/Clang __atomic_* builtin tier is selected. */
+#undef HAVE_ATOMIC_GCC_BUILTIN
+
 /* Define to 1 to use Solaris library routes for atomic operations. */
 #undef HAVE_ATOMIC_SOLARIS
 

--- a/dist/configure
+++ b/dist/configure
@@ -25809,6 +25809,7 @@ esac
 
 
 
+
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking for atomic operations" >&5
 printf %s "checking for atomic operations... " >&6; }
 if test ${db_cv_atomic+y}
@@ -25828,6 +25829,35 @@ if test "$db_cv_mingw" = yes; then
 fi
 
 if test "$db_cv_atomic" = no; then
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <stdint.h>
+int
+main (void)
+{
+
+	uint32_t val32 = 1;
+	uint32_t exp32 = 1;
+	intptr_t valp = 1;
+	intptr_t expp = 1;
+	__atomic_add_fetch(&val32, 1, __ATOMIC_SEQ_CST);
+	__atomic_compare_exchange_n(&val32, &exp32, 2, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+	__atomic_compare_exchange_n(&valp, &expp, 2, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  db_cv_atomic="gcc/__atomic"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+fi
+
+if test "$db_cv_atomic" = no; then
 	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -25836,9 +25866,9 @@ main (void)
 {
 
 	#if ((defined(i386) || defined(__i386__)) && defined(__GNUC__))
-		exit(0);
+		(void)0;
 	#elif ((defined(x86_64) || defined(__x86_64__)) && defined(__GNUC__))
-		exit(0);
+		(void)0;
 	#else
 		FAIL TO COMPILE/LINK
 	#endif
@@ -25886,6 +25916,15 @@ fi
 printf '%s\n' "$db_cv_atomic" >&6; }
 
 case "$db_cv_atomic" in
+	gcc/__atomic)
+		printf '%s\n' "#define HAVE_ATOMIC_SUPPORT 1" >>confdefs.h
+
+		printf '%s\n' "#define HAVE_ATOMIC_BUILTINS 1" >>confdefs.h
+
+		printf '%s\n' "#define HAVE_ATOMIC_GCC_BUILTIN 1" >>confdefs.h
+
+		;;
+
 	x86/gcc-assembly)
 		printf '%s\n' "#define HAVE_ATOMIC_SUPPORT 1" >>confdefs.h
 
@@ -25958,6 +25997,32 @@ else case e in #(
   e)
 db_cv_atomic_64bit=no
 case "$db_cv_atomic" in
+	gcc/__atomic)
+		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <stdint.h>
+int
+main (void)
+{
+
+	int64_t val = 1;
+	int64_t exp = 1;
+	__atomic_add_fetch(&val, 1, __ATOMIC_SEQ_CST);
+	__atomic_sub_fetch(&val, 1, __ATOMIC_SEQ_CST);
+	__atomic_compare_exchange_n(&val, &exp, 2, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"
+then :
+  db_cv_atomic_64bit=yes
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.beam \
+    conftest$ac_exeext conftest.$ac_ext
+		;;
 	x86/gcc-assembly)
 		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */


### PR DESCRIPTION
## What

Teach `configure` to detect the GCC/Clang `__atomic` builtins and select them
as the atomic-operations backend, ahead of the inline-assembly tier.

## Why

The atomic-operation detection in `dist/aclocal/mutex.m4` only knew the
x86/gcc-assembly, Solaris, and MinGW tiers. On a modern clang or gcc toolchain
the x86/gcc-assembly probe runs first and fails to compile (its probe body
calls `exit()` with no `<stdlib.h>`, a hard error under C99+). Detection then
falls through every remaining tier and `db_cv_atomic` ends up `no`.

With `HAVE_ATOMIC_SUPPORT` undefined, the engine uses the mutex-emulated atomic
tier: `atomic_inc`/`atomic_dec`/`atomic_compare_exchange` on mpool buffer
refcounts, shared-latch reader counts, and lock-manager counters each take a
pool mutex. Native hardware atomics were silently off on every modern build.

This is the same class of issue as the K&R / C-standard fix in #25.

## Change

- Add a `__atomic` builtin probe (tests `__atomic_add_fetch` plus 32-bit and
  pointer-width `__atomic_compare_exchange_n`) and try it before the inline-asm
  probe. The builtin tier is portable across architectures and provides the
  full set of primitives the engine uses, including 64-bit and pointer-width
  compare-and-swap.
- When it matches, define `HAVE_ATOMIC_SUPPORT`, `HAVE_ATOMIC_BUILTINS`, and
  `HAVE_ATOMIC_GCC_BUILTIN`, and probe 64-bit support so `HAVE_ATOMIC_64BIT` is
  set.
- `HAVE_ATOMIC_GCC_BUILTIN` is the macro `os_ext.h` uses to expose the
  `__os_atomic_*` prototypes; defining it from `configure` makes those
  prototypes visible to every translation unit, not just `os_atomic.c`.
- Replace the bare `exit(0)` in the x86/gcc-assembly probe with `(void)0` so it
  compiles cleanly on modern toolchains.
- `configure` and `config.hin` regenerated with Autoconf 2.73.

No engine source changes; this only selects which existing `os_atomic.c` tier
compiles.

## Verification

On x86_64-linux / clang, building from clean master plus these files:

- `checking for atomic operations... gcc/__atomic`
- `checking for 64-bit atomic operations... yes`
- `db_config.h`: `HAVE_ATOMIC_SUPPORT`, `HAVE_ATOMIC_BUILTINS`,
  `HAVE_ATOMIC_GCC_BUILTIN`, `HAVE_ATOMIC_64BIT` all defined
- full build clean; `__os_atomic_cas_ptr` compiles to a single `lock cmpxchg`
  with no mutex call
- TCL: test001, test012, ssi001, ssi002 pass; recd001 recovery cycles verify
