### PR TITLE
ci: expand matrix (TSan, warnings gate, mutex backends, nightly extras)

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -1,0 +1,200 @@
+# libdb extended CI (heavy / scheduled-only).
+#
+# These jobs are too slow or too noisy to run on every PR, so they run nightly
+# (cron) and on demand (workflow_dispatch). Everything here is best-effort
+# (continue-on-error) and never gates a PR -- the fast PR signal lives in
+# ci.yml. Kept in a separate workflow so the PR "Checks" list stays readable.
+
+name: CI (extended)
+
+on:
+  schedule:
+    # Nightly at 04:23 UTC, staggered after the main CI cron (03:17).
+    - cron: '23 4 * * *'
+  workflow_dispatch:
+    inputs:
+      full_tcl:
+        description: 'Run the full TCL regression suite (run_std)'
+        type: boolean
+        default: true
+
+concurrency:
+  group: ci-extended-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ----------------------------------------------------------------------------
+  # Full TCL regression suite (run_std). Long-running: generous timeout, never
+  # on PRs. On manual dispatch, full_tcl=false narrows it to a broad subset.
+  # ----------------------------------------------------------------------------
+  full-tcl:
+    name: full tcl suite
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 330
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Tcl
+        run: sudo apt-get update && sudo apt-get install -y tcl-dev tcl
+      - name: Configure (test + tcl)
+        working-directory: build_unix
+        run: ../dist/configure --enable-debug --enable-test --with-tcl=/usr/lib/tcl8.6
+      - name: Build
+        working-directory: build_unix
+        run: make -j$(nproc)
+      - name: Run suite
+        working-directory: build_unix
+        run: |
+          # Scheduled runs (no dispatch input) default to the full suite; a
+          # manual dispatch may opt out via full_tcl=false for a broad subset.
+          if [ "${{ github.event.inputs.full_tcl }}" = "false" ]; then
+            cat > /tmp/run.tcl <<'TCL'
+          source ../test/tcl/test.tcl
+          foreach t {test001 test003 test010 lock001 lock002 txn001 txn003 \
+                     mut001 ssi001 ssi002 ssi003 ssi009 rep001 recd001} {
+            source ../test/tcl/$t.tcl
+            set a {}
+            if {[string match test* $t]} { set a btree }
+            if {[catch {eval $t $a} res]} { puts "FAIL $t: $res"; exit 1 }
+            puts "PASS $t"
+          }
+          TCL
+          else
+            cat > /tmp/run.tcl <<'TCL'
+          source ../test/tcl/test.tcl
+          run_std
+          TCL
+          fi
+          # 5h ceiling under the 5.5h job timeout.
+          timeout 18000 tclsh /tmp/run.tcl 2>&1 | tee /tmp/out.txt
+          ! grep -qE "^FAIL|FAIL:" /tmp/out.txt
+
+  # ----------------------------------------------------------------------------
+  # gcc/clang version matrix -- extra toolchain versions from apt (best-effort;
+  # a version may be unavailable on a given runner image, hence the guard).
+  # ----------------------------------------------------------------------------
+  compiler-versions:
+    name: build ${{ matrix.compiler }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { compiler: gcc-12,   pkg: gcc-12,     cc: gcc-12 }
+          - { compiler: gcc-13,   pkg: gcc-13,     cc: gcc-13 }
+          - { compiler: clang-15, pkg: clang-15,   cc: clang-15 }
+          - { compiler: clang-17, pkg: clang-17,   cc: clang-17 }
+    env:
+      CC: ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ${{ matrix.pkg }}
+        run: |
+          sudo apt-get update
+          if ! sudo apt-get install -y ${{ matrix.pkg }}; then
+            echo "::warning title=Toolchain unavailable::${{ matrix.pkg }} not installable on this runner image; skipping."
+            exit 0
+          fi
+      - name: Configure
+        working-directory: build_unix
+        run: |
+          command -v ${{ matrix.cc }} >/dev/null || { echo "::warning::${{ matrix.cc }} absent; skipping"; exit 0; }
+          ../dist/configure --enable-debug
+      - name: Build
+        working-directory: build_unix
+        run: |
+          command -v ${{ matrix.cc }} >/dev/null || exit 0
+          make -j$(nproc)
+
+  # ----------------------------------------------------------------------------
+  # Valgrind memcheck over a small core TCL subset. Noisy + slow, so advisory:
+  # we surface the error/leak summary but do not fail the job on it.
+  # ----------------------------------------------------------------------------
+  valgrind:
+    name: valgrind memcheck (core subset)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Tcl + Valgrind
+        run: sudo apt-get update && sudo apt-get install -y tcl-dev tcl valgrind
+      - name: Configure (debug + test + tcl)
+        working-directory: build_unix
+        run: ../dist/configure --enable-debug --enable-test --with-tcl=/usr/lib/tcl8.6
+      - name: Build
+        working-directory: build_unix
+        run: make -j$(nproc)
+      - name: Valgrind a small core subset
+        working-directory: build_unix
+        run: |
+          cat > /tmp/vg.tcl <<'TCL'
+          source ../test/tcl/test.tcl
+          foreach t {test001 lock001 txn001} {
+            source ../test/tcl/$t.tcl
+            set a {}
+            if {[string match test* $t]} { set a btree }
+            catch {eval $t $a}
+          }
+          TCL
+          # Leak-check the tclsh driver; --error-exitcode=0 keeps it advisory.
+          timeout 6000 valgrind --leak-check=full --show-leak-kinds=definite \
+            --errors-for-leak-kinds=definite --error-exitcode=0 \
+            --log-file=/tmp/vg.log \
+            tclsh /tmp/vg.tcl >/tmp/vg.out 2>&1 || true
+          echo "===== valgrind summary ====="
+          grep -E "ERROR SUMMARY|definitely lost|indirectly lost" /tmp/vg.log || true
+          n=$(grep -cE "definitely lost: [1-9]" /tmp/vg.log || true)
+          echo "::notice title=Valgrind::$n definite-leak line(s) (advisory)"
+
+  # ----------------------------------------------------------------------------
+  # Meson/Autoconf db_config.h feature-flag parity. Meson has no feature
+  # toggles today (always full build), so this diffs the DEFAULT autoconf
+  # db_config.h feature flags against meson's -- catching silent drift between
+  # the two build systems' baselines. Advisory.
+  # ----------------------------------------------------------------------------
+  config-parity:
+    name: meson/autoconf config parity
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Meson + Ninja
+        run: python -m pip install --upgrade meson ninja
+      - name: Autoconf configure (default)
+        working-directory: build_unix
+        run: ../dist/configure >/dev/null
+      - name: Meson configure (default)
+        run: meson setup build-meson >/dev/null
+      - name: Diff key feature flags
+        run: |
+          flags="HAVE_HASH HAVE_HEAP HAVE_QUEUE HAVE_VERIFY HAVE_STATISTICS \
+                 HAVE_REPLICATION HAVE_CRYPTO HAVE_COMPRESSION HAVE_PARTITION \
+                 HAVE_MUTEX_SUPPORT HAVE_SHARED_LATCHES HAVE_DBM \
+                 HAVE_LOG_CHECKSUM HAVE_UPGRADE_SUPPORT"
+          extract() {
+            for f in $flags; do
+              if grep -qE "^#define $f( |\$)" "$1" 2>/dev/null; then
+                echo "$f=1"
+              else
+                echo "$f=0"
+              fi
+            done
+          }
+          extract build_unix/db_config.h > /tmp/auto.flags
+          extract build-meson/db_config.h > /tmp/meson.flags
+          echo "=== autoconf | meson ==="
+          paste -d' ' /tmp/auto.flags /tmp/meson.flags
+          if diff -u /tmp/auto.flags /tmp/meson.flags > /tmp/flags.diff; then
+            echo "::notice title=Config parity::autoconf and meson agree on key feature flags"
+          else
+            echo "::warning title=Config parity::autoconf vs meson feature-flag drift (advisory):"
+            cat /tmp/flags.diff
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ on:
   push:
     branches: [master]
   pull_request:
+  schedule:
+    # Nightly (03:17 UTC) exercises the full TCL suite via the tcl-tests job
+    # below; the heavy scheduled-only jobs live in ci-extended.yml.
+    - cron: '17 3 * * *'
   workflow_dispatch:
     inputs:
       full_tcl:
@@ -123,7 +127,118 @@ jobs:
         run: make -j$(nproc)
 
   # ----------------------------------------------------------------------------
-  # TCL test suite (targeted by default; full suite on manual dispatch).
+  # ThreadSanitizer build + concurrency SMOKE (SSI / lock / mutex TCL subset).
+  # Critical for the ongoing SSI/MVCC/atomics work; best-effort so it informs
+  # without gating. NOT the full suite -- TSan slowdown would time out.
+  # ----------------------------------------------------------------------------
+  tsan:
+    name: clang tsan (concurrency smoke)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      CC: clang
+      # halt_on_error keeps a clean failure signal; second_deadlock_stack aids
+      # triage of any lock-order report from the SSI paths.
+      TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Tcl
+        run: sudo apt-get update && sudo apt-get install -y tcl-dev tcl
+      - name: Configure (tsan + test + tcl)
+        working-directory: build_unix
+        run: >
+          ../dist/configure --enable-debug --enable-test --with-tcl=/usr/lib/tcl8.6
+          "CFLAGS=-fsanitize=thread -fno-omit-frame-pointer -g"
+          "LDFLAGS=-fsanitize=thread"
+      - name: Build
+        working-directory: build_unix
+        run: make -j$(nproc)
+      - name: Concurrency smoke subset
+        working-directory: build_unix
+        run: |
+          cat > /tmp/tsan.tcl <<'TCL'
+          source ../test/tcl/test.tcl
+          foreach t {mut001 lock001 lock002 ssi001 ssi002 ssi009} {
+            source ../test/tcl/$t.tcl
+            if {[catch {eval $t} res]} { puts "FAIL $t: $res"; exit 1 }
+            puts "PASS $t"
+          }
+          TCL
+          # Generous per-test slowdown under TSan, but bounded so a hang fails
+          # loudly instead of eating the whole runner budget.
+          timeout 1800 tclsh /tmp/tsan.tcl 2>&1 | tee /tmp/tsan.out
+          ! grep -qE "^FAIL|data race|WARNING: ThreadSanitizer" /tmp/tsan.out
+
+  # ----------------------------------------------------------------------------
+  # Compiler-warnings gate: -Wall -Wextra with gcc + clang. Advisory
+  # (continue-on-error) and NOT -Werror -- this is pre-2000 K&R-era C and the
+  # autoconf build already suppresses two whole warning classes
+  # (-Wno-deprecated-non-prototype / -Wno-knr-promoted-parameter). We surface
+  # the count so new warnings in touched code are visible without blocking PRs.
+  # ----------------------------------------------------------------------------
+  warnings:
+    name: warnings gate ${{ matrix.cc }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        cc: [gcc, clang]
+    env:
+      CC: ${{ matrix.cc }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure (-Wall -Wextra)
+        working-directory: build_unix
+        run: ../dist/configure --enable-debug "CFLAGS=-Wall -Wextra -g -O1"
+      - name: Build and count warnings
+        working-directory: build_unix
+        run: |
+          set -o pipefail
+          make -j$(nproc) 2>&1 | tee /tmp/build.log
+          n=$(grep -c 'warning:' /tmp/build.log || true)
+          echo "::notice title=Compiler warnings (${{ matrix.cc }})::$n warning line(s)"
+          echo "Top warning kinds:"
+          grep 'warning:' /tmp/build.log \
+            | grep -oE '\-W[a-z0-9-]+' | sort | uniq -c | sort -rn | head -20 || true
+
+  # ----------------------------------------------------------------------------
+  # Mutex backend variants (Linux only). --with-mutex overrides autodetection,
+  # so each entry forces a genuinely different mutex implementation:
+  #   POSIX/pthreads          -> HAVE_MUTEX_PTHREADS (blocking pthread mutexes)
+  #   POSIX/pthreads/library  -> same, linked explicitly against -lpthread
+  #   x86_64/gcc-assembly     -> HAVE_MUTEX_X86_64_GCC_ASSEMBLY (test-and-set)
+  # posix-forced uses --enable-posixmutexes (intra-process pthread fast path).
+  # All names verified against dist/aclocal/mutex.m4 + a local configure run.
+  # ----------------------------------------------------------------------------
+  mutex-backends:
+    name: mutex ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: pthreads,         flags: '--with-mutex=POSIX/pthreads' }
+          - { name: pthreads-library, flags: '--with-mutex=POSIX/pthreads/library' }
+          - { name: tas-x86_64,       flags: '--with-mutex=x86_64/gcc-assembly' }
+          - { name: posix-forced,     flags: '--enable-posixmutexes' }
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure (${{ matrix.name }})
+        working-directory: build_unix
+        run: ../dist/configure --enable-debug ${{ matrix.flags }}
+      - name: Build
+        working-directory: build_unix
+        run: make -j$(nproc)
+      - name: Smoke (build ex_access)
+        working-directory: build_unix
+        run: make ex_access 2>/dev/null || true
+
+  # ----------------------------------------------------------------------------
+  # TCL test suite: targeted subset on every push/PR (fast PR signal); the full
+  # run is manual (workflow_dispatch full_tcl=true). The generous nightly full
+  # suite lives in ci-extended.yml so it never gates PRs.
   # ----------------------------------------------------------------------------
   tcl-tests:
     name: tcl tests (${{ github.event.inputs.full_tcl == 'true' && 'full' || 'targeted' }})


### PR DESCRIPTION
## Summary

Expands the CI matrix to fill release-quality gaps. Experimental/portability
jobs are `continue-on-error: true` (matching the existing best-effort jobs) so
they inform without gating PRs. Heavy/noisy jobs live in a new **scheduled-only**
`ci-extended.yml` so they never appear in the PR checks list.

Touches only `.github/workflows/ci.yml` and adds `.github/workflows/ci-extended.yml`.
Does **not** touch `ocr-review.yml`, `ocr-model-check.yml`, `.github/ocr/`,
`build_windows/`, or AWS.

## Tier 1 (all implemented)

1. **TSan smoke** (`ci.yml` -> `tsan`): clang `-fsanitize=thread -fno-omit-frame-pointer -g`,
   `--enable-debug`, builds + runs a bounded concurrency subset (`mut001`,
   `lock001/002`, `ssi001/002/009`) with a 1800s ceiling. Not the full suite
   (TSan slowdown would time out). `continue-on-error`.
2. **Full TCL suite** (`ci-extended.yml` -> `full-tcl`): `run_std`, 5.5h job
   timeout, only on nightly cron + `workflow_dispatch`. Never blocks PRs. The
   PR-time `tcl-tests` job stays targeted.
3. **Warnings gate** (`ci.yml` -> `warnings`): `-Wall -Wextra`, gcc + clang.
   **Advisory, not `-Werror`** -- this is K&R-era C and the autoconf build
   already suppresses two whole warning classes
   (`-Wno-deprecated-non-prototype`, `-Wno-knr-promoted-parameter`). Surfaces
   the warning count + top kinds instead.
4. **Mutex backends** (`ci.yml` -> `mutex-backends`, Linux only): four forced
   `--with-mutex` implementations (see table).

## Tier 2 (implemented, all in `ci-extended.yml`, advisory)

5. **compiler-versions**: gcc-12/13, clang-15/17 from apt, guarded so a runner
   image missing a package warns + skips instead of failing.
6. **valgrind**: `--leak-check=full` over a small core subset (`test001`,
   `lock001`, `txn001`), `--error-exitcode=0` (advisory, noisy).
7. **config-parity**: diffs key `db_config.h` feature flags between the default
   autoconf and meson builds.

## Verification against configure sources

All configure/mutex names were checked against `dist/aclocal/mutex.m4`,
`dist/aclocal/options.m4`, and confirmed with local `../dist/configure` runs in
the nix dev shell:

| Entry | Verified | Resulting define |
|---|---|---|
| `--with-mutex=POSIX/pthreads` | configures | `HAVE_MUTEX_PTHREADS` |
| `--with-mutex=POSIX/pthreads/library` | configures | `HAVE_MUTEX_PTHREADS` (+ explicit `-lpthread`) |
| `--with-mutex=x86_64/gcc-assembly` | configures + `mut_tas.lo` compiles | `HAVE_MUTEX_X86_64_GCC_ASSEMBLY` (test-and-set) |
| `--enable-posixmutexes` | configures | `HAVE_MUTEX_PTHREADS` |
| `--enable-test --with-tcl=/usr/lib/tcl8.6` | in `configure --help` | -- |
| `--enable-debug` / `--enable-diagnostic` | in `configure --help` | -- |

Note: `--with-mutex` **overrides** autodetection, so the tas entry does *not*
also set `HAVE_MUTEX_HYBRID` (pthread detection is bypassed) -- it exercises the
pure test-and-set path, a genuinely distinct backend.

### config-parity scope note
`meson.build` has **no feature toggles** today (always full build), so a literal
"build the same feature config both ways" is not meaningful. `config-parity`
instead diffs the **default** autoconf vs meson feature flags to catch silent
baseline drift between the two build systems. Adjusted from the original Tier 2
#7 wording for this reason.

### Nothing dropped as non-existent
Every entry maps to a real, verified configure option. No invented flags.

## Validation performed
- `yq` parses both workflow files; all jobs have `runs-on`; no tab indentation.
- Triggers: `ci.yml` = push/PR/schedule/workflow_dispatch; `ci-extended.yml` =
  schedule/workflow_dispatch only.
- Every experimental job carries `continue-on-error: true`.
- Local `../dist/configure` runs confirmed the mutex/test/debug options and that
  the tas backend + `-Wall -Wextra` compile.