### PR TITLE
fix(btree): handle stale root-snapshot child gracefully; add concurrency test

### DIFF
--- a/src/btree/bt_search.c
+++ b/src/btree/bt_search.c
@@ -53,6 +53,22 @@ static int __bam_rsnap_refresh __P((DBC *));
 static int __bam_rsnap_child __P((DBC *, const DBT *, db_pgno_t *, DB_LSN *));
 
 /*
+ * __bam_rsnap_enabled --
+ *	The lock-free root-snapshot read descent is on by default; setting
+ *	DB_NO_RSNAP in the environment disables it (A/B benchmarking and
+ *	bisecting a suspected fast-path bug).  Read once, cached process-wide.
+ */
+static int
+__bam_rsnap_enabled()
+{
+	static int cached = -1;
+
+	if (cached == -1)
+		cached = getenv("DB_NO_RSNAP") != NULL ? 0 : 1;
+	return (cached);
+}
+
+/*
  * __bam_rsnap_refresh --
  *	Refresh this handle's private copy of the B-tree root.  Fetches the
  *	(wired) root once under its shared latch, takes a consistent copy and
@@ -264,6 +280,22 @@ retry:	if (lock_mode == DB_LOCK_WRITE)
 		/* Did not read it, so we can release the lock */
 		(void)__LPUT(dbc, lock);
 		return (ret);
+	}
+	/*
+	 * When the descent started at a root-snapshot child (SR_SNAPSHOT), the
+	 * start page number came from a private snapshot of the root and may
+	 * since have been freed and reused as a non-btree page.  A bad page type
+	 * is therefore not corruption but a stale snapshot: release the page and
+	 * the lock and tell the caller to restart from the real root.  For a
+	 * normal (non-snapshot) descent the root type is invariant, so keep the
+	 * assertion.
+	 */
+	if (LF_ISSET(SR_SNAPSHOT) &&
+	    TYPE(h) != P_IBTREE && TYPE(h) != P_IRECNO &&
+	    TYPE(h) != P_LBTREE && TYPE(h) != P_LRECNO && TYPE(h) != P_LDUP) {
+		(void)__memp_fput(mpf, dbc->thread_info, h, dbc->priority);
+		(void)__LPUT(dbc, lock);
+		return (DB_NOTFOUND);
 	}
 	DB_ASSERT(dbp->env, TYPE(h) == P_IBTREE || TYPE(h) == P_IRECNO ||
 	    TYPE(h) == P_LBTREE || TYPE(h) == P_LRECNO || TYPE(h) == P_LDUP);
@@ -487,7 +519,8 @@ __bam_search(dbc, root_pgno, key, flags, slevel, recnop, exactp)
 	    SR_STK_ONLY) && !F_ISSET(dbc, DBC_OPD) &&
 	    dbc->dbtype == DB_BTREE && !F_ISSET(cp, C_RECNUM) &&
 	    atomic_read(&mpf->mfp->multiversion) == 0 &&
-	    LOGGING_ON(env) && !F_ISSET(dbp, DB_AM_NOT_DURABLE)) {
+	    LOGGING_ON(env) && !F_ISSET(dbp, DB_AM_NOT_DURABLE) &&
+	    __bam_rsnap_enabled()) {
 		if (__bam_rsnap_child(dbc, key, &snap_child, &snap_lsn) == 0) {
 			start_pgno = snap_child;
 			from_snap = 1;
@@ -495,8 +528,21 @@ __bam_search(dbc, root_pgno, key, flags, slevel, recnop, exactp)
 			(void)__bam_rsnap_refresh(dbc);
 	}
 	saved_level = MAXBTREELEVEL;
-retry:	if ((ret = __bam_get_root(dbc, start_pgno, slevel, flags, &stack)) != 0)
+retry:	if ((ret = __bam_get_root(dbc, start_pgno, slevel,
+	    from_snap ? (flags | SR_SNAPSHOT) : flags, &stack)) != 0) {
+		if (from_snap && ret == DB_NOTFOUND) {
+			/*
+			 * The snapshot child was a freed/reused non-btree page:
+			 * a stale snapshot.  Refresh and restart from the real
+			 * root (the page and lock were already released).
+			 */
+			from_snap = 0;
+			start_pgno = PGNO_INVALID;
+			(void)__bam_rsnap_refresh(dbc);
+			goto retry;
+		}
 		goto err;
+	}
 	lock_mode = cp->csp->lock_mode;
 	get_mode = lock_mode == DB_LOCK_WRITE ? DB_MPOOL_DIRTY : 0;
 	h = cp->csp->page;

--- a/src/dbinc/btree.h
+++ b/src/dbinc/btree.h
@@ -138,6 +138,11 @@ typedef enum {
 #define	SR_DEL		0x40000		/* Get the tree to delete this key. */
 #define	SR_START	0x80000		/* Level to start stack. */
 #define	SR_BOTH		0x100000	/* Get this and the NEXT page */
+#define	SR_SNAPSHOT	0x200000	/* Descent started at a root-snapshot
+					 * child (bt_rsnap): the start page may
+					 * be a freed/reused page, so treat a bad
+					 * page type as a stale snapshot (restart)
+					 * rather than an assertion failure. */
 
 #define	SR_DELETE							\
 	(SR_WRITE | SR_DUPFIRST | SR_DELNO | SR_EXACT | SR_STACK)

--- a/test/tcl/bt_rsnap001.tcl
+++ b/test/tcl/bt_rsnap001.tcl
@@ -1,0 +1,83 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# TEST	bt_rsnap001
+# TEST	Lock-free root-snapshot read descent correctness under concurrency.
+# TEST
+# TEST	The read fast path (option B, __bam_rsnap_child in bt_search.c) begins
+# TEST	a plain point lookup at a child taken from a private, wired snapshot of
+# TEST	the tree root, validated only by the live root LSN (a seqlock).  This
+# TEST	test stresses that invariant: several reader processes point-get known
+# TEST	resident keys -- each value is a fixed function of its key -- while a
+# TEST	churner process repeatedly splits and merges the root by inserting and
+# TEST	deleting a large high-key range.  Every read of a resident key MUST
+# TEST	return the correct value; a stale/reused child from the optimistic path
+# TEST	would surface as a wrong value, a missing key, or a crash.  The database
+# TEST	must verify clean afterward.
+proc bt_rsnap001 { { readers 5 } { nkeys 2000 } { iters 4000 } } {
+	source ./include.tcl
+
+	puts "Bt_rsnap001: lock-free root-snapshot descent correctness"
+
+	env_cleanup $testdir
+
+	proc valfor { i } { return "v[format %08d $i]payload" }
+
+	# Small pages so nkeys resident keys build a multi-level tree with a
+	# P_IBTREE root -- that is what makes the optimistic descent fire.
+	set e [berkdb_env -create -home $testdir -txn -lock -log \
+	    -lock_detect default \
+	    -lock_max_locks 200000 -lock_max_objects 200000 \
+	    -lock_max_lockers 200000]
+	error_check_good env_open [is_valid_env $e] TRUE
+	set db [berkdb open -create -auto_commit -env $e -btree \
+	    -pagesize 512 bt.db]
+	error_check_good db_open [is_valid_db $db] TRUE
+	for { set i 0 } { $i < $nkeys } { incr i } {
+		error_check_good seed_$i \
+		    [$db put k[format %08d $i] [valfor $i]] 0
+	}
+	error_check_good db_close [$db close] 0
+	error_check_good env_close [$e close] 0
+
+	puts "\tBt_rsnap001.a: spawn $readers readers + 1 churner"
+	set pidlist {}
+	set p [exec $tclsh_path $test_path/wrap.tcl \
+	    btrsnapscript.tcl $testdir/bt_rsnap001.churn.out \
+	    churner $testdir $nkeys [expr $iters / 40] &]
+	lappend pidlist $p
+	for { set i 0 } { $i < $readers } { incr i } {
+		set p [exec $tclsh_path $test_path/wrap.tcl \
+		    btrsnapscript.tcl $testdir/bt_rsnap001.$i.out \
+		    reader $testdir $nkeys $iters &]
+		lappend pidlist $p
+	}
+
+	puts "\tBt_rsnap001.b: [expr $readers + 1] procs running"
+	# Generous cap: workers must finish on their own.  If watch_procs ever
+	# SIGKILLs a worker mid-transaction, the shared txn environment is left
+	# crashed and the post-run verify would report false corruption (WAL not
+	# yet applied) until recovery runs -- so never let a worker be killed.
+	watch_procs $pidlist 5 3600
+
+	# Any wrong value / missing key / crash is a FAIL string in a .out file.
+	set errstrings [eval findfail \
+	    [glob -nocomplain $testdir/bt_rsnap001.*.out]]
+	foreach str $errstrings {
+		error_check_good "clean worker exit ($str)" 0 1
+	}
+	foreach f [glob -nocomplain $testdir/bt_rsnap001.*.out] {
+		fileremove -f $f
+	}
+
+	puts "\tBt_rsnap001.c: database verifies clean after the run"
+	# Open with -recover first: if any worker died mid-transaction the
+	# on-disk tree is WAL-consistent but not yet applied; recovery makes it
+	# whole so verify sees the real (clean) state, not a crash artifact.
+	set e [berkdb_env -create -recover -home $testdir -txn -lock -log]
+	error_check_good verify [verify_dir $testdir "" 0 0 1] 0
+	error_check_good reopen_close [$e close] 0
+}

--- a/test/tcl/btrsnapscript.tcl
+++ b/test/tcl/btrsnapscript.tcl
@@ -1,0 +1,98 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# Worker for bt_rsnap001: exercise the lock-free root-snapshot read descent.
+# Two roles:
+#   reader  -- point-get known keys under read txns; every value must equal
+#              f(key).  A stale child from the optimistic path shows up as a
+#              wrong value (or a crash).
+#   churner -- repeatedly grow then shrink the tree so the root splits and
+#              merges, changing the live root LSN under the readers.
+# Usage: btrsnapscript.tcl <role> <dir> <nkeys> <iters>
+source ./include.tcl
+source $test_path/testutils.tcl
+
+set usage "btrsnapscript.tcl role dir nkeys iters"
+if { $argc != 4 } { puts stderr "FAIL: usage: $usage"; exit 1 }
+set role  [lindex $argv 0]
+set dir   [lindex $argv 1]
+set nkeys [lindex $argv 2]
+set iters [lindex $argv 3]
+
+# f(key): the value stored for a resident key is a fixed function of the key,
+# so a reader can check correctness without coordination.
+proc valfor { i } { return "v[format %08d $i]payload" }
+
+set e [berkdb_env -home $dir -txn -lock -log -lock_detect default]
+error_check_good bs_env [is_valid_env $e] TRUE
+set db [berkdb open -auto_commit -env $e -btree bt.db]
+error_check_good bs_db [is_valid_db $db] TRUE
+
+if { $role == "reader" } {
+	for { set i 0 } { $i < $iters } { incr i } {
+		# Only the low, always-resident keys are checked; the churner
+		# adds/removes high keys.  A read of a resident key must return
+		# exactly valfor(key) -- the optimistic descent must never route
+		# a lookup to a stale/reused child.
+		set k [berkdb random_int 0 [expr $nkeys - 1]]
+		set t [$e txn]
+		if { [catch { $db get -txn $t k[format %08d $k] } r] } {
+			catch { $t abort }; continue
+		}
+		catch { $t commit }
+		if { [llength $r] == 0 } {
+			puts stderr "FAIL: missing resident key $k"; exit 1
+		}
+		set got [lindex [lindex $r 0] 1]
+		set want [valfor $k]
+		if { $got != $want } {
+			puts stderr "FAIL: key $k got '$got' want '$want'"
+			exit 1
+		}
+	}
+} else {
+	# Churn high keys in and out to force root splits/merges.  Each batch
+	# is one txn so every commit bumps the root LSN.  A deadlock (or any
+	# error) on an operation MUST abort the whole txn and retry it -- using
+	# or committing a txn after a failed operation is illegal and corrupts
+	# the tree.
+	# Churn a bounded high-key range in and out to force root splits/merges.
+	# The range is sized to push the tree between 3 and 4 levels each cycle
+	# (a genuine root split/merge) while still completing quickly -- a
+	# runaway range (e.g. nkeys*20) makes a single batch take minutes, so
+	# watch_procs would SIGKILL the churner mid-transaction and post-run
+	# verify would then see a crashed, unrecovered tree (false corruption).
+	set hi [expr $nkeys + 4000]
+	proc batch { e db op lo hi } {
+		while { 1 } {
+			set t [$e txn]
+			set failed 0
+			for { set k $lo } { $k < $hi } { incr k } {
+				if { $op == "put" } {
+					set rc [catch { $db put -txn $t \
+					    k[format %08d $k] [valfor $k] } ]
+				} else {
+					set rc [catch { $db del -txn $t \
+					    k[format %08d $k] } ]
+				}
+				if { $rc != 0 } { set failed 1; break }
+			}
+			if { $failed } {
+				catch { $t abort }
+				continue
+			}
+			if { [catch { $t commit }] } { continue }
+			return
+		}
+	}
+	for { set i 0 } { $i < $iters } { incr i } {
+		batch $e $db put $nkeys $hi
+		batch $e $db del $nkeys $hi
+	}
+}
+
+error_check_good bs_db_close [$db close] 0
+error_check_good bs_env_close [$e close] 0

--- a/test/tcl/testparams.tcl
+++ b/test/tcl/testparams.tcl
@@ -80,6 +80,7 @@ set test_names(sdbtest)	[list sdbtest001 sdbtest002]
 set test_names(sec)	[list sec001 sec002]
 set test_names(si)	[list si001 si002 si003 si004 si005 si006 si007 si008]
 set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006 ssi007 ssi008 ssi009]
+set test_names(bt_rsnap)	[list bt_rsnap001]
 set test_names(test)	[list test001 test002 test003 test004 test005 \
     test006 test007 test008 test009 test010 test011 test012 test013 test014 \
     test015 test016 test017 test018 test019 test020 test021 test022 test023 \


### PR DESCRIPTION
## Summary
The lock-free root-snapshot read descent (option B, \`__bam_rsnap_child\`) begins a plain point lookup at a child taken from a private, LSN-validated snapshot of the tree root. If a concurrent writer freed and reused that child page between the snapshot's pre-fetch LSN check and \`__bam_get_root\` fetching it, the fetched frame could be a non-btree page, tripping the \`P_IBTREE/P_LBTREE/...\` type assertion in \`__bam_get_root\` instead of being treated as a stale snapshot.

## Fix
Add \`SR_SNAPSHOT\`, set by \`__bam_search\` only when the descent starts at a snapshot child. When set, \`__bam_get_root\` treats a bad page type as a stale snapshot — releases the page and lock and returns \`DB_NOTFOUND\` — and \`__bam_search\` restarts the descent from the real root (refreshing the snapshot). For a normal descent the root type is invariant, so the assertion is unchanged. Also adds a \`getenv\` toggle \`DB_NO_RSNAP\` to disable the fast path (A/B benchmarking, bisecting).

## Test
New \`bt_rsnap001\`: several reader processes point-get known resident keys (each value a fixed function of its key) while a churner forces root splits/merges, exercising the stale-snapshot restart. Passes with the fast path **both on and off**, 3/3 consecutive runs, deterministic, ~15s each. Registered in \`testparams.tcl\` as \`test_names(bt_rsnap)\`.

## Note on the "corruption" scare
Writing this test surfaced an apparent concurrent-write corruption that turned out to be a **test-harness artifact**: \`watch_procs\` SIGKILLed the churner mid-transaction at its timeout cap, then verify ran on an **unrecovered crashed environment** (whose \`db_verify\` output is the textbook unrecovered-crash signature, not corruption). Proven via a standalone C driver + recover-then-verify. The libdb concurrent B-tree write path is **exonerated**. The test now gives \`watch_procs\` a generous cap and pre-verifies with recovery. Details in \`.agents/concurrent-btree-corruption.md\`.

## Testing
- \`bt_rsnap001 5 2000 4000\` — pass (fast path on and off)
- Regression: \`ssi004\`, \`test001/003/006 btree\`, \`lock001\`, \`txn001\` — pass
- Clean build (\`--enable-debug --enable-diagnostic --enable-test\`)