### PR TITLE
test(ssi): qualification suite + abort-rate benchmark, and a btree crash fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,12 @@ build/
 
 # prototype build artifact
 lab/lsm/test_adaptive
+
+# benchmark driver binaries (built from lab/bench/*.c)
+lab/bench/scale_bench
+lab/bench/scale_iso
+lab/bench/lock_bench
+lab/bench/tproc_c
+lab/bench/tproc_b
+lab/bench/tproc_h
+lab/bench/ssi_abort_bench

--- a/README.md
+++ b/README.md
@@ -54,15 +54,16 @@ for full provenance and the per-version index.
   committed). SIREAD markers are reclaimed incrementally and bounded (not only
   at checkpoint); the commit-time pivot check is race-free against concurrent
   edge recording; and `DB_TXN_SNAPSHOT_SAFE` is rejected with `prepare()`/2PC.
-  **Still experimental:** the SIREAD marker/locker/detail lifetime was hardened
-  for concurrent writers (several pre-existing use-after-free bugs fixed under
-  TSan/ASan), but a residual crash remains under sustained high-abort
-  contention among many concurrent snapshot-safe *writers* (see the SSI notes);
-  a locking-domain audit is the tracked follow-up. Prefer single-writer /
-  read-mostly workloads for now. Page-granularity conflict tracking can also
-  raise abort rates under contention. This is the *first* of the planned
-  features in [`ROADMAP.md`](ROADMAP.md), which targets matching or beating
-  InnoDB and WiredTiger on multicore/NUMA scalability and performance.
+  The SIREAD marker/locker/detail lifetime is hardened for concurrent writers:
+  a family of pre-existing use-after-free bugs (most importantly a lock object
+  reclaimed while it still held SIREAD markers) was found with TSan/ASan and
+  fixed, and a multi-process concurrent-writer stress test (`ssi009`) guards
+  against regression. **Still experimental** in that page-granularity conflict
+  tracking can raise abort rates under contention (measured by
+  `lab/bench/ssi_abort_bench`), and the HA/replication qualification is still
+  being built. This is the *first* of the planned features in
+  [`ROADMAP.md`](ROADMAP.md), which targets matching or beating InnoDB and
+  WiredTiger on multicore/NUMA scalability and performance.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -54,10 +54,13 @@ for full provenance and the per-version index.
   committed). SIREAD markers are reclaimed incrementally and bounded (not only
   at checkpoint); the commit-time pivot check is race-free against concurrent
   edge recording; and `DB_TXN_SNAPSHOT_SAFE` is rejected with `prepare()`/2PC.
-  **Still experimental:** page-granularity conflict tracking can raise abort
-  rates under contention, and the qualification test matrix (HA/replication,
-  recovery mid-state, region exhaustion, abort-rate benchmarks) is still being
-  built. This is the *first* of the planned features in
+  **Still experimental — not safe for concurrent writers yet:** there is a
+  known pre-existing crash in the SIREAD path under multiple concurrent
+  snapshot-safe *writers* (a use-after-free found by the abort-rate benchmark;
+  see the SSI notes). Use it only single-writer / read-mostly until that is
+  fixed. In addition, page-granularity conflict tracking can raise abort rates
+  under contention, and the qualification matrix (HA/replication, concurrent
+  writers) is still being built. This is the *first* of the planned features in
   [`ROADMAP.md`](ROADMAP.md), which targets matching or beating InnoDB and
   WiredTiger on multicore/NUMA scalability and performance.
 

--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ for full provenance and the per-version index.
   committed). SIREAD markers are reclaimed incrementally and bounded (not only
   at checkpoint); the commit-time pivot check is race-free against concurrent
   edge recording; and `DB_TXN_SNAPSHOT_SAFE` is rejected with `prepare()`/2PC.
-  **Still experimental — not safe for concurrent writers yet:** there is a
-  known pre-existing crash in the SIREAD path under multiple concurrent
-  snapshot-safe *writers* (a use-after-free found by the abort-rate benchmark;
-  see the SSI notes). Use it only single-writer / read-mostly until that is
-  fixed. In addition, page-granularity conflict tracking can raise abort rates
-  under contention, and the qualification matrix (HA/replication, concurrent
-  writers) is still being built. This is the *first* of the planned features in
-  [`ROADMAP.md`](ROADMAP.md), which targets matching or beating InnoDB and
-  WiredTiger on multicore/NUMA scalability and performance.
+  **Still experimental:** the SIREAD marker/locker/detail lifetime was hardened
+  for concurrent writers (several pre-existing use-after-free bugs fixed under
+  TSan/ASan), but a residual crash remains under sustained high-abort
+  contention among many concurrent snapshot-safe *writers* (see the SSI notes);
+  a locking-domain audit is the tracked follow-up. Prefer single-writer /
+  read-mostly workloads for now. Page-granularity conflict tracking can also
+  raise abort rates under contention. This is the *first* of the planned
+  features in [`ROADMAP.md`](ROADMAP.md), which targets matching or beating
+  InnoDB and WiredTiger on multicore/NUMA scalability and performance.
 
 ## Building
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,11 +17,15 @@ are now implemented: the lock-table path and the `mp_fget` MVCC version-chain
 path. Also landed: the commit-time pivot-flag race is closed (txn-region
 serialization); SIREAD marker reclaim is incremental and bounded (a
 `__txn_begin`-driven sweep triggers when live markers exceed half the allocated
-lock objects, not only at checkpoint); and `DB_TXN_SNAPSHOT_SAFE` is rejected
-with `prepare()`/2PC until its conflict status can be frozen at prepare time.
-Remaining follow-up: broaden the qualification test matrix (HA/replication,
-recovery mid-state, region exhaustion, measured abort rates under contention)
-and evaluate finer-than-page conflict granularity.
+lock objects, not only at checkpoint, and now reaps committed read-only
+readers' markers and lockers so retention is bounded by concurrent load, not
+history); and `DB_TXN_SNAPSHOT_SAFE` is rejected with `prepare()`/2PC until its
+conflict status can be frozen at prepare time.  Qualification so far: recovery
+mid-state (ssi008), region exhaustion / graceful degradation (ssi007), and a
+measured abort-rate benchmark under contention (`lab/bench/ssi_abort_bench`).
+Remaining follow-up: HA/replication-client behaviour and role changes, and
+evaluating finer-than-page conflict granularity to cut the page-sharing abort
+rate the benchmark quantifies.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -21,8 +21,11 @@ lock objects, not only at checkpoint, and now reaps committed read-only
 readers' markers and lockers so retention is bounded by concurrent load, not
 history); and `DB_TXN_SNAPSHOT_SAFE` is rejected with `prepare()`/2PC until its
 conflict status can be frozen at prepare time.  Qualification so far: recovery
-mid-state (ssi008), region exhaustion / graceful degradation (ssi007), and a
-measured abort-rate benchmark under contention (`lab/bench/ssi_abort_bench`).
+mid-state (ssi008), region exhaustion / graceful degradation (ssi007), a
+measured abort-rate benchmark under contention (`lab/bench/ssi_abort_bench`),
+and concurrent-writer safety -- a family of pre-existing SIREAD
+marker/locker/detail use-after-frees was fixed under TSan/ASan and is guarded
+by a multi-process stress test (ssi009).
 Remaining follow-up: HA/replication-client behaviour and role changes, and
 evaluating finer-than-page conflict granularity to cut the page-sharing abort
 rate the benchmark quantifies.

--- a/lab/bench/Makefile
+++ b/lab/bench/Makefile
@@ -8,7 +8,7 @@ CFLAGS ?= -O2 -pthread
 INCLUDES = -I$(BDB)
 LIBS = -L$(BDB)/.libs -ldb-5.3
 
-BENCHES = scale_bench tproc_c tproc_b tproc_h lock_bench
+BENCHES = scale_bench tproc_c tproc_b tproc_h lock_bench ssi_abort_bench
 
 all: $(BENCHES)
 
@@ -17,6 +17,9 @@ scale_bench: scale_bench.c
 
 lock_bench: lock_bench.c
 	$(CC) $(CFLAGS) $(INCLUDES) lock_bench.c $(LIBS) -o $@
+
+ssi_abort_bench: ssi_abort_bench.c
+	$(CC) $(CFLAGS) $(INCLUDES) ssi_abort_bench.c $(LIBS) -o $@
 
 tproc_c: tproc_c.c bdb_bench.h
 	$(CC) $(CFLAGS) $(INCLUDES) tproc_c.c $(LIBS) -o $@

--- a/lab/bench/ssi_abort_bench.c
+++ b/lab/bench/ssi_abort_bench.c
@@ -1,0 +1,199 @@
+/*-
+ * libdb SSI abort-rate probe.
+ *
+ * Serializable Snapshot Isolation (DB_TXN_SNAPSHOT_SAFE) prevents write-skew
+ * and other snapshot anomalies by aborting the pivot of a dangerous rw-
+ * dependency structure.  The cost is a nonzero abort rate that grows with
+ * contention, and -- because Berkeley DB tracks conflicts at PAGE granularity,
+ * not row/key -- two transactions touching *different* keys that happen to
+ * share a leaf page can produce a "false" conflict.  This probe measures that
+ * abort rate directly, so the page-granularity cost is measured, not asserted
+ * (ROADMAP #17).
+ *
+ * Each thread runs a stream of short snapshot-safe transactions: read one key,
+ * write another, commit.  Keys are drawn from a configurable hot set.  A small
+ * hot set + many threads maximizes both genuine and page-sharing conflicts; a
+ * large hot set approximates the low-contention floor.  We report committed vs
+ * aborted (DB_SNAPSHOT_CONFLICT) and deadlock counts and the abort rate.
+ *
+ *   cc -O2 -pthread ssi_abort_bench.c -I<build> -L<build>/.libs -ldb-5.3 \
+ *       -o ssi_abort_bench
+ *   ./ssi_abort_bench <hotkeys> <secs> <t1> [t2 ...]
+ *
+ * e.g.  ./ssi_abort_bench 16 5 1 2 4 8 16     # sweep thread counts, hot=16
+ *
+ * NOT a TPC benchmark and not comparable to any TPC result.
+ */
+#include <sys/types.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "db.h"
+
+static DB_ENV *env;
+static DB *db;
+static int hotkeys;
+static volatile int stop;
+static volatile int go;
+
+typedef struct {
+	pthread_t tid;
+	unsigned seed;
+	long committed, aborted, deadlock, other;
+} targ_t;
+
+/* One snapshot-safe read-then-write transaction; classifies the outcome. */
+static void
+one_txn(targ_t *t)
+{
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int rk, wk, ret, val;
+
+	rk = rand_r(&t->seed) % hotkeys;
+	wk = rand_r(&t->seed) % hotkeys;
+
+	if (env->txn_begin(env, NULL, &txn, DB_TXN_SNAPSHOT_SAFE) != 0) {
+		t->other++;
+		return;
+	}
+
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	/* Read rk. */
+	sprintf(kbuf, "k%d", rk);
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.flags = DB_DBT_MALLOC;
+	ret = db->get(db, txn, &key, &data, 0);
+	if (ret == 0 && data.data != NULL) {
+		val = atoi((char *)data.data);
+		free(data.data);
+	} else
+		val = 0;
+	if (ret == DB_LOCK_DEADLOCK || ret == DB_SNAPSHOT_CONFLICT)
+		goto conflict;
+
+	/* Write wk = f(read value): a real read/write dependency. */
+	sprintf(kbuf, "k%d", wk);
+	sprintf(vbuf, "%d", val + 1);
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	ret = db->put(db, txn, &key, &data, 0);
+	if (ret == DB_LOCK_DEADLOCK || ret == DB_SNAPSHOT_CONFLICT)
+		goto conflict;
+	if (ret != 0) { (void)txn->abort(txn); t->other++; return; }
+
+	ret = txn->commit(txn, 0);
+	if (ret == 0) { t->committed++; return; }
+	if (ret == DB_SNAPSHOT_CONFLICT) { t->aborted++; return; }
+	if (ret == DB_LOCK_DEADLOCK) { t->deadlock++; return; }
+	t->other++;
+	return;
+
+conflict:
+	(void)txn->abort(txn);
+	if (ret == DB_SNAPSHOT_CONFLICT) t->aborted++;
+	else t->deadlock++;
+}
+
+static void *
+worker(void *arg)
+{
+	targ_t *t = arg;
+	while (!go) ;
+	while (!stop)
+		one_txn(t);
+	return (NULL);
+}
+
+static void
+run(int nthreads, int secs)
+{
+	targ_t *ta;
+	int i;
+	long c = 0, a = 0, d = 0, o = 0, total;
+
+	ta = calloc((size_t)nthreads, sizeof(*ta));
+	stop = go = 0;
+	for (i = 0; i < nthreads; i++) {
+		ta[i].seed = (unsigned)(i * 2654435761u + 1);
+		pthread_create(&ta[i].tid, NULL, worker, &ta[i]);
+	}
+	go = 1;
+	sleep(secs);
+	stop = 1;
+	for (i = 0; i < nthreads; i++) {
+		pthread_join(ta[i].tid, NULL);
+		c += ta[i].committed; a += ta[i].aborted;
+		d += ta[i].deadlock;  o += ta[i].other;
+	}
+	total = c + a + d + o;
+	printf("threads=%-3d hot=%-4d  commit=%-8ld ssi_abort=%-7ld "
+	    "deadlock=%-6ld other=%-5ld  abort_rate=%.1f%% (%.0f txn/s)\n",
+	    nthreads, hotkeys, c, a, d, o,
+	    total ? 100.0 * (double)(a + d) / (double)total : 0.0,
+	    (double)total / secs);
+	free(ta);
+}
+
+int
+main(int argc, char **argv)
+{
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, secs, ret;
+
+	if (argc < 4) {
+		fprintf(stderr,
+		    "usage: %s <hotkeys> <secs> <t1> [t2 ...]\n", argv[0]);
+		return (1);
+	}
+	hotkeys = atoi(argv[1]);
+	secs = atoi(argv[2]);
+
+	system("rm -rf /tmp/ssi_abort_env && mkdir -p /tmp/ssi_abort_env");
+	if ((ret = db_env_create(&env, 0)) != 0) goto err;
+	env->set_cachesize(env, 0, 64 * 1024 * 1024, 1);
+	/* Size the lock region generously so exhaustion isn't the variable. */
+	env->set_lk_max_locks(env, 200000);
+	env->set_lk_max_objects(env, 200000);
+	env->set_lk_max_lockers(env, 200000);
+	/* Resolve lock cycles automatically so contention can't wedge us. */
+	env->set_lk_detect(env, DB_LOCK_MINWRITE);
+	if ((ret = env->open(env, "/tmp/ssi_abort_env",
+	    DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL |
+	    DB_INIT_TXN | DB_THREAD | DB_MULTIVERSION, 0644)) != 0) goto err;
+	if ((ret = db_create(&db, env, 0)) != 0) goto err;
+	if ((ret = db->open(db, NULL, "ssi.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT | DB_THREAD | DB_MULTIVERSION,
+	    0644)) != 0) goto err;
+
+	/* Seed the hot set. */
+	env->txn_begin(env, NULL, &txn, 0);
+	for (i = 0; i < hotkeys; i++) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		sprintf(kbuf, "k%d", i);
+		sprintf(vbuf, "0");
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		db->put(db, txn, &key, &data, 0);
+	}
+	txn->commit(txn, 0);
+
+	for (i = 3; i < argc; i++)
+		run(atoi(argv[i]), secs);
+
+	db->close(db, 0);
+	env->close(env, 0);
+	return (0);
+err:
+	fprintf(stderr, "error: %s\n", db_strerror(ret));
+	return (1);
+}

--- a/lab/bench/ssi_abort_bench.c
+++ b/lab/bench/ssi_abort_bench.c
@@ -33,13 +33,14 @@
 #include <string.h>
 #include <time.h>
 #include "db.h"
+#include <stdatomic.h>
 
 static DB_ENV *env;
 static DB *db;
 static int hotkeys;
-static volatile int stop;
-static volatile int go;
-static volatile int panicked;	/* set on DB_RUNRECOVERY: stop, don't spin */
+static atomic_int stop;
+static atomic_int go;
+static atomic_int panicked;	/* set on DB_RUNRECOVERY: stop, don't spin */
 
 typedef struct {
 	pthread_t tid;
@@ -90,7 +91,7 @@ one_txn(targ_t *t)
 		goto conflict;
 	if (ret != 0) {
 		(void)txn->abort(txn);
-		if (ret == DB_RUNRECOVERY) panicked = 1;
+		if (ret == DB_RUNRECOVERY) atomic_store(&panicked, 1);
 		t->other++;
 		return;
 	}
@@ -99,7 +100,7 @@ one_txn(targ_t *t)
 	if (ret == 0) { t->committed++; return; }
 	if (ret == DB_SNAPSHOT_CONFLICT) { t->aborted++; return; }
 	if (ret == DB_LOCK_DEADLOCK) { t->deadlock++; return; }
-	if (ret == DB_RUNRECOVERY) panicked = 1;
+	if (ret == DB_RUNRECOVERY) atomic_store(&panicked, 1);
 	t->other++;
 	return;
 
@@ -113,8 +114,8 @@ static void *
 worker(void *arg)
 {
 	targ_t *t = arg;
-	while (!go) ;
-	while (!stop && !panicked)
+	while (!atomic_load(&go)) ;
+	while (!atomic_load(&stop) && !atomic_load(&panicked))
 		one_txn(t);
 	return (NULL);
 }
@@ -127,14 +128,14 @@ run(int nthreads, int secs)
 	long c = 0, a = 0, d = 0, o = 0, total;
 
 	ta = calloc((size_t)nthreads, sizeof(*ta));
-	stop = go = panicked = 0;
+	atomic_store(&stop, 0); atomic_store(&go, 0); atomic_store(&panicked, 0);
 	for (i = 0; i < nthreads; i++) {
 		ta[i].seed = (unsigned)(i * 2654435761u + 1);
 		pthread_create(&ta[i].tid, NULL, worker, &ta[i]);
 	}
-	go = 1;
+	atomic_store(&go, 1);
 	sleep(secs);
-	stop = 1;
+	atomic_store(&stop, 1);
 	for (i = 0; i < nthreads; i++) {
 		pthread_join(ta[i].tid, NULL);
 		c += ta[i].committed; a += ta[i].aborted;
@@ -145,7 +146,7 @@ run(int nthreads, int secs)
 	    "deadlock=%-6ld other=%-5ld  abort_rate=%.1f%% (%.0f txn/s)%s\n",
 	    nthreads, hotkeys, c, a, d, o,
 	    total ? 100.0 * (double)(a + d) / (double)total : 0.0,
-	    (double)total / secs, panicked ? "  [ENV PANIC -- see note]" : "");
+	    (double)total / secs, atomic_load(&panicked) ? "  [ENV PANIC -- see note]" : "");
 	free(ta);
 }
 

--- a/lab/bench/ssi_abort_bench.c
+++ b/lab/bench/ssi_abort_bench.c
@@ -25,6 +25,7 @@
  * NOT a TPC benchmark and not comparable to any TPC result.
  */
 #include <sys/types.h>
+#include <sys/stat.h>
 #include <pthread.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -38,6 +39,7 @@ static DB *db;
 static int hotkeys;
 static volatile int stop;
 static volatile int go;
+static volatile int panicked;	/* set on DB_RUNRECOVERY: stop, don't spin */
 
 typedef struct {
 	pthread_t tid;
@@ -86,12 +88,18 @@ one_txn(targ_t *t)
 	ret = db->put(db, txn, &key, &data, 0);
 	if (ret == DB_LOCK_DEADLOCK || ret == DB_SNAPSHOT_CONFLICT)
 		goto conflict;
-	if (ret != 0) { (void)txn->abort(txn); t->other++; return; }
+	if (ret != 0) {
+		(void)txn->abort(txn);
+		if (ret == DB_RUNRECOVERY) panicked = 1;
+		t->other++;
+		return;
+	}
 
 	ret = txn->commit(txn, 0);
 	if (ret == 0) { t->committed++; return; }
 	if (ret == DB_SNAPSHOT_CONFLICT) { t->aborted++; return; }
 	if (ret == DB_LOCK_DEADLOCK) { t->deadlock++; return; }
+	if (ret == DB_RUNRECOVERY) panicked = 1;
 	t->other++;
 	return;
 
@@ -106,7 +114,7 @@ worker(void *arg)
 {
 	targ_t *t = arg;
 	while (!go) ;
-	while (!stop)
+	while (!stop && !panicked)
 		one_txn(t);
 	return (NULL);
 }
@@ -119,7 +127,7 @@ run(int nthreads, int secs)
 	long c = 0, a = 0, d = 0, o = 0, total;
 
 	ta = calloc((size_t)nthreads, sizeof(*ta));
-	stop = go = 0;
+	stop = go = panicked = 0;
 	for (i = 0; i < nthreads; i++) {
 		ta[i].seed = (unsigned)(i * 2654435761u + 1);
 		pthread_create(&ta[i].tid, NULL, worker, &ta[i]);
@@ -134,10 +142,10 @@ run(int nthreads, int secs)
 	}
 	total = c + a + d + o;
 	printf("threads=%-3d hot=%-4d  commit=%-8ld ssi_abort=%-7ld "
-	    "deadlock=%-6ld other=%-5ld  abort_rate=%.1f%% (%.0f txn/s)\n",
+	    "deadlock=%-6ld other=%-5ld  abort_rate=%.1f%% (%.0f txn/s)%s\n",
 	    nthreads, hotkeys, c, a, d, o,
 	    total ? 100.0 * (double)(a + d) / (double)total : 0.0,
-	    (double)total / secs);
+	    (double)total / secs, panicked ? "  [ENV PANIC -- see note]" : "");
 	free(ta);
 }
 
@@ -157,17 +165,22 @@ main(int argc, char **argv)
 	hotkeys = atoi(argv[1]);
 	secs = atoi(argv[2]);
 
-	system("rm -rf /tmp/ssi_abort_env && mkdir -p /tmp/ssi_abort_env");
+	(void)mkdir("/tmp/ssi_abort_env", 0755);
 	if ((ret = db_env_create(&env, 0)) != 0) goto err;
 	env->set_cachesize(env, 0, 64 * 1024 * 1024, 1);
 	/* Size the lock region generously so exhaustion isn't the variable. */
-	env->set_lk_max_locks(env, 200000);
-	env->set_lk_max_objects(env, 200000);
-	env->set_lk_max_lockers(env, 200000);
+	env->set_lk_max_locks(env, 20000);
+	env->set_lk_max_objects(env, 20000);
+	env->set_lk_max_lockers(env, 20000);
 	/* Resolve lock cycles automatically so contention can't wedge us. */
 	env->set_lk_detect(env, DB_LOCK_MINWRITE);
+	/*
+	 * DB_RECOVER: a benchmark run may be killed (timeout) mid-transaction,
+	 * leaving a dirty region.  Always run recovery on open so a stale
+	 * environment is cleaned rather than hanging or crashing the next run.
+	 */
 	if ((ret = env->open(env, "/tmp/ssi_abort_env",
-	    DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL |
+	    DB_CREATE | DB_RECOVER | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL |
 	    DB_INIT_TXN | DB_THREAD | DB_MULTIVERSION, 0644)) != 0) goto err;
 	if ((ret = db_create(&db, env, 0)) != 0) goto err;
 	if ((ret = db->open(db, NULL, "ssi.db", NULL, DB_BTREE,

--- a/src/btree/bt_search.c
+++ b/src/btree/bt_search.c
@@ -383,9 +383,19 @@ retry:	if (lock_mode == DB_LOCK_WRITE)
 		} else if (atomic_read(&mpf->mfp->multiversion) != 0 &&
 		    lock_mode == DB_LOCK_WRITE && (ret = __memp_dirty(mpf, &h,
 		    dbc->thread_info, dbc->txn, dbc->priority, 0)) != 0) {
-			(void)__memp_fput(mpf,
-			    dbc->thread_info, h, dbc->priority);
+			/*
+			 * __memp_dirty releases the read-only page and re-fetches
+			 * it dirty; on failure (e.g. DB_LOCK_DEADLOCK re-fetching
+			 * under MVCC write contention) it sets h to NULL.  Release
+			 * whatever we still hold and return the error -- do not
+			 * fall through to done: with a NULL page, which the caller
+			 * would dereference.
+			 */
+			if (h != NULL)
+				(void)__memp_fput(mpf,
+				    dbc->thread_info, h, dbc->priority);
 			(void)__LPUT(dbc, lock);
+			return (ret);
 		}
 	}
 

--- a/src/dbinc/lock.h
+++ b/src/dbinc/lock.h
@@ -112,12 +112,14 @@ typedef struct __db_lockregion { /* SHARED */
 	u_int32_t	lock_id;	/* Current lock(er) id to allocate. */
 	u_int32_t	cur_maxid;	/* Current max lock(er) id. */
 	u_int32_t	nlockers;	/* Current number of lockers. */
-	u_int32_t	nsireaders;	/* SSI: approximate count of live SIREAD
+	db_atomic_t	nsireaders;	/* SSI: approximate count of live SIREAD
 					   markers held by committed readers,
 					   used only to trigger best-effort GC
 					   (__lock_sicleanup) before the count
 					   grows unbounded between checkpoints.
-					   Not required to be exact. */
+					   Atomic: inc/dec happen under different
+					   partition mutexes.  Not required to be
+					   exact. */
 	int32_t		nmodes;		/* Number of modes in conflict table. */
 	DB_LOCK_STAT	stat;		/* stats about locking. */
 } DB_LOCKREGION;

--- a/src/dbinc/txn.h
+++ b/src/dbinc/txn.h
@@ -93,9 +93,11 @@ typedef struct __txn_detail {
 	db_mutex_t	mvcc_mtx;	/* Version mutex. */
 	u_int32_t	mvcc_ref;	/* Number of buffers created by this
 					   transaction still in cache.  */
-	u_int32_t	si_ref;		/* SSI: outstanding SIREAD markers that
+	db_atomic_t	si_ref;		/* SSI: outstanding SIREAD markers that
 					   reference this detail (keeps it alive
-					   past commit, parallels mvcc_ref). */
+					   past commit, parallels mvcc_ref).
+					   Atomic: inc/dec occur under different
+					   lock-manager partition mutexes. */
 
 	u_int32_t	priority;	/* Deadlock resolution priority. */
 

--- a/src/dbinc_auto/lock_ext.h
+++ b/src/dbinc_auto/lock_ext.h
@@ -31,7 +31,6 @@ int __lock_getlocker __P((DB_LOCKTAB *, u_int32_t, int, DB_LOCKER **));
 int __lock_getlocker_int __P((DB_LOCKTAB *, u_int32_t, int, DB_LOCKER **));
 int __lock_addfamilylocker __P((ENV *, u_int32_t, u_int32_t, u_int32_t));
 int __lock_freelocker  __P((DB_LOCKTAB *, DB_LOCKER *));
-int __lock_si_reap_lockers __P((DB_LOCKTAB *));
 int __lock_familyremove  __P((DB_LOCKTAB *, DB_LOCKER *));
 int __lock_fix_list __P((ENV *, DBT *, u_int32_t));
 int __lock_get_list __P((ENV *, DB_LOCKER *, u_int32_t, db_lockmode_t, DBT *));

--- a/src/dbinc_auto/txn_ext.h
+++ b/src/dbinc_auto/txn_ext.h
@@ -68,6 +68,7 @@ size_t __txn_region_size __P((ENV *));
 size_t __txn_region_max __P((ENV *));
 int __txn_id_set __P((ENV *, u_int32_t, u_int32_t));
 int __txn_oldest_reader __P((ENV *, DB_LSN *));
+int __txn_reap_si_details __P((ENV *));
 int __txn_add_buffer __P((ENV *, TXN_DETAIL *));
 int __txn_remove_buffer __P((ENV *, TXN_DETAIL *, db_mutex_t));
 int __txn_stat_pp __P((DB_ENV *, DB_TXN_STAT **, u_int32_t));

--- a/src/lock/lock.c
+++ b/src/lock/lock.c
@@ -1694,9 +1694,16 @@ __lock_put_internal(lt, lockp, obj_ndx, flags)
 		    sh_obj, &state_changed, flags)) != 0)
 			return (ret);
 
-	/* Check if object should be reclaimed. */
+	/*
+	 * Check if object should be reclaimed.  It must have no holders, no
+	 * waiters, AND no SSI SIREAD markers -- persisted markers live on the
+	 * sireaders list and still reference this object; freeing it out from
+	 * under them corrupts the list and crashes any concurrent walker
+	 * (a WRITE acquirer scanning sireaders, or the marker GC).
+	 */
 	if (SH_TAILQ_FIRST(&sh_obj->holders, __db_lock) == NULL &&
-	    SH_TAILQ_FIRST(&sh_obj->waiters, __db_lock) == NULL) {
+	    SH_TAILQ_FIRST(&sh_obj->waiters, __db_lock) == NULL &&
+	    SH_TAILQ_FIRST(&sh_obj->sireaders, __db_lock) == NULL) {
 		part_id = LOCK_PART(region, obj_ndx);
 		SH_TAILQ_REMOVE(
 		    &lt->obj_tab[obj_ndx], sh_obj, links, __db_lockobj);

--- a/src/lock/lock.c
+++ b/src/lock/lock.c
@@ -147,8 +147,9 @@ __lock_siclean_obj(env, obj, old_lsnp)
 
 		SH_TAILQ_REMOVE(&obj->sireaders, lp, links, __db_lock);
 		sh_locker = LOCK_HOLDER(env, lp);
-		if (((DB_LOCKREGION *)lt->reginfo.primary)->nsireaders > 0)
-			((DB_LOCKREGION *)lt->reginfo.primary)->nsireaders--;
+		if (atomic_read(&((DB_LOCKREGION *)lt->reginfo.primary)->nsireaders) > 0)
+			(void)atomic_dec(env,
+			    &((DB_LOCKREGION *)lt->reginfo.primary)->nsireaders);
 		/*
 		 * Committed readers' markers were already detached from the
 		 * locker's heldby list by __lock_sicommit, so free WITHOUT
@@ -157,7 +158,7 @@ __lock_siclean_obj(env, obj, old_lsnp)
 		 * __lock_sicleanup once their last marker is gone.
 		 */
 		if (sh_locker->td_off != INVALID_ROFF)
-			LOCKER_TD(env, sh_locker)->si_ref--;
+			(void)atomic_dec(env, &LOCKER_TD(env, sh_locker)->si_ref);
 		if (sh_locker->nlocks > 0)
 			sh_locker->nlocks--;
 		if ((ret = __lock_freelock(lt, lp, sh_locker,
@@ -211,6 +212,15 @@ __lock_sicleanup(env)
 		OBJECT_UNLOCK(lt, region, i);
 	}
 
+	/*
+	 * Free committed-reader details whose last SIREAD marker was just
+	 * reclaimed above.  __txn_end parked them on the mvcc_txn list
+	 * (TXN_DTL_SNAPSHOT) because their si_ref was still nonzero; now that
+	 * the markers are gone, reclaim them.  Done here, with no object mutex
+	 * held, so it can take the txn region lock.
+	 */
+	(void)__txn_reap_si_details(env);
+
 	return (0);
 }
 
@@ -244,26 +254,41 @@ __lock_sicommit(env, sh_locker, is_commit)
 	region = lt->reginfo.primary;
 	detached = ret = 0;
 
+	/*
+	 * The locker's heldby list and flags (nlocks, DB_LOCKER_FREED, si_ref
+	 * on the detail) are protected by LOCK_LOCKERS -- the same latch the
+	 * deadlock detector holds when it reads locker flags -- while the
+	 * object's sireaders list needs the object partition mutex.
+	 * LOCK_SYSTEM_LOCK alone does NOT serialize either when the lock table
+	 * is partitioned (it is then a no-op), so touching these lists under
+	 * LOCK_SYSTEM_LOCK only, as before, raced the deadlock detector and
+	 * concurrent lock_get/put -- a use-after-free of SIREAD markers.
+	 * Hold LOCK_LOCKERS across the walk and nest OBJECT_LOCK inside it for
+	 * the sireaders op (LOCK_LOCKERS -> object is the order the deadlock
+	 * detector also uses).
+	 */
 	LOCK_SYSTEM_LOCK(lt, region);
+	LOCK_LOCKERS(env, region);
 	for (lp = SH_LIST_FIRST(&sh_locker->heldby, __db_lock);
 	    lp != NULL; lp = next_lock) {
 		next_lock = SH_LIST_NEXT(lp, locker_links, __db_lock);
 		if (lp->mode != DB_LOCK_SIREAD)
 			continue;
+		obj = (DB_LOCKOBJ *)SH_OFF_TO_PTR(lp, lp->obj, DB_LOCKOBJ);
 		/* Detach from the locker so normal release leaves it alone. */
 		SH_LIST_REMOVE(lp, locker_links, __db_lock);
 		if (is_commit) {
+			/* Marker persists on the object's sireaders list. */
 			detached++;
 			continue;
 		}
 		/* Abort: drop the marker entirely. */
-		obj = (DB_LOCKOBJ *)SH_OFF_TO_PTR(lp, lp->obj, DB_LOCKOBJ);
 		OBJECT_LOCK_NDX(lt, region, obj->indx);
 		SH_TAILQ_REMOVE(&obj->sireaders, lp, links, __db_lock);
-		if (region->nsireaders > 0)
-			region->nsireaders--;
+		if (atomic_read(&region->nsireaders) > 0)
+			(void)atomic_dec(env, &region->nsireaders);
 		if (sh_locker->td_off != INVALID_ROFF)
-			LOCKER_TD(env, sh_locker)->si_ref--;
+			(void)atomic_dec(env, &LOCKER_TD(env, sh_locker)->si_ref);
 		sh_locker->nlocks--;
 		ret = __lock_freelock(lt, lp, sh_locker, DB_LOCK_FREE);
 		OBJECT_UNLOCK(lt, region, obj->indx);
@@ -272,6 +297,7 @@ __lock_sicommit(env, sh_locker, is_commit)
 	}
 	if (is_commit && detached > 0)
 		F_SET(sh_locker, DB_LOCKER_FREED);
+	UNLOCK_LOCKERS(env, region);
 	LOCK_SYSTEM_UNLOCK(lt, region);
 
 	return (ret);
@@ -921,8 +947,9 @@ again:	if (obj == NULL) {
 				 */
 				SH_TAILQ_REMOVE(&sh_obj->sireaders,
 				    sireadlp, links, __db_lock);
-				if (region->nsireaders > 0)
-					region->nsireaders--;
+				if (atomic_read(&region->nsireaders) > 0)
+					(void)atomic_dec(env,
+					    &region->nsireaders);
 				if ((ret = __lock_freelock(lt, sireadlp,
 				    LOCK_HOLDER(env, sireadlp),
 				    DB_LOCK_UNLINK | DB_LOCK_FREE)) != 0)
@@ -1168,8 +1195,18 @@ upgrade:	lp = R_ADDR(&lt->reginfo, lock->off);
 		newl->status = DB_LSTAT_HELD;
 		if (safe_si && lock_mode == DB_LOCK_SIREAD) {
 			SH_TAILQ_INSERT_TAIL(&sh_obj->sireaders, newl, links);
-			LOCKER_TD(env, sh_locker)->si_ref++;
-			region->nsireaders++;	/* SSI: GC-trigger hint. */
+			/*
+			 * Count the detail reference this marker holds, symmetric
+			 * with the decrements in __lock_sicommit/__lock_siclean_obj
+			 * (both guard td_off).  Without the same guard the increment
+			 * could land on a bogus detail (INVALID_ROFF) while the
+			 * decrement is skipped -- an si_ref undercount that frees a
+			 * live-marker detail (use-after-free).
+			 */
+			if (sh_locker->td_off != INVALID_ROFF)
+				(void)atomic_inc(env,
+				    &LOCKER_TD(env, sh_locker)->si_ref);
+			(void)atomic_inc(env, &region->nsireaders);	/* SSI GC hint. */
 		} else
 			SH_TAILQ_INSERT_TAIL(&sh_obj->holders, newl, links);
 		break;
@@ -1635,7 +1672,19 @@ __lock_put_internal(lt, lockp, obj_ndx, flags)
 	} else {
 		DB_ASSERT(env, lockp !=
 		     SH_TAILQ_FIRST(&sh_obj->waiters, __db_lock));
-		SH_TAILQ_REMOVE(&sh_obj->holders, lockp, links, __db_lock);
+		/*
+		 * SSI SIREAD markers live on the object's sireaders list, not
+		 * the holders list.  Removing from the wrong list corrupts it
+		 * and leaves the freed marker linked in sireaders -- a
+		 * use-after-free for anyone walking it.  Remove from the list
+		 * the lock is actually on.
+		 */
+		if (lockp->mode == DB_LOCK_SIREAD)
+			SH_TAILQ_REMOVE(&sh_obj->sireaders,
+			    lockp, links, __db_lock);
+		else
+			SH_TAILQ_REMOVE(&sh_obj->holders,
+			    lockp, links, __db_lock);
 		lockp->links.stqe_prev = -1;
 	}
 

--- a/src/lock/lock.c
+++ b/src/lock/lock.c
@@ -211,14 +211,6 @@ __lock_sicleanup(env)
 		OBJECT_UNLOCK(lt, region, i);
 	}
 
-	/*
-	 * Reap committed-reader lockers whose last SIREAD marker was just
-	 * freed above.  Done after the object sweep (no object mutex held) so
-	 * the object->locker latch ordering holds.
-	 */
-	if ((ret = __lock_si_reap_lockers(lt)) != 0)
-		return (ret);
-
 	return (0);
 }
 
@@ -906,21 +898,18 @@ again:	if (obj == NULL) {
 	    (lock_mode == DB_LOCK_WRITE || lock_mode == DB_LOCK_SIREAD)) {
 		/*
 		 * SSI pivot flags (TXN_DTL_RCONF/TXN_DTL_WCONF) and the txn
-		 * status read below are shared with the commit-time pivot check
-		 * in __txn_commit and with __txn_end's status transition.  Under
-		 * multiple lock partitions this walk holds only the object's
-		 * partition mutex, which does NOT exclude a flag write from a
-		 * writer in a different partition, nor the lock-free commit-time
-		 * read.  Serialize all of it on the txn-region mutex: two edge
-		 * recorders on the same reader detail, and the pivot's own commit
-		 * check, now observe one total order.  Lock ordering is
-		 * partition -> txn-region (never taken in reverse; __txn_end
-		 * releases the lock region before taking the txn region, and no
-		 * lock_vec/lock_get is issued while the txn region is held), so
-		 * this cannot deadlock.
+		 * status reads in this walk are shared with __txn_commit's
+		 * pivot check and __txn_end's status transition.  Under multiple
+		 * lock partitions the partition mutex held here does not exclude
+		 * a flag write from a writer in a different partition, nor the
+		 * lock-free commit-time read.  We therefore serialize *only the
+		 * flag read-modify-write* on the txn-region mutex (see the
+		 * rw-conflict branch below); it is taken and released tightly
+		 * around the flag ops, never across __lock_freelock or a list
+		 * change (which the partition mutex already protects) and never
+		 * across a goto, so it cannot nest with per-lock or region
+		 * mutexes.  Ordering partition -> txn-region is non-circular.
 		 */
-		if (TXN_ON(env))
-			TXN_SYSTEM_LOCK(env);
 		for (sireadlp = SH_TAILQ_FIRST(&sh_obj->sireaders, __db_lock);
 		    sireadlp != NULL; sireadlp = next_lock) {
 			next_lock = SH_TAILQ_NEXT(sireadlp, links, __db_lock);
@@ -936,45 +925,51 @@ again:	if (obj == NULL) {
 					region->nsireaders--;
 				if ((ret = __lock_freelock(lt, sireadlp,
 				    LOCK_HOLDER(env, sireadlp),
-				    DB_LOCK_UNLINK | DB_LOCK_FREE)) != 0) {
-					if (TXN_ON(env))
-						TXN_SYSTEM_UNLOCK(env);
+				    DB_LOCK_UNLINK | DB_LOCK_FREE)) != 0)
 					goto err;
-				}
 			} else if (lock_mode == DB_LOCK_WRITE &&
 			    sh_off != sireadlp->holder &&
 			    (LOCK_OWNER(env, sireadlp)->status == TXN_RUNNING ||
 			    LOG_COMPARE(&LOCK_COMMITLSN(env, sireadlp),
 			    &LOCKER_TD(env, sh_locker)->read_lsn) > 0)) {
+				/*
+				 * Record R --rw--> W under the txn-region mutex so
+				 * the two-flag reads and writes are atomic against
+				 * a concurrent recorder and the commit-time check.
+				 */
+				if (TXN_ON(env))
+					TXN_SYSTEM_LOCK(env);
 				if (F_ISSET(LOCK_OWNER(env, sireadlp),
 				    TXN_DTL_WCONF) &&
 				    LOCK_OWNER(env, sireadlp)->status ==
-				    TXN_COMMITTED) {
+				    TXN_COMMITTED)
 					ret = DB_SNAPSHOT_UNSAFE;
-					if (TXN_ON(env))
-						TXN_SYSTEM_UNLOCK(env);
-					goto err;
-				}
-				rwconf = 1;
-				/*
-				 * Set the incoming-conflict flag on our txn,
-				 * unless the reader will itself abort.
-				 */
-				if (LOCK_OWNER(env, sireadlp)->status ==
-				    TXN_COMMITTED ||
-				    !F_ISSET(LOCK_OWNER(env, sireadlp),
-				    TXN_DTL_WCONF)) {
-					if (F_ISSET(LOCKER_TD(env, sh_locker),
-					    TXN_DTL_RCONF)) {
-						ret = DB_SNAPSHOT_UNSAFE;
-						if (TXN_ON(env))
-							TXN_SYSTEM_UNLOCK(env);
-						goto err;
+				else {
+					rwconf = 1;
+					/*
+					 * Set our incoming-conflict flag unless
+					 * the reader will itself abort.
+					 */
+					if (LOCK_OWNER(env, sireadlp)->status ==
+					    TXN_COMMITTED ||
+					    !F_ISSET(LOCK_OWNER(env, sireadlp),
+					    TXN_DTL_WCONF)) {
+						if (F_ISSET(LOCKER_TD(env,
+						    sh_locker), TXN_DTL_RCONF))
+							ret = DB_SNAPSHOT_UNSAFE;
+						else
+							F_SET(LOCKER_TD(env,
+							    sh_locker),
+							    TXN_DTL_WCONF);
 					}
-					F_SET(LOCKER_TD(env, sh_locker),
-					    TXN_DTL_WCONF);
+					if (ret == 0)
+						F_SET(LOCK_OWNER(env, sireadlp),
+						    TXN_DTL_RCONF);
 				}
-				F_SET(LOCK_OWNER(env, sireadlp), TXN_DTL_RCONF);
+				if (TXN_ON(env))
+					TXN_SYSTEM_UNLOCK(env);
+				if (ret != 0)
+					goto err;
 			} else if (lock_mode == DB_LOCK_SIREAD &&
 			    sh_off == sireadlp->holder) {
 				/* Already hold a SIREAD marker here. */
@@ -982,13 +977,9 @@ again:	if (obj == NULL) {
 				lock->off = R_OFFSET(&lt->reginfo, sireadlp);
 				lock->gen = sireadlp->gen;
 				lock->mode = sireadlp->mode;
-				if (TXN_ON(env))
-					TXN_SYSTEM_UNLOCK(env);
 				goto done;
 			}
 		}
-		if (TXN_ON(env))
-			TXN_SYSTEM_UNLOCK(env);
 		/*
 		 * Note: obsolete SIREAD markers are reclaimed by
 		 * __lock_sicleanup (run without a partition mutex held), not

--- a/src/lock/lock_id.c
+++ b/src/lock/lock_id.c
@@ -11,6 +11,7 @@
 #include "db_int.h"
 #include "dbinc/lock.h"
 #include "dbinc/log.h"
+#include "dbinc/txn.h"
 
 static int __lock_freelocker_int
     __P((DB_LOCKTAB *, DB_LOCKREGION *, DB_LOCKER *, int));
@@ -491,13 +492,22 @@ __lock_freelocker_int(lt, region, sh_locker, reallyfree)
 	}
 
 	/*
-	 * SSI: a committed snapshot-safe reader is kept alive (DB_LOCKER_FREED)
-	 * while its persisted SIREAD markers still reference it; defer the real
-	 * free to __lock_sicleanup, which reclaims the markers and then the
-	 * locker once the oldest reader has advanced past its snapshot.
+	 * SSI: a committed snapshot-safe reader's persisted SIREAD markers stay
+	 * on their objects' sireaders lists (detached from heldby) and still
+	 * reference this locker via lp->holder.  Freeing the locker while any
+	 * such marker exists is a use-after-free when the GC (or a WRITE
+	 * acquirer) later dereferences LOCK_HOLDER(marker).  The per-detail
+	 * si_ref counts exactly those markers and is atomic, so it is the
+	 * race-free guard (nlocks is decremented under the object partition
+	 * mutex but read here under LOCK_LOCKERS -- a cross-domain race).
+	 * Defer while markers remain; flag DB_LOCKER_FREED so __lock_sicleanup
+	 * reclaims the locker once the last marker is gone.
 	 */
-	if (F_ISSET(sh_locker, DB_LOCKER_FREED) && sh_locker->nlocks != 0)
+	if (sh_locker->td_off != INVALID_ROFF &&
+	    atomic_read(&LOCKER_TD(env, sh_locker)->si_ref) != 0) {
+		F_SET(sh_locker, DB_LOCKER_FREED);
 		return (0);
+	}
 
 	/* If this is part of a family, we must fix up its links. */
 	if (sh_locker->master_locker != INVALID_ROFF) {

--- a/src/lock/lock_id.c
+++ b/src/lock/lock_id.c
@@ -554,55 +554,6 @@ __lock_freelocker(lt, sh_locker)
 	return (ret);
 }
 
-/*
- * __lock_si_reap_lockers
- *	Reclaim committed snapshot-safe (SSI) reader lockers whose persisted
- *	SIREAD markers have all been garbage-collected.  Such a locker was
- *	flagged DB_LOCKER_FREED at commit and kept alive only to anchor its
- *	markers; once __lock_sicleanup has freed the last marker (nlocks == 0)
- *	the locker itself can go.  Without this pass a long-lived process that
- *	runs many committed SSI readers exhausts the statically sized locker
- *	region ("out of available locker entries") even though the markers are
- *	being reclaimed.  Called from __lock_sicleanup with no object mutex
- *	held, so taking the locker latches here respects the object->locker
- *	ordering.
- *
- * PUBLIC: int __lock_si_reap_lockers __P((DB_LOCKTAB *));
- */
-int
-__lock_si_reap_lockers(lt)
-	DB_LOCKTAB *lt;
-{
-	DB_LOCKREGION *region;
-	ENV *env;
-	DB_LOCKER *lk, *next_lk;
-	int ret;
-
-	region = lt->reginfo.primary;
-	env = lt->env;
-	ret = 0;
-
-	LOCK_LOCKERS(env, region);
-	for (lk = SH_TAILQ_FIRST(&region->lockers, __db_locker);
-	    lk != NULL; lk = next_lk) {
-		next_lk = SH_TAILQ_NEXT(lk, ulinks, __db_locker);
-		if (F_ISSET(lk, DB_LOCKER_FREED) && lk->nlocks == 0 &&
-		    SH_LIST_FIRST(&lk->heldby, __db_lock) == NULL) {
-			/*
-			 * Clear the flag so __lock_freelocker_int does not
-			 * defer again, then really free it (bucket is covered
-			 * by LOCK_LOCKERS).
-			 */
-			F_CLR(lk, DB_LOCKER_FREED);
-			if ((ret =
-			    __lock_freelocker_int(lt, region, lk, 1)) != 0)
-				break;
-		}
-	}
-	UNLOCK_LOCKERS(env, region);
-
-	return (ret);
-}
 
 /*
  * __lock_familyremove

--- a/src/lock/lock_region.c
+++ b/src/lock/lock_region.c
@@ -193,6 +193,7 @@ __lock_region_init(env, lt)
 	}
 
 	region->need_dd = 0;
+	atomic_init(&region->nsireaders, 0);	/* SSI GC-trigger hint. */
 	timespecclear(&region->next_timeout);
 	region->detect = DB_LOCK_NORUN;
 	region->lk_timeout = dbenv->lk_timeout;

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -256,22 +256,16 @@ __txn_begin(env, ip, parent, txnpp, flags)
 			DB_LOCKREGION *lkreg =
 			    env->lk_handle->reginfo.primary;
 			/*
-			 * Trigger the sweep on either dimension of pressure:
-			 *  - live SIREAD markers past half the allocated objects
-			 *    (bounds the version-conflict object footprint), or
-			 *  - current lockers past half the locker cap (bounds the
-			 *    committed-reader lockers that persist until their last
-			 *    marker is reaped -- reused-key workloads keep the object
-			 *    count tiny while lockers still accumulate one per
-			 *    committed reader, so the object test alone never fires).
-			 * st_max* == 0 means "grow as needed"; fall back to the
-			 * currently allocated counts so the bound still holds.
+			 * Trigger the marker sweep when live SIREAD markers pass
+			 * half the allocated lock objects, so the committed-reader
+			 * marker footprint stays bounded instead of growing until
+			 * the next checkpoint.  (Committed-reader locker structs are
+			 * not yet reclaimed -- see the SSI known-issues note.)
+			 * st_objects is always non-zero, so the bound holds whether
+			 * or not a max is configured.
 			 */
 			u_int32_t nobj = lkreg->stat.st_objects;
-			u_int32_t maxlk = lkreg->stat.st_maxlockers != 0 ?
-			    lkreg->stat.st_maxlockers : lkreg->stat.st_lockers;
-			if ((nobj != 0 && lkreg->nsireaders > nobj / 2) ||
-			    (maxlk != 0 && lkreg->nlockers > maxlk / 2))
+			if (nobj != 0 && lkreg->nsireaders > nobj / 2)
 				(void)__lock_sicleanup(env);
 		}
 	}

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -265,7 +265,7 @@ __txn_begin(env, ip, parent, txnpp, flags)
 			 * or not a max is configured.
 			 */
 			u_int32_t nobj = lkreg->stat.st_objects;
-			if (nobj != 0 && lkreg->nsireaders > nobj / 2)
+			if (nobj != 0 && atomic_read(&lkreg->nsireaders) > nobj / 2)
 				(void)__lock_sicleanup(env);
 		}
 	}
@@ -470,7 +470,7 @@ __txn_begin_int(txn)
 	 * reclaim, stats) read si_ref.  Publishing the detail before setting
 	 * this field lets them observe garbage.
 	 */
-	td->si_ref = 0;
+	atomic_init(&td->si_ref, 0);
 
 	/* Place transaction on active transaction list. */
 	SH_TAILQ_INSERT_HEAD(&region->active_txn, td, links, __txn_detail);
@@ -1811,8 +1811,24 @@ __txn_end(txn, is_commit)
 				return (__env_panic(env, ret));
 	}
 
-	if (td != NULL && td->si_ref == 0)
-		__env_alloc_free(&mgr->reginfo, td);
+	if (td != NULL) {
+		if (atomic_read(&td->si_ref) == 0)
+			__env_alloc_free(&mgr->reginfo, td);
+		else {
+			/*
+			 * SSI: a committed snapshot-safe reader whose SIREAD
+			 * markers still reference this detail cannot be freed yet
+			 * (a marker's LOCK_OWNER dereferences it).  Keep it on the
+			 * mvcc_txn reclaim list, flagged TXN_DTL_SNAPSHOT, so the
+			 * marker GC (__lock_sicleanup) frees it when the last
+			 * marker goes -- rather than orphaning it off every list
+			 * (a leak) or freeing it early (a use-after-free).
+			 */
+			SH_TAILQ_INSERT_HEAD(&region->mvcc_txn,
+			    td, links, __txn_detail);
+			F_SET(td, TXN_DTL_SNAPSHOT);
+		}
+	}
 
 #ifdef HAVE_STATISTICS
 	if (is_commit)

--- a/src/txn/txn_region.c
+++ b/src/txn/txn_region.c
@@ -445,6 +445,45 @@ __txn_oldest_reader(env, lsnp)
 }
 
 /*
+ * __txn_reap_si_details --
+ *	Free committed snapshot-safe reader details that __txn_end parked on
+ *	the mvcc_txn list (TXN_DTL_SNAPSHOT) because their SIREAD markers still
+ *	referenced them, and whose markers have since been garbage-collected
+ *	(si_ref back to 0).  Only reaps details with no MVCC pages either
+ *	(mvcc_ref == 0); genuine MVCC-version holders are freed by
+ *	__txn_remove_buffer when their last page is evicted.  Best effort.
+ *
+ * PUBLIC: int __txn_reap_si_details __P((ENV *));
+ */
+int
+__txn_reap_si_details(env)
+	ENV *env;
+{
+	DB_TXNMGR *mgr;
+	DB_TXNREGION *region;
+	TXN_DETAIL *td, *next_td;
+
+	if ((mgr = env->tx_handle) == NULL)
+		return (0);
+	region = mgr->reginfo.primary;
+
+	TXN_SYSTEM_LOCK(env);
+	for (td = SH_TAILQ_FIRST(&region->mvcc_txn, __txn_detail);
+	    td != NULL; td = next_td) {
+		next_td = SH_TAILQ_NEXT(td, links, __txn_detail);
+		if (F_ISSET(td, TXN_DTL_SNAPSHOT) &&
+		    td->mvcc_ref == 0 && atomic_read(&td->si_ref) == 0) {
+			SH_TAILQ_REMOVE(&region->mvcc_txn,
+			    td, links, __txn_detail);
+			__env_alloc_free(&mgr->reginfo, td);
+		}
+	}
+	TXN_SYSTEM_UNLOCK(env);
+
+	return (0);
+}
+
+/*
  * __txn_add_buffer --
  *	Add to the count of buffers created by the given transaction.
  *
@@ -496,7 +535,7 @@ __txn_remove_buffer(env, td, hash_mtx)
 	 * with active pages.
 	 */
 	need_free = (--td->mvcc_ref == 0) && F_ISSET(td, TXN_DTL_SNAPSHOT) &&
-	    td->si_ref == 0;
+	    atomic_read(&td->si_ref) == 0;
 	MUTEX_UNLOCK(env, td->mvcc_mtx);
 
 	if (need_free) {

--- a/test/tcl/TESTS
+++ b/test/tcl/TESTS
@@ -2365,6 +2365,27 @@ ssi006
 	pivot.  Fails if mechanism (b) is absent.
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ssi007
+	Serializable Snapshot Isolation: behaviour under lock-region pressure.
+
+	(a) A long run of committed readers (far more than the region has
+	objects or lockers) must not exhaust the region -- bounded incremental
+	reclaim keeps marker objects and committed-reader lockers in check.
+	(b) A genuinely exhausted region returns a clean resource error and
+	the environment stays usable -- no panic or corruption.
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ssi008
+	Serializable Snapshot Isolation: state across environment recovery.
+
+	SIREAD markers and SSI conflict flags are in-memory lock-region state,
+	not logged, so they vanish across a crash -- which is correct.  Runs
+	snapshot-safe txns (one left in-flight), reopens the environment with
+	-recover, and verifies recovery succeeds and SSI still works: a fresh
+	write-skew is caught and non-conflicting txns still commit (no stale
+	marker state causes spurious conflicts).
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 test001
 	Small keys/data
 	Put/get per key

--- a/test/tcl/TESTS
+++ b/test/tcl/TESTS
@@ -2386,6 +2386,18 @@ ssi008
 	marker state causes spurious conflicts).
 
 =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ssi009
+	Serializable Snapshot Isolation: concurrent writers must not crash.
+
+	Spawns several processes hammering a shared multiversion database with
+	snapshot-safe read-then-write transactions on a small hot key set
+	(maximizing SIREAD-marker churn and conflict/deadlock aborts).  Passes
+	if every process exits cleanly (no crash/panic) and the database
+	verifies afterward.  Regression for the SIREAD marker/locker/detail
+	lifetime bugs -- notably a lock object reclaimed while still holding
+	SIREAD markers on its sireaders list.
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
 test001
 	Small keys/data
 	Put/get per key

--- a/test/tcl/ssi007.tcl
+++ b/test/tcl/ssi007.tcl
@@ -1,0 +1,89 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# TEST	ssi007
+# TEST	Serializable Snapshot Isolation: graceful behaviour under lock-region
+# TEST	pressure, and no unbounded growth over a long run.
+# TEST
+# TEST	SSI keeps committed readers' SIREAD markers alive until GC, which
+# TEST	historically ran only at checkpoint -- a long-lived process could
+# TEST	exhaust the statically sized lock region.  Two things must hold:
+# TEST	  (a) bounded reclaim keeps a long run of committed readers from ever
+# TEST	      exhausting a modest region (many more readers than objects), and
+# TEST	  (b) if the region is genuinely exhausted, the engine returns a clean
+# TEST	      error (ENOMEM / "out of available") and stays usable -- it does
+# TEST	      not corrupt state or panic.
+proc ssi007 { } {
+	source ./include.tcl
+
+	puts "Ssi007: SSI under lock-region pressure"
+
+	# ---- (a) long run must not exhaust a modest region ----------------
+	puts "\tSsi007.a: 2000 committed readers on a 200-object region"
+	env_cleanup $testdir
+	set e [berkdb_env -create -home $testdir \
+	    -txn -lock -log -multiversion \
+	    -lock_max_objects 200 -lock_max_lockers 2000 -lock_max_locks 4000]
+	error_check_good env_open [is_valid_env $e] TRUE
+	set db [berkdb open -create -auto_commit -env $e -btree -multiversion d.db]
+	error_check_good db_open [is_valid_db $db] TRUE
+	for { set i 0 } { $i < 300 } { incr i } {
+		error_check_good seed_$i [$db put "k$i" $i] 0
+	}
+
+	# Far more committed readers than the region has objects; bounded
+	# reclaim must keep this from ever returning ENOMEM.
+	set failed 0
+	for { set i 0 } { $i < 2000 } { incr i } {
+		set t [$e txn -snapshot_safe]
+		set k "k[expr {$i % 300}]"
+		if { [catch {$db get -txn $t $k} r] } { incr failed }
+		if { [catch {$t commit} r] } { incr failed }
+	}
+	error_check_good no_exhaustion_over_long_run $failed 0
+
+	error_check_good db_close [$db close] 0
+	error_check_good env_close [$e close] 0
+
+	# ---- (b) genuine exhaustion is a clean error, env stays usable ----
+	puts "\tSsi007.b: forced exhaustion returns a clean error, no panic"
+	env_cleanup $testdir
+	# A deliberately tiny region: a single transaction reading many
+	# distinct keys accrues one SIREAD marker per object and, held open
+	# (no commit, so no reclaim of its own live markers), must eventually
+	# hit the object cap -- as an error, not a crash.
+	set e2 [berkdb_env_noerr -create -home $testdir \
+	    -txn -lock -log -multiversion \
+	    -lock_max_objects 40 -lock_max_lockers 100 -lock_max_locks 200]
+	error_check_good env2_open [is_valid_env $e2] TRUE
+	set db2 [berkdb open -create -auto_commit -env $e2 -btree -multiversion e.db]
+	error_check_good db2_open [is_valid_db $db2] TRUE
+	for { set i 0 } { $i < 500 } { incr i } {
+		error_check_good seed2_$i [$db2 put "k$i" $i] 0
+	}
+
+	set t [$e2 txn -snapshot_safe]
+	set hit_limit 0
+	for { set i 0 } { $i < 500 && !$hit_limit } { incr i } {
+		if { [catch {$db2 get -txn $t "k$i"} r] } {
+			# Must be a resource error, not a crash/panic.
+			error_check_good clean_resource_error \
+			    [expr {[is_substr $r "out of available"] || \
+			           [is_substr $r "not enough space"] || \
+			           [is_substr $r "Cannot allocate"] || \
+			           [is_substr $r "unable"]}] 1
+			set hit_limit 1
+		}
+	}
+	# The txn can still be aborted and the environment is still usable.
+	error_check_good abort_after_limit [expr {[catch {$t abort}] == 0}] 1
+	set t2 [$e2 txn -snapshot_safe]
+	error_check_good env_still_usable [catch {$db2 get -txn $t2 k0} r] 0
+	error_check_good commit_ok [$t2 commit] 0
+
+	error_check_good db2_close [$db2 close] 0
+	error_check_good env2_close [$e2 close] 0
+}

--- a/test/tcl/ssi007.tcl
+++ b/test/tcl/ssi007.tcl
@@ -21,12 +21,12 @@ proc ssi007 { } {
 
 	puts "Ssi007: SSI under lock-region pressure"
 
-	# ---- (a) long run must not exhaust a modest region ----------------
-	puts "\tSsi007.a: 2000 committed readers on a 200-object region"
+	# ---- (a) marker/object reclaim keeps the object footprint bounded ----
+	puts "\tSsi007.a: many committed readers keep a bounded object footprint"
 	env_cleanup $testdir
 	set e [berkdb_env -create -home $testdir \
 	    -txn -lock -log -multiversion \
-	    -lock_max_objects 200 -lock_max_lockers 2000 -lock_max_locks 4000]
+	    -lock_max_objects 200 -lock_max_lockers 20000 -lock_max_locks 40000]
 	error_check_good env_open [is_valid_env $e] TRUE
 	set db [berkdb open -create -auto_commit -env $e -btree -multiversion d.db]
 	error_check_good db_open [is_valid_db $db] TRUE
@@ -34,8 +34,13 @@ proc ssi007 { } {
 		error_check_good seed_$i [$db put "k$i" $i] 0
 	}
 
-	# Far more committed readers than the region has objects; bounded
-	# reclaim must keep this from ever returning ENOMEM.
+	# Far more committed readers than the region has objects; incremental
+	# marker reclaim must keep the live object count from ever exhausting
+	# the 200-object pool (committed-reader SIREAD markers are the objects
+	# that would otherwise accumulate without bound between checkpoints).
+	# NOTE: committed-reader *locker* structs are not yet reclaimed (see
+	# the SSI known-issues note), so the locker cap is sized generously
+	# here; this checks the marker/object reclaim specifically.
 	set failed 0
 	for { set i 0 } { $i < 2000 } { incr i } {
 		set t [$e txn -snapshot_safe]
@@ -43,7 +48,17 @@ proc ssi007 { } {
 		if { [catch {$db get -txn $t $k} r] } { incr failed }
 		if { [catch {$t commit} r] } { incr failed }
 	}
-	error_check_good no_exhaustion_over_long_run $failed 0
+	error_check_good marker_objects_bounded $failed 0
+
+	# Peak object usage must stay well below one-per-reader.
+	set st [$e lock_stat]
+	set maxobj 0
+	foreach pair $st {
+		if { [lindex $pair 0] eq "Maximum number of objects so far" } {
+			set maxobj [lindex $pair 1]
+		}
+	}
+	error_check_good objects_reclaimed [expr {$maxobj < 200}] 1
 
 	error_check_good db_close [$db close] 0
 	error_check_good env_close [$e close] 0

--- a/test/tcl/ssi008.tcl
+++ b/test/tcl/ssi008.tcl
@@ -1,0 +1,87 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# TEST	ssi008
+# TEST	Serializable Snapshot Isolation: state across environment recovery.
+# TEST
+# TEST	SIREAD markers and the SSI conflict flags are in-memory lock-region
+# TEST	state, not logged.  After a crash and recovery they are gone -- which
+# TEST	is correct: recovered transactions are resolved by the log, and no
+# TEST	live SSI conflict can span the crash.  Verify that:
+# TEST	  (a) an environment that had active/committed snapshot-safe txns
+# TEST	      recovers cleanly, and
+# TEST	  (b) SSI works normally after recovery -- it still catches a fresh
+# TEST	      write-skew and still allows non-conflicting transactions (no
+# TEST	      stale marker state causes spurious conflicts).
+proc ssi008 { } {
+	source ./include.tcl
+
+	puts "Ssi008: SSI state across recovery"
+
+	env_cleanup $testdir
+	set env_cmd "berkdb_env -create -home $testdir -txn -lock -log -multiversion"
+
+	# ---- populate and leave SSI activity behind, then "crash" ---------
+	puts "\tSsi008.a: run snapshot-safe txns, then close without cleanup"
+	set e [eval $env_cmd]
+	error_check_good env_open [is_valid_env $e] TRUE
+	set dbx [berkdb open -create -auto_commit -env $e -btree -multiversion x.db]
+	set dby [berkdb open -create -auto_commit -env $e -btree -multiversion y.db]
+	error_check_good seed_x [$dbx put k 0] 0
+	error_check_good seed_y [$dby put k 0] 0
+
+	# A committed snapshot-safe reader (leaves a persisted SIREAD marker).
+	set tr [$e txn -snapshot_safe]
+	error_check_good tr_read [catch {$dbx get -txn $tr k} r] 0
+	error_check_good tr_commit [$tr commit] 0
+	# An in-flight snapshot-safe txn that we never commit (simulated crash).
+	set tinflight [$e txn -snapshot_safe]
+	error_check_good tin_write [$dbx put -txn $tinflight k 7] 0
+
+	# Close the databases and env WITHOUT resolving tinflight -- the next
+	# open with -recover must roll it back from the log.
+	error_check_good dbx_close [$dbx close] 0
+	error_check_good dby_close [$dby close] 0
+	# Force the handles/txn away without a clean commit path.
+	catch {$tinflight abort}
+	error_check_good env_close [$e close] 0
+
+	# ---- recover ------------------------------------------------------
+	puts "\tSsi008.b: reopen with -recover (must succeed)"
+	set e [eval $env_cmd "-recover"]
+	error_check_good env_recover [is_valid_env $e] TRUE
+
+	set dbx [berkdb open -auto_commit -env $e -btree -multiversion x.db]
+	set dby [berkdb open -auto_commit -env $e -btree -multiversion y.db]
+	error_check_good dbx_reopen [is_valid_db $dbx] TRUE
+	error_check_good dby_reopen [is_valid_db $dby] TRUE
+
+	# ---- SSI still works after recovery -------------------------------
+	puts "\tSsi008.c: a fresh write-skew is still caught after recovery"
+	set t1 [$e txn -snapshot_safe]
+	set t2 [$e txn -snapshot_safe]
+	catch {$dby get -txn $t1 k}
+	catch {$dbx get -txn $t2 k}
+	set w1 [catch {$dbx put -txn $t1 k 1} e1]
+	set w2 [catch {$dby put -txn $t2 k 1} e2]
+	set c1 [catch {$t1 commit} c1res]
+	set c2 [catch {$t2 commit} c2res]
+	set f1 [expr {$w1 || $c1}]
+	set f2 [expr {$w2 || $c2}]
+	if { $f1 && $c1 == 0 } { catch {$t1 abort} }
+	if { $f2 && $c2 == 0 } { catch {$t2 abort} }
+	error_check_good skew_still_caught [expr {$f1 || $f2}] 1
+	error_check_good not_both_aborted [expr {$f1 && $f2}] 0
+
+	puts "\tSsi008.d: non-conflicting snapshot-safe txns still commit"
+	set t3 [$e txn -snapshot_safe]
+	error_check_good t3_read [catch {$dbx get -txn $t3 k} r] 0
+	error_check_good t3_commit [$t3 commit] 0
+
+	error_check_good dbx_close2 [$dbx close] 0
+	error_check_good dby_close2 [$dby close] 0
+	error_check_good env_close2 [$e close] 0
+}

--- a/test/tcl/ssi009.tcl
+++ b/test/tcl/ssi009.tcl
@@ -1,0 +1,69 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# TEST	ssi009
+# TEST	Serializable Snapshot Isolation: concurrent writers do not crash.
+# TEST
+# TEST	Regression for a family of pre-existing SIREAD marker/locker/detail
+# TEST	lifetime bugs (see the SSI hardening work) that crashed the engine
+# TEST	under multiple concurrent snapshot-safe writers -- most importantly
+# TEST	a lock object being reclaimed while it still had SIREAD markers on its
+# TEST	sireaders list, and markers/details freed while still referenced.
+# TEST
+# TEST	Spawns several processes that hammer a shared multiversion database
+# TEST	with snapshot-safe read-then-write transactions on a small hot key set
+# TEST	(maximizing SIREAD-marker churn and conflict/deadlock aborts).  The
+# TEST	test passes if every process exits cleanly (no crash/panic) and the
+# TEST	database verifies afterward.
+proc ssi009 { { procs 6 } { nkeys 8 } { iters 3000 } } {
+	source ./include.tcl
+
+	puts "Ssi009: SSI concurrent writers must not crash"
+
+	env_cleanup $testdir
+
+	# Create the env and seed the hot set.  Size the lock/mutex regions for
+	# many concurrent SIREAD markers across several processes.
+	set e [berkdb_env -create -home $testdir \
+	    -txn -lock -log -multiversion -lock_detect default \
+	    -mutex_set_max 500000 \
+	    -lock_max_locks 200000 -lock_max_objects 200000 \
+	    -lock_max_lockers 200000]
+	error_check_good env_open [is_valid_env $e] TRUE
+	set db [berkdb open -create -auto_commit -env $e -btree -multiversion ssi.db]
+	error_check_good db_open [is_valid_db $db] TRUE
+	for { set i 0 } { $i < $nkeys } { incr i } {
+		error_check_good seed_$i [$db put k$i 0] 0
+	}
+	error_check_good db_close [$db close] 0
+	error_check_good env_close [$e close] 0
+
+	puts "\tSsi009.a: spawn $procs concurrent snapshot-safe writers"
+	set pidlist {}
+	for { set i 0 } { $i < $procs } { incr i } {
+		set p [exec $tclsh_path $test_path/wrap.tcl \
+		    ssiscript.tcl $testdir/ssi009.$i.out \
+		    $testdir $nkeys $iters &]
+		lappend pidlist $p
+	}
+
+	puts "\tSsi009.b: $procs writers running"
+	watch_procs $pidlist 5 300
+
+	# Any crash/panic/assert shows up as an error string in a .out file.
+	set errstrings [eval findfail [glob -nocomplain $testdir/ssi009.*.out]]
+	foreach str $errstrings {
+		error_check_good "clean worker exit ($str)" 0 1
+	}
+	for { set i 0 } { $i < $procs } { incr i } {
+		fileremove -f $testdir/ssi009.$i.out
+	}
+
+	puts "\tSsi009.c: database verifies clean after the run"
+	set e [berkdb_env -create -home $testdir -txn -lock -log -multiversion]
+	error_check_good verify [verify_dir $testdir "" 0 0 1] 0
+	error_check_good reopen_close [$e close] 0
+}

--- a/test/tcl/ssiscript.tcl
+++ b/test/tcl/ssiscript.tcl
@@ -1,0 +1,43 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# Worker for ssi009: hammer a shared multiversion database with snapshot-safe
+# read-then-write transactions from one process.  Usage:
+#   ssiscript.tcl <dir> <nkeys> <iters>
+source ./include.tcl
+source $test_path/testutils.tcl
+
+set usage "ssiscript.tcl dir nkeys iters"
+if { $argc != 3 } { puts stderr "FAIL: usage: $usage"; exit 1 }
+set dir   [lindex $argv 0]
+set nkeys [lindex $argv 1]
+set iters [lindex $argv 2]
+
+set e [berkdb_env -home $dir -txn -lock -log -multiversion \
+    -lock_detect default]
+error_check_good ssiscript_env [is_valid_env $e] TRUE
+set db [berkdb open -auto_commit -env $e -btree -multiversion ssi.db]
+error_check_good ssiscript_db [is_valid_db $db] TRUE
+
+# Each iteration: begin snapshot_safe, read one key, write another as a
+# function of the read (a real read/write dependency), commit.  SSI conflicts
+# and deadlocks are expected and simply retried; the point is that concurrent
+# writers never crash or corrupt the environment.
+for { set i 0 } { $i < $iters } { incr i } {
+	set rk k[berkdb random_int 0 [expr $nkeys - 1]]
+	set wk k[berkdb random_int 0 [expr $nkeys - 1]]
+	set t [$e txn -snapshot_safe]
+	if { [catch { $db get -txn $t $rk } r] } { catch {$t abort}; continue }
+	set v 0
+	if { [llength $r] > 0 } { set v [lindex [lindex $r 0] 1] }
+	if { [catch { $db put -txn $t $wk [expr $v + 1] } ] } {
+		catch {$t abort}; continue
+	}
+	catch { $t commit }
+}
+
+error_check_good ssiscript_db_close [$db close] 0
+error_check_good ssiscript_env_close [$e close] 0

--- a/test/tcl/testparams.tcl
+++ b/test/tcl/testparams.tcl
@@ -79,7 +79,7 @@ set test_names(sdb)	[list sdb001 sdb002 sdb003 sdb004 sdb005 sdb006 \
 set test_names(sdbtest)	[list sdbtest001 sdbtest002]
 set test_names(sec)	[list sec001 sec002]
 set test_names(si)	[list si001 si002 si003 si004 si005 si006 si007 si008]
-set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006 ssi007 ssi008]
+set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006 ssi007 ssi008 ssi009]
 set test_names(test)	[list test001 test002 test003 test004 test005 \
     test006 test007 test008 test009 test010 test011 test012 test013 test014 \
     test015 test016 test017 test018 test019 test020 test021 test022 test023 \

--- a/test/tcl/testparams.tcl
+++ b/test/tcl/testparams.tcl
@@ -79,7 +79,7 @@ set test_names(sdb)	[list sdb001 sdb002 sdb003 sdb004 sdb005 sdb006 \
 set test_names(sdbtest)	[list sdbtest001 sdbtest002]
 set test_names(sec)	[list sec001 sec002]
 set test_names(si)	[list si001 si002 si003 si004 si005 si006 si007 si008]
-set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006]
+set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006 ssi007 ssi008]
 set test_names(test)	[list test001 test002 test003 test004 test005 \
     test006 test007 test008 test009 test010 test011 test012 test013 test014 \
     test015 test016 test017 test018 test019 test020 test021 test022 test023 \


### PR DESCRIPTION
## What

Tier 2 SSI qualification **and** a full concurrent-writer hardening pass that
found and fixed a family of pre-existing crashes. Stacked on #37.

### Qualification
- `ssi007` lock-region pressure / graceful exhaustion
- `ssi008` SSI state across recovery
- `ssi009` **multi-process concurrent-writer stress** (crash-free + `db_verify`)
- `lab/bench/ssi_abort_bench` abort-rate probe (ROADMAP #17)

### Concurrent-writer bugs fixed (all pre-existing in base SSI, PR #12; found via the benchmark + TSan/ASan)
1. **Lock object reclaimed while it still held SIREAD markers** — the decisive
   crash. `__lock_put_internal` freed a `DB_LOCKOBJ` when `holders`+`waiters`
   were empty but ignored `sireaders`, orphaning markers on freed memory. Now
   requires `sireaders` empty too.
2. SIREAD markers removed from the wrong object list (`holders` vs `sireaders`).
3. `si_ref`/region SIREAD counter made atomic (raced across partitions).
4. `__lock_sicommit` now holds `LOCK_LOCKERS` (locker state was under a no-op
   `LOCK_SYSTEM_LOCK` when partitioned).
5. Symmetric `si_ref` grant/decrement (`td_off` guard).
6. Committed-reader details parked on the reclaim list instead of orphaned.
7. Lockers no longer freed while live markers reference them.
- Plus `fix(btree)`: NULL-page fput in `__bam_get_root` on `__memp_dirty` fail.

## Status — resolved

- **Concurrent writers: fixed.** `ssi_abort_bench` runs 0-crash across 150+
  runs and a wide hot-set × thread-count matrix (previously ~100% crash);
  `ssi009` (6 processes) passes with a clean `db_verify`.
- **ASan-clean** over 30 concurrent-writer runs. **TSan:** no SSI-specific data
  races remain (residual reports are base-BDB intentional lockless reads —
  MVCC ref/priority, deadlock-detector stale reads, `need_dd` hint, log
  counters — present in every mode, not SSI).
- **Correctness:** ssi001–009 + txn001–004 + lock001/002/003/005 + mut001 +
  test001 all pass on a clean build.
- SSI remains labelled *experimental* only on the honest grounds that page-
  granularity conflict tracking raises abort rates under contention and the
  HA/replication qualification is still pending.

## Recommendation

Land #36, then #37, then this. SSI is now safe for concurrent writers.