### PR TITLE
test(dst): Deterministic Simulation Testing foundation + pilots (RNG, crash/recover, torn)

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -210,6 +210,10 @@ DTRACE_PROVIDER=	$(distdir)/db_provider.d
 ##################################################
 # Object and utility lists.
 ##################################################
+# Deterministic Simulation Testing (DST) sim core -- added to the library's
+# ADDITIONAL_OBJS by configure only when --enable-dst.  Compile rules below.
+SIM_OBJS=	sim_core@o@ sim_os_hooks@o@
+
 BTREE_OBJS=\
 	bt_compare@o@ bt_compress@o@ bt_conv@o@ bt_curadj@o@ bt_cursor@o@ \
 	bt_delete@o@ bt_method@o@ bt_open@o@ bt_put@o@ bt_rec@o@ \
@@ -1476,6 +1480,42 @@ test_mutex@o@: $(srcdir)/mutex/test_mutex.c
 test_mutex: test_mutex@o@ $(DEF_LIB)
 	$(CCLINK) -o $@ $(LDFLAGS) test_mutex@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
 	$(POSTLINK) $@
+
+##################################################
+# Deterministic Simulation Testing (DST) -- test/sim/.
+#
+# The sim core objects (sim_core, sim_os_hooks) are added to the library's
+# ADDITIONAL_OBJS by configure when --enable-dst; their compile rules live
+# here.  `make dst_tests` builds the pilot scenarios; requires --enable-dst.
+# DSTBUG=<n> plants bug n (see test/sim/sim_inject.h) to prove DST catches it.
+##################################################
+sim_core@o@: $(testdir)/sim/sim_core.c
+	$(CC) $(CFLAGS) $(DEPFLAGS) -I$(testdir)/sim $<
+sim_os_hooks@o@: $(testdir)/sim/sim_os_hooks.c
+	$(CC) $(CFLAGS) $(DEPFLAGS) -I$(testdir)/sim $<
+
+DST_CFLAGS= $(CFLAGS) -I$(testdir)/sim $(DSTBUG:%=-DDB_DST_INJECT_BUG=%)
+
+test_sim_rng@o@: $(testdir)/sim/test_sim_rng.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_rng: test_sim_rng@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ $(LDFLAGS) test_sim_rng@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_crash_recover@o@: $(testdir)/sim/test_sim_crash_recover.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_crash_recover: test_sim_crash_recover@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_crash_recover@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_torn@o@: $(testdir)/sim/test_sim_torn.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_torn: test_sim_torn@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ $(LDFLAGS) test_sim_torn@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn
 
 ##################################################
 # Targets for example programs.

--- a/dist/aclocal/options.m4
+++ b/dist/aclocal/options.m4
@@ -195,6 +195,13 @@ if test "$db_cv_diagnostic" = "no"; then
 	AC_MSG_RESULT($db_cv_diagnostic)
 fi
 
+AC_MSG_CHECKING(if --enable-dst option specified)
+AC_ARG_ENABLE(dst,
+	[AS_HELP_STRING([--enable-dst],
+			[Build with Deterministic Simulation Testing (DST) fault-injection hooks.])],
+	[db_cv_dst="$enable_dst"], [db_cv_dst="no"])
+AC_MSG_RESULT($db_cv_dst)
+
 AC_MSG_CHECKING(if --enable-dump185 option specified)
 AC_ARG_ENABLE(dump185,
 	[AS_HELP_STRING([--enable-dump185],

--- a/dist/config.hin
+++ b/dist/config.hin
@@ -120,6 +120,9 @@
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
+/* Define to 1 to build with Deterministic Simulation Testing hooks. */
+#undef HAVE_DST
+
 /* Define to 1 to use dtrace for performance monitoring. */
 #undef HAVE_DTRACE
 

--- a/dist/configure
+++ b/dist/configure
@@ -870,6 +870,7 @@ enable_debug
 enable_debug_rop
 enable_debug_wop
 enable_diagnostic
+enable_dst
 enable_dump185
 enable_java
 enable_mingw
@@ -1574,6 +1575,8 @@ Optional Features:
   --enable-debug_rop      Build a version that logs read operations.
   --enable-debug_wop      Build a version that logs write operations.
   --enable-diagnostic     Build a version with run-time diagnostics.
+  --enable-dst            Build with Deterministic Simulation Testing (DST)
+                          fault-injection hooks.
   --enable-dump185        Build db_dump185(1) to dump 1.85 databases.
   --enable-java           Build Java API.
   --enable-mingw          Build Berkeley DB for MinGW.
@@ -3928,6 +3931,20 @@ if test "$db_cv_diagnostic" = "no"; then
 printf '%s\n' "$db_cv_diagnostic" >&6; }
 fi
 
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking if --enable-dst option specified" >&5
+printf %s "checking if --enable-dst option specified... " >&6; }
+# Check whether --enable-dst was given.
+if test ${enable_dst+y}
+then :
+  enableval=$enable_dst; db_cv_dst="$enable_dst"
+else case e in #(
+  e) db_cv_dst="no" ;;
+esac
+fi
+
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $db_cv_dst" >&5
+printf '%s\n' "$db_cv_dst" >&6; }
+
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking if --enable-dump185 option specified" >&5
 printf %s "checking if --enable-dump185 option specified... " >&6; }
 # Check whether --enable-dump185 was given.
@@ -4525,6 +4542,19 @@ if test "$db_cv_diagnostic" = "yes"; then
 	printf '%s\n' "#define DIAGNOSTIC 1" >>confdefs.h
 
 
+fi
+
+# Deterministic Simulation Testing (DST): compile the sim fault-injection
+# core into the library and enable the guarded __os_* I/O hooks.  Additive
+# and DST-scoped: when off (the default) HAVE_DST is undefined, the hooks
+# vanish, and none of the test/sim sources are built, so a production build
+# is bit-for-bit the stock library.
+if test "$db_cv_dst" = "yes"; then
+	printf '%s\n' "#define HAVE_DST 1" >>confdefs.h
+
+
+	ADDITIONAL_OBJS="$ADDITIONAL_OBJS \$(SIM_OBJS)"
+	CPPFLAGS="$CPPFLAGS -I\$(topdir)/test/sim"
 fi
 if test "$db_cv_debug_rop" = "yes"; then
 	printf '%s\n' "#define DEBUG_ROP 1" >>confdefs.h
@@ -20332,7 +20362,7 @@ else case e in #(
 JAVA_TEST=Test.java
 CLASS_TEST=Test.class
 cat << \EOF > $JAVA_TEST
-/* #line 20335 "configure" */
+/* #line 20365 "configure" */
 public class Test {
 }
 EOF
@@ -20627,7 +20657,7 @@ EOF
 if uudecode$EXEEXT Test.uue; then
         ac_cv_prog_uudecode_base64=yes
 else
-        echo "configure: 20630: uudecode had trouble decoding base 64 file 'Test.uue'" >&5
+        echo "configure: 20660: uudecode had trouble decoding base 64 file 'Test.uue'" >&5
         echo "configure: failed file was:" >&5
         cat Test.uue >&5
         ac_cv_prog_uudecode_base64=no
@@ -20759,7 +20789,7 @@ else case e in #(
 JAVA_TEST=Test.java
 CLASS_TEST=Test.class
 cat << \EOF > $JAVA_TEST
-/* #line 20762 "configure" */
+/* #line 20792 "configure" */
 public class Test {
 }
 EOF
@@ -20796,7 +20826,7 @@ JAVA_TEST=Test.java
 CLASS_TEST=Test.class
 TEST=Test
 cat << \EOF > $JAVA_TEST
-/* [#]line 20799 "configure" */
+/* [#]line 20829 "configure" */
 public class Test {
 public static void main (String args[]) {
         System.exit (0);

--- a/dist/configure.ac
+++ b/dist/configure.ac
@@ -134,6 +134,19 @@ if test "$db_cv_diagnostic" = "yes"; then
 	AH_TEMPLATE(DIAGNOSTIC,
     [Define to 1 if you want a version with run-time diagnostic checking.])
 fi
+
+# Deterministic Simulation Testing (DST): compile the sim fault-injection
+# core into the library and enable the guarded __os_* I/O hooks.  Additive
+# and DST-scoped: when off (the default) HAVE_DST is undefined, the hooks
+# vanish, and none of the test/sim sources are built, so a production build
+# is bit-for-bit the stock library.
+if test "$db_cv_dst" = "yes"; then
+	AC_DEFINE(HAVE_DST)
+	AH_TEMPLATE(HAVE_DST,
+    [Define to 1 to build with Deterministic Simulation Testing hooks.])
+	ADDITIONAL_OBJS="$ADDITIONAL_OBJS \$(SIM_OBJS)"
+	CPPFLAGS="$CPPFLAGS -I\$(topdir)/test/sim"
+fi
 if test "$db_cv_debug_rop" = "yes"; then
 	AC_DEFINE(DEBUG_ROP)
 	AH_TEMPLATE(DEBUG_ROP,

--- a/src/os/os_fsync.c
+++ b/src/os/os_fsync.c
@@ -10,6 +10,10 @@
 
 #include "db_int.h"
 
+#ifdef HAVE_DST
+#include "sim_os.h"			/* DST I/O hooks (--enable-dst only). */
+#endif
+
 #ifdef __hp3000s900
 #define	fsync(fd)	__mpe_fsync(fd)
 
@@ -78,5 +82,14 @@ __os_fsync(env, fhp)
 		__db_syserr(env, ret, DB_STR("0151", "fsync"));
 		ret = __os_posix_err(ret);
 	}
+#ifdef HAVE_DST
+	/*
+	 * DST write-back cache crash model: a successful fsync promotes this
+	 * file's written extent to durable.  A no-op unless a sim run armed
+	 * the model.  (A single relaxed load in the common case.)
+	 */
+	if (ret == 0)
+		__db_sim_io_sync_hook(fhp);
+#endif
 	return (ret);
 }

--- a/src/os/os_rw.c
+++ b/src/os/os_rw.c
@@ -10,6 +10,10 @@
 
 #include "db_int.h"
 
+#ifdef HAVE_DST
+#include "sim_os.h"			/* DST I/O hooks (--enable-dst only). */
+#endif
+
 /*
  * __os_io --
  *	Do an I/O.
@@ -96,6 +100,17 @@ __os_io(env, op, fhp, pgno, pgsize, relative, io_len, buf, niop)
 	}
 	if (nio == (ssize_t)io_len) {
 		*niop = io_len;
+#ifdef HAVE_DST
+		/* DST write-back model: record the written high-water for the
+		 * page-write fast path.  A no-op unless a sim armed it. */
+		if (op == DB_IO_WRITE)
+			__db_sim_io_write_off_hook(fhp,
+			    (u_int64_t)offset + io_len);
+		/* DST corrupt-read: silently flip a byte the checksum must
+		 * catch.  A no-op unless a sim armed the corrupt knob. */
+		else if (op == DB_IO_READ)
+			__db_sim_io_read_hook(buf, io_len);
+#endif
 		return (0);
 	}
 slow:

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -1,0 +1,331 @@
+# libdb Deterministic Simulation Testing (DST) — design & roadmap
+
+> Canonical copy lives at `.agents/dst-design.md` (gitignored, per repo convention); this is the committed PR copy.
+
+Status: **v1 foundation landed** (this branch). Seeded PRNG tree, determinism
+guard, buggify, simulated-I/O fault knobs, the write-back-cache durable-frontier
+crash model, the `__os_*` I/O hooks, a `--enable-dst` build switch that is
+zero-overhead when off, and three runnable pilot scenarios (RNG, crash+recover,
+torn/corrupt-read). Modeled on FoundationDB / TigerBeetle and the xtc project's
+DST (`/home/gburd/ws/xtc`).
+
+This document is the PLAN. It records what shipped, the honest architectural
+gap vs xtc, and the full scenario catalog to grow into.
+
+---
+
+## 0. Why libdb DST looks different from xtc DST
+
+xtc is a **single-process cooperative-fiber actor runtime**: its DST can run N
+"loops" as N fibers on one thread under a seed-determined interleaving, with a
+virtual clock and a fully deterministic scheduler. Every source of
+nondeterminism (time, RNG, I/O completion order, message delivery) funnels
+through one seam the scheduler owns, so a seed reproduces the *entire* run
+bit-for-bit including thread interleaving.
+
+**libdb cannot get that for free.** libdb is:
+
+- **multi-process** — multiple processes attach the same environment via
+  shared `mmap` regions (the buffer pool, lock table, log region, txn region);
+- **real-threaded with real fsync durability** — durability is `pwrite` +
+  `fsync` to real files, and correctness depends on genuine OS scheduling and
+  memory visibility across processes.
+
+A single-threaded deterministic scheduler does **not** directly apply: there is
+no one seam that owns cross-process interleaving. Pretending otherwise would be
+coverage theater.
+
+So libdb DST is **phased**, and v1 deliberately targets the axis that *does*
+map cleanly onto BDB's architecture:
+
+- **v1 (this branch): deterministic FAULT-INJECTION + CRASH/RECOVERY.**
+  The seeds control *what faults happen and when* (I/O latency, EIO, short
+  transfer, torn write, corrupt read, ENOSPC, and the ack-before-fsync
+  write-back crash model), plus a deterministic workload (keys/values drawn
+  from a seeded stream). We sidestep cross-process scheduling nondeterminism by
+  running the pilots **single-process** (and, where a scenario needs a cold
+  cache, `DB_PRIVATE` so the buffer pool is process-local). This is exactly the
+  FoundationDB "simulated disk + crash" discipline, and it is where the
+  highest-value storage-engine bugs live (lost commits, torn logs, silent page
+  corruption).
+
+- **v2 (later): deterministic scheduler / multi-process.** A genuine
+  deterministic interleaving of multiple BDB processes/threads requires either
+  (a) a PCT/coarse-interleaving controller that pins scheduling at BDB's own
+  yield/lock seams, or (b) a record-replay layer over the shared-region
+  accesses. Both are large; the `DB_SIM_RNG_SCHED` stream and the virtual-clock
+  seam are reserved now so v1 draw ordering does not shift when v2 lands.
+
+---
+
+## 1. Architecture (what shipped in v1)
+
+All of it lives in `test/sim/` and is compiled into the library **only** under
+`--enable-dst` (`HAVE_DST`). With DST off, none of these symbols exist and the
+`__os_*` hooks compile to the stock code path — verified: the OFF library has
+zero `__db_sim_*` symbols and builds with no undefined references.
+
+### 1.1 Seeded PRNG tree (`sim_rng.c/.h`, in `sim_core.c`)
+
+Per-stream **splitmix64**, adapted from xtc. One root seed splits into
+independent sub-streams via the golden-ratio finalizer, so a draw added at one
+decision site never perturbs another site's sequence (stable replay under code
+change — the FoundationDB discipline).
+
+Streams (`enum db_sim_stream`):
+
+| Stream | Use |
+|---|---|
+| `DB_SIM_RNG_IO` | simulated I/O latency, fault/torn/corrupt/ENOSPC toggles |
+| `DB_SIM_RNG_FAULT` | generic fault-injection toggles |
+| `DB_SIM_RNG_BUGGIFY` | buggify per-run activation coins |
+| `DB_SIM_RNG_APP` | application/test workload draws |
+| `DB_SIM_RNG_SCHED` | **reserved** for the v2 deterministic scheduler |
+
+`SCHED` is reserved (not yet drawn) so adding the scheduler later does not move
+v1 seeds. `__db_sim_rng(s)` returns 0 when sim is inactive; callers gate on
+`__db_sim_active()` (a single relaxed atomic load).
+
+### 1.2 Determinism guard
+
+`__db_sim_nondeterminism(what)`: a sim-reachable primitive that would break
+seed replay (a real clock read, an unseeded `rand()`, a raw pid) calls this.
+Outside a sim run it is a no-op; inside a run it records the violation and, in
+**strict mode (default)**, aborts naming the source. `__db_sim_strict(0)`
+switches to count-only for a diagnostic sweep. `__db_sim_nondeterminism_count()`
+lets a harness assert 0 to *prove* a run was fully deterministic.
+
+> v1 does not yet *plant* guard calls at BDB's nondeterministic primitives
+> (`__os_clock`, `__os_unique_id`, `__os_id`). That wiring is a small,
+> mechanical follow-up (§4, item G) and is where the guard earns its keep.
+
+### 1.3 Buggify (per-run cached coin)
+
+`DB_SIM_BUGGIFY("name")`: a named point in real library code that, under sim,
+takes a legal-but-pessimal path. Unlike a per-call fault, a buggify point is a
+coin flipped **once per run per site**, cached, so all reaches of a name agree
+and the run replays. Drawn from the dedicated `BUGGIFY` stream so enabling it
+never perturbs the IO/FAULT streams. Compiles to constant 0 when DST is off.
+
+### 1.4 Simulated I/O faults + the write-back crash model
+
+Knobs the `__os_*` hooks consult (all off by default; a no-op unless a sim run
+arms them; all seeded on the IO stream so enabling them never shifts the
+schedule):
+
+- **latency** — `__db_sim_io_latency()` (v1 records intent; a synchronous
+  single-process pilot does not yet *sleep*, since there is no scheduler to
+  reorder against — this becomes load-bearing in v2 with concurrent I/O).
+- **short transfer / EIO** — `__db_sim_io_should_fault()`.
+- **ENOSPC** — `__db_sim_io_enospc()`: a whole write fails, nothing persists.
+- **torn write** — `__db_sim_io_torn_prefix(len)`: persist a seeded strict
+  prefix but report full success (latent bad tail a checksum must catch).
+- **corrupt read** — `__db_sim_io_flip_byte(len)`: flip one returned byte
+  (wired into `__os_io` read path via `__db_sim_io_read_hook`).
+- **write-back cache crash model** — the ack-before-fsync durability catcher,
+  below.
+
+**The write-back model (THE key to catching ack-before-fsync bugs).** The sim
+writes to a *real* file, so bytes reach the file on `pwrite` regardless of
+`fsync` — which means a naive crash test cannot catch a writer that ACKs a
+commit without fsyncing it. The model fixes this honestly:
+
+- a write records the **written high-water** offset for the file
+  (`__db_sim_io_wb_wrote`);
+- `fsync`/`fdatasync` promotes written → **durable** (`__db_sim_io_wb_synced`);
+- a crash loses everything past the last fsync;
+- a recovery test asks `__db_sim_io_durable_end(key)` for the true post-crash
+  durable frontier to truncate to, instead of trusting the writer.
+
+Keyed by a **stable FNV-1a hash of the file name** (not the fd), so the
+frontier tracks a *logical* file across libdb's frequent close/reopen — exactly
+how a real disk behaves.
+
+### 1.5 The `__os_*` I/O seam (where the hooks attach)
+
+BDB funnels durability through a tiny OS layer, which is the clean seam:
+
+| Function (file) | Hook added (under `#ifdef HAVE_DST`) | Purpose |
+|---|---|---|
+| `__os_io` write fast path (`os_rw.c`) | `__db_sim_io_write_off_hook(fhp, off+len)` | record written high-water (covers WAL + page writes) |
+| `__os_io` read fast path (`os_rw.c`) | `__db_sim_io_read_hook(buf, len)` | corrupt-read bit flip |
+| `__os_fsync` (`os_fsync.c`) | `__db_sim_io_sync_hook(fhp)` | promote written → durable |
+
+The WAL write path (`__log_fill`/`__log_write` → `__os_io(DB_IO_WRITE, lfhp,
+0,0, w_off, len, …)`) and the WAL fsync (`__log_flush_int` → `__os_fsync(env,
+lfhp)`) both route through these exact hooks — so the write-back model tracks
+the log's durable frontier precisely, which is the ack-before-fsync seam.
+
+Each hook is a single `__db_sim_active()` relaxed load in the common no-sim
+case, and vanishes entirely when `HAVE_DST` is undefined.
+
+> **Remaining integration (documented, not yet wired):** the slow/`__os_physwrite`
+> path (non-`pread` platforms, `j_write` hook, `HAVE_FILESYSTEM_NOTZERO`) is not
+> hooked — on Linux with pread/pwrite the fast path always wins, so v1 is fully
+> covered there. `os_aio*` (the newer async buffer-pool I/O) is likewise not yet
+> hooked; the buffer pool's *synchronous* `__os_io` path (`mp_bh.c`) is, which is
+> what the pilots exercise. Torn-write and latency knobs exist but are only
+> consulted by the corrupt-read hook so far; wiring torn-write into the write
+> hook and latency into a v2 async path are §4 items.
+
+### 1.6 The determinism-proof harness
+
+`test_sim_rng` runs a workload twice with the same seed and asserts the byte
+sequences are identical, asserts different seeds diverge, asserts stream
+independence (interleaving one stream's draws does not shift another's), and
+asserts the determinism-guard count behaves. `test_sim_crash_recover` re-derives
+the expected committed set from the seed after recovery — a mismatch across a
+replay of the same seed would fail.
+
+---
+
+## 2. Build integration
+
+- **Autoconf (primary; what the validation recipe uses).**
+  `--enable-dst` → `db_cv_dst` (`dist/aclocal/options.m4`) → in
+  `dist/configure.ac`: `AC_DEFINE(HAVE_DST)`, append `$(SIM_OBJS)` to
+  `ADDITIONAL_OBJS`, and add `-I$(topdir)/test/sim` to `CPPFLAGS`.
+  `dist/Makefile.in` defines `SIM_OBJS = sim_core@o@ sim_os_hooks@o@`, their
+  compile rules, and a `dst_tests` target (`test_sim_rng`,
+  `test_sim_crash_recover`, `test_sim_torn`). `DSTBUG=<n>` plants bug n.
+  All additions are additive and DST-scoped so they merge cleanly alongside the
+  concurrent PBT work.
+
+- **Meson (TODO, documented).** The PBT agent owns `meson.build` /
+  `meson_options.txt`. To avoid clobbering, v1 does **not** wire DST into meson.
+  The follow-up is one option + one guarded subdir:
+  ```
+  # meson_options.txt
+  option('dst', type: 'boolean', value: false,
+    description: 'Build with Deterministic Simulation Testing hooks.')
+  # meson.build (near the hegel subdir block)
+  if get_option('dst')
+    add_project_arguments('-DHAVE_DST', language: 'c')
+    subdir('test/sim')   # test/sim/meson.build fully owned by DST
+  endif
+  ```
+  and a `test/sim/meson.build` that adds `sim_core.c`/`sim_os_hooks.c` to the
+  lib sources and declares the three pilot executables. The `#ifdef HAVE_DST`
+  guards in `os_rw.c`/`os_fsync.c` already work with either build system.
+
+---
+
+## 3. Pilot scenarios (runnable now)
+
+| Pilot | Proves | Result |
+|---|---|---|
+| `test_sim_rng` | seeded PRNG determinism, seed-sensitivity, stream independence, guard | PASS |
+| `test_sim_crash_recover` | **capstone**: N durable txns survive a mid-txn crash; uncommitted txn does not; DB verifies clean **after recovery** | PASS (64 txns; deterministic across seeds; replays) |
+| `test_sim_torn` | corrupt reads are caught by DB_CHKSUM or invisible — **never silently wrong** | PASS (e.g. 297 correct / 103 detected / 0 silent-bad) |
+
+**Recovery-before-verify discipline** (from
+`.agents/concurrent-btree-corruption.md`): a crashed txn env verified *without*
+recovery falsely looks corrupt. `test_sim_crash_recover` **always** runs
+`DB_RECOVER` before `db->verify`.
+
+**Planted-bug harness** (`sim_inject.h`, `DB_DST_INJECT_BUG=<n>`): the crash
+pilot has a `NODURABLE` hook (bug 1) that "acks" a commit with `DB_TXN_NOSYNC`
+and asserts it must *not* survive the crash — the scaffold for the
+FoundationDB-grade "DST finds real bugs within K seeds" proof. v1 wires the hook
+and the harness; planting the bug *inside* `__log_flush` (so the write-back
+model's durable frontier truly drops the un-fsynced tail) is the immediate next
+step (§4, item A) that turns this into a hard catch.
+
+---
+
+## 4. Immediate next steps (ordered)
+
+- **A. Real ack-before-fsync catch.** Truncate the log to
+  `__db_sim_io_durable_end(logkey)` before `DB_RECOVER` in the crash pilot, and
+  add a `DB_SIM_BUGGIFY("log.flush.skip_fsync")` in `__log_flush_int` that skips
+  the fsync while still returning success. Then bug-build must lose the "acked"
+  commit → capstone fires. This is the headline DST proof.
+- **B. Torn-write into the write hook.** Consult `__db_sim_io_torn_prefix` in
+  the write path and add a torn-log scenario (recovery must stop at the torn
+  record, not misparse past it).
+- **C. Disk-full scenario.** Arm `__db_sim_io_enospc` mid-workload; assert
+  graceful degradation (clean error, no corruption, recoverable).
+- **D. Stale-read model.** Port xtc's superseded-write ring
+  (`__xtc_sim_io_stale_*`) to catch recovery/cache code that skips an LSN check.
+- **E. Seed sweep driver.** `scripts/dst-sweep.sh SEED_LO SEED_HI` running each
+  scenario across a seed range, plus `scripts/dst-bug-inject.sh` asserting each
+  planted bug is caught within K seeds (the bug-detection-latency yardstick).
+- **F. Meson wiring** (§2).
+- **G. Determinism-guard planting** at `__os_clock`, `__os_unique_id`,
+  `__os_id`, so a regression that reads wall-clock time on a sim path aborts.
+- **H. `os_aio*` + `__os_physwrite` hooks** for full I/O-path coverage.
+
+---
+
+## 5. Full scenario catalog (grow into FoundationDB-grade coverage)
+
+Marked **v1** (mappable now on the single-process fault/crash axis),
+**v1.x** (small extension of v1), or **v2** (needs the deterministic
+scheduler / multi-process). ~34 scenarios across BDB subsystems.
+
+### Access methods (workload correctness under faults)
+1. **btree put/get/del** round-trip under corrupt-read — *v1* (shipped: torn).
+2. **btree split/merge** churn across a crash + recovery — *v1*.
+3. **hash** insert/lookup/delete round-trip under faults — *v1.x*.
+4. **recno / queue** append + consume across a crash — *v1.x*.
+5. **secondary index / join** consistency after recovery — *v1.x*.
+6. **large / overflow records** torn-write + checksum detection — *v1.x*.
+7. **duplicate keys** (sorted/unsorted) survive crash+recover — *v1.x*.
+
+### Log / WAL
+8. **commit durability**: every fsync-acked commit survives a crash — *v1* (capstone).
+9. **ack-before-fsync bug caught** via the write-back frontier — *v1* (item A).
+10. **torn log write**: recovery stops cleanly at the torn record — *v1.x* (item B).
+11. **log record checksum** mismatch detected on replay — *v1.x*.
+12. **log file rollover** crash at the boundary, clean recovery — *v1.x*.
+13. **in-memory log** (`DB_LOG_IN_MEMORY`) crash semantics — *v1.x*.
+
+### Recovery
+14. **crash at every phase**: pre-commit, post-log-pre-fsync, post-fsync,
+    mid-checkpoint, mid-recovery — parameterized by a seeded crash step — *v1*.
+15. **catastrophic (fatal) recovery** from an archived log set — *v1.x*.
+16. **recovery idempotency**: recover twice, identical state hash — *v1*.
+17. **partial page write** at crash; recovery repairs via WAL — *v1*.
+
+### Checkpoint
+18. **crash mid-checkpoint**; recovery from the prior checkpoint — *v1*.
+19. **checkpoint + ENOSPC**: checkpoint fails cleanly, txns still durable — *v1.x* (item C).
+
+### Buffer pool (mpool)
+20. **eviction under memory pressure** + corrupt-read on refetch — *v1* (torn uses DB_PRIVATE small cache).
+21. **dirty-page flush torn write** caught by page checksum — *v1.x* (item B).
+22. **MVCC version-chain fget** returns the correct snapshot under faults — *v1.x*.
+23. **trickle / sync** interaction with a crash — *v2* (needs concurrency).
+
+### Lock / deadlock
+24. **deadlock detection** picks a victim deterministically (seeded) — *v2*.
+25. **lock timeout** under seeded clock skew — *v2* (needs virtual clock).
+26. **lock-table region exhaustion** graceful degradation — *v1.x*.
+
+### Transactions
+27. **commit/abort mix**: aborted txns leave no trace after recovery — *v1*.
+28. **nested / child txn** commit+abort correctness across crash — *v1.x*.
+29. **prepare/2PC**: prepared txns recover to the resolvable state — *v1.x*.
+30. **cursor stability** across abort — *v1.x*.
+
+### MVCC / SSI (roadmap feature #0)
+31. **snapshot isolation visibility** under faults — *v1.x*.
+32. **SSI rw-conflict abort** deterministically reproduced — *v2* (concurrency).
+33. **SIREAD marker reclaim** correctness across crash+recover — *v1.x*.
+
+### Multi-process / scheduler (the v2 frontier)
+34. **concurrent writers** deterministic interleaving + crash — *v2*.
+35. **network partition / replication** role change (repmgr) — *v2* (xtc models
+    partition at the message seam; BDB's real socket transport needs a v2 shim).
+
+---
+
+## 6. References
+
+- xtc DST core: `/home/gburd/ws/xtc/src/evt/sim.c`,
+  `src/io/io_sim.c`, `src/inc/xtc_sim.h`, `src/inc/xtc_dst_inject.h`,
+  `test/sim/test_sim_*.c`.
+- BDB OS seam: `src/os/os_rw.c`, `os_fsync.c`, `src/dbinc/os.h`,
+  `src/dbinc_auto/os_ext.h`.
+- Recovery-before-verify lesson: `.agents/concurrent-btree-corruption.md`.
+- FoundationDB simulation testing; TigerBeetle VOPR.

--- a/test/sim/README.md
+++ b/test/sim/README.md
@@ -1,0 +1,113 @@
+# test/sim — Deterministic Simulation Testing (DST) for libdb
+
+Seed-driven, replayable fault-injection and crash/recovery testing, modeled on
+FoundationDB / TigerBeetle and the xtc project's DST. See
+See [`DESIGN.md`](DESIGN.md) (or the local canonical copy `.agents/dst-design.md`) for the full architecture
+and scenario catalog.
+
+**v1 scope:** deterministic fault-injection + crash/recovery on the single-process
+axis. The full deterministic multi-process scheduler is v2 (design doc §0).
+
+## Layout
+
+| File | Role |
+|---|---|
+| `sim_rng.h` | seeded per-stream PRNG + activation/guard API |
+| `sim_fault.h` | fault toggles, buggify, I/O fault knobs, write-back model API |
+| `sim_os.h` | declarations of the `__os_*` I/O hooks (included by the os layer) |
+| `sim_inject.h` | planted-bug ids (`DB_DST_INJECT_BUG`) — the bug-detection yardstick |
+| `sim_core.c` | the DST core (PRNG, guard, buggify, I/O fault knobs, write-back crash model) — linked into libdb under `--enable-dst` |
+| `sim_os_hooks.c` | bridge from `__os_*` (os_rw.c, os_fsync.c) to the core — linked into libdb under `--enable-dst` |
+| `test_sim_rng.c` | pilot: PRNG determinism / seed-sensitivity / stream independence / guard |
+| `test_sim_crash_recover.c` | **capstone** pilot: durable txns survive a crash; recovery is clean |
+| `test_sim_torn.c` | pilot: corrupt reads are caught by checksum or invisible — never silently wrong |
+
+## Build
+
+DST is a compile-time option. **Off by default** and **zero-overhead when off**:
+with `--enable-dst` absent, `HAVE_DST` is undefined, the `__os_*` hooks compile
+to the stock code path, and none of `sim_core.c`/`sim_os_hooks.c` are linked
+(verified: the OFF library exports no `__db_sim_*` symbols).
+
+From the nix dev shell:
+
+```sh
+cd /home/gburd/ws/libdb
+nix develop --command bash -c '
+  cd build_unix &&
+  ../dist/configure --enable-debug --enable-dst &&
+  make -j4 &&           # builds libdb with the DST core
+  make dst_tests'       # builds the three pilot executables
+```
+
+Run the pilots (they link the shared lib, so set `LD_LIBRARY_PATH`):
+
+```sh
+cd build_unix
+LD_LIBRARY_PATH=.libs ./test_sim_rng
+LD_LIBRARY_PATH=.libs ./test_sim_crash_recover
+LD_LIBRARY_PATH=.libs ./test_sim_torn
+```
+
+Expected:
+
+```
+test_sim_rng: PASS (determinism, seed-sensitivity, stream-independence, guard)
+test_sim_crash_recover: PASS -- 64 committed txns survived, uncommitted did not, DB verifies clean (seed 0xdb5eed)
+test_sim_torn: PASS -- no silent corruption; every read was correct or cleanly rejected
+```
+
+## Replaying a failing seed
+
+Every scenario takes an optional seed argument (default is a fixed constant).
+When a run fails, it prints its seed; rerun with that seed to reproduce the
+**exact** run — same workload, same fault schedule:
+
+```sh
+LD_LIBRARY_PATH=.libs ./test_sim_crash_recover 0xBEEF
+LD_LIBRARY_PATH=.libs ./test_sim_torn 0x701234
+```
+
+Determinism is proven directly by `test_sim_rng` (same seed → identical draws)
+and by the crash pilot re-deriving its expected committed set from the seed
+after recovery.
+
+## Proving DST catches real bugs (planted-bug harness)
+
+`sim_inject.h` defines planted-bug ids. A dedicated build activates exactly one:
+
+```sh
+cd build_unix
+make test_sim_crash_recover DSTBUG=1   # plant bug 1 (NODURABLE)
+LD_LIBRARY_PATH=.libs ./test_sim_crash_recover
+```
+
+The bug build is *expected to fail* (an invariant fires) — that failure is the
+"DST caught it" signal. A planted bug the sweep does **not** catch is a hole in
+the DST coverage of that safety property. v1 ships the harness and the
+`NODURABLE` hook; wiring the fsync-skip into `__log_flush` itself (so the
+write-back durable frontier truly drops the un-fsynced tail) is the immediate
+next step — see design doc §4 item A.
+
+## Determinism guarantees
+
+- **Per-stream PRNG isolation.** Each decision site (IO, FAULT, BUGGIFY, APP)
+  draws from its own splitmix64 stream, so adding a draw at one site never
+  shifts another site's sequence. Replays survive code change.
+- **Determinism guard.** `__db_sim_nondeterminism()` aborts (strict mode) if a
+  sim-reachable path reads a real clock / unseeded RNG / raw pid. A harness can
+  assert `__db_sim_nondeterminism_count() == 0` to prove a run was fully
+  deterministic. (v1 ships the guard; planting calls at BDB's clock/id
+  primitives is a follow-up — design doc §4 item G.)
+- **Fault config never perturbs the schedule.** All fault knobs draw on the IO
+  stream, so enabling/disabling faults does not change what the APP workload
+  produces — the same workload replays regardless of fault config.
+
+## Housekeeping
+
+- Scenarios create scratch env dirs (`TESTDIR_sim_*`) under the working dir and
+  remove them at start. If a run is killed mid-way, remove leftovers with
+  `trash TESTDIR_sim_*` (this repo blocks `rm -rf`).
+- **Always recover before verifying** a crashed transactional env — verifying
+  an unrecovered crash falsely looks like corruption (see
+  `.agents/concurrent-btree-corruption.md`). The crash pilot does this.

--- a/test/sim/meson.build
+++ b/test/sim/meson.build
@@ -1,0 +1,38 @@
+# test/sim/meson.build -- Deterministic Simulation Testing (DST) build wiring.
+#
+# This subdir is fully owned by the DST work.  It is NOT yet entered by the
+# top-level meson.build (to avoid clobbering the concurrently-edited
+# meson.build / meson_options.txt owned by the PBT effort).  To enable the
+# meson DST build, a follow-up adds exactly two things:
+#
+#   # meson_options.txt
+#   option('dst', type: 'boolean', value: false,
+#     description: 'Build with Deterministic Simulation Testing hooks.')
+#
+#   # meson.build (near the `hegel` subdir block)
+#   if get_option('dst')
+#     add_project_arguments('-DHAVE_DST', language: 'c')
+#     libdb_sources += files(
+#       'test/sim/sim_core.c', 'test/sim/sim_os_hooks.c')
+#     # test/sim must be on the include path for the __os_* hooks:
+#     #   add_project_arguments('-I' + meson.project_source_root() / 'test/sim', language: 'c')
+#     subdir('test/sim')
+#   endif
+#
+# The `#ifdef HAVE_DST` guards in src/os/os_rw.c and src/os/os_fsync.c work
+# unchanged under meson once -DHAVE_DST is set and test/sim is on the include
+# path.  The autoconf build (dist/configure --enable-dst) is the primary,
+# fully-working path today.
+
+sim_inc = include_directories('.')
+
+# The three pilot scenarios.  They link the shared libdb (built with the DST
+# core when -Ddst is set) and the DST include dir.
+foreach t : ['test_sim_rng', 'test_sim_crash_recover', 'test_sim_torn']
+  exe = executable(t, t + '.c',
+    include_directories : [sim_inc, libdb_inc],
+    link_with : libdb_shared,
+    build_by_default : false,
+    install : false)
+  test('dst_' + t, exe, timeout : 120)
+endforeach

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -1,0 +1,496 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_core.c --
+ *	The DST core: seeded per-stream PRNG tree, determinism guard,
+ *	seeded fault toggles, buggify, and the simulated-I/O fault knobs
+ *	(latency / EIO / short transfer / torn write / corrupt read /
+ *	ENOSPC + the write-back-cache durable-frontier crash model).
+ *
+ *	Adapted from the xtc DST core (src/evt/sim.c, src/io/io_sim.c),
+ *	reduced to the single-process libdb fault+crash axis and rewritten
+ *	to libdb conventions.  All state is process-global; hot-path
+ *	accessors are relaxed atomic loads so a NON-active sim run (and,
+ *	when HAVE_DST is off, the whole absence of this TU) costs nothing.
+ *
+ *	This whole file is compiled into the library ONLY when configured
+ *	--enable-dst (guarded by HAVE_DST in Makefile).  When off, none of
+ *	these symbols exist and the __os_* hooks (guarded by the same
+ *	macro) compile to the stock code path.
+ */
+
+#include "db_config.h"
+
+#include "db_int.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ---- activation + PRNG tree ---- */
+
+static _Atomic int g_sim_active;
+static uint64_t    g_sim_seed;
+static uint64_t    g_sim_stream[DB_SIM_RNG_NSTREAMS];
+
+/* splitmix64: the standard finalizer used to derive independent streams
+ * from a seed.  0x9E3779B97F4A7C15 is the golden-ratio increment. */
+static uint64_t
+splitmix64(sp)
+	uint64_t *sp;
+{
+	uint64_t z = (*sp += 0x9E3779B97F4A7C15ull);
+	z = (z ^ (z >> 30)) * 0xBF58476D1CE4E5B9ull;
+	z = (z ^ (z >> 27)) * 0x94D049BB133111EBull;
+	return (z ^ (z >> 31));
+}
+
+int
+__db_sim_active()
+{
+	return (atomic_load_explicit(&g_sim_active, memory_order_relaxed));
+}
+
+uint64_t
+__db_sim_seed()
+{
+	return (g_sim_seed);
+}
+
+/* ---- determinism guard ---- */
+
+static _Atomic int g_nondet_count;
+static _Atomic int g_nondet_strict = 1;   /* abort on violation by default */
+
+void
+__db_sim_nondeterminism(what)
+	const char *what;
+{
+	if (!__db_sim_active())
+		return;
+	atomic_fetch_add_explicit(&g_nondet_count, 1, memory_order_relaxed);
+	if (atomic_load_explicit(&g_nondet_strict, memory_order_relaxed)) {
+		fprintf(stderr, "libdb DST determinism violation: %s called on "
+		    "a sim-reachable path (breaks seed replay)\n",
+		    what != NULL ? what : "(unknown)");
+		abort();
+	}
+}
+
+void
+__db_sim_strict(on)
+	int on;
+{
+	atomic_store_explicit(&g_nondet_strict, on ? 1 : 0,
+	    memory_order_relaxed);
+}
+
+int
+__db_sim_nondeterminism_count()
+{
+	return (atomic_load_explicit(&g_nondet_count, memory_order_relaxed));
+}
+
+/* ---- io fault knobs (defined early: deactivate resets them) ---- */
+
+static _Atomic int     g_io_faults_on;
+static _Atomic int64_t g_io_lat_min_ns;
+static _Atomic int64_t g_io_lat_max_ns;
+static _Atomic int     g_io_fault_pct;    /* per-1000 short/EIO probability */
+static _Atomic int     g_io_enospc_pct;   /* per-1000 write ENOSPC */
+static _Atomic int     g_io_corrupt_pct;  /* per-1000 torn-write/corrupt-read */
+static _Atomic int     g_io_corrupt_on;
+
+void
+__db_sim_activate(seed)
+	uint64_t seed;
+{
+	int i;
+	uint64_t s = seed != 0 ? seed : 0x9E3779B97F4A7C15ull;
+
+	g_sim_seed = s;
+	/* Derive each stream's state from the root seed so the streams are
+	 * independent yet fully determined by the seed. */
+	for (i = 0; i < DB_SIM_RNG_NSTREAMS; i++) {
+		uint64_t t = s + (uint64_t)(i + 1) * 0x9E3779B97F4A7C15ull;
+		g_sim_stream[i] = splitmix64(&t);
+	}
+	atomic_store_explicit(&g_nondet_count, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_sim_active, 1, memory_order_release);
+}
+
+void
+__db_sim_deactivate()
+{
+	atomic_store_explicit(&g_sim_active, 0, memory_order_release);
+	/* Reset io fault knobs so one run's config never leaks into the
+	 * next in-process run. */
+	atomic_store_explicit(&g_io_faults_on, 0, memory_order_release);
+	atomic_store_explicit(&g_io_fault_pct, 0, memory_order_release);
+	atomic_store_explicit(&g_io_enospc_pct, 0, memory_order_release);
+	atomic_store_explicit(&g_io_corrupt_pct, 0, memory_order_release);
+	atomic_store_explicit(&g_io_corrupt_on, 0, memory_order_release);
+	__db_sim_wb_enable(0);
+}
+
+uint64_t
+__db_sim_rng(s)
+	int s;
+{
+	if (!__db_sim_active())
+		return (0);
+	if (s < 0 || s >= DB_SIM_RNG_NSTREAMS)
+		s = DB_SIM_RNG_APP;
+	return (splitmix64(&g_sim_stream[s]));
+}
+
+uint64_t
+__db_sim_rng_range(s, bound)
+	int s;
+	uint64_t bound;
+{
+	if (bound == 0)
+		return (0);
+	/* Modulo bias over a 64-bit draw with a small bound is negligible
+	 * and -- crucially -- deterministic. */
+	return (__db_sim_rng(s) % bound);
+}
+
+/* ---- seeded fault toggle ---- */
+
+int
+__db_sim_fault(pct_per_1000)
+	unsigned pct_per_1000;
+{
+	if (!__db_sim_active())
+		return (0);
+	if (pct_per_1000 == 0)
+		return (0);
+	if (pct_per_1000 >= 1000)
+		return (1);
+	return (__db_sim_rng_range(DB_SIM_RNG_FAULT, 1000) < pct_per_1000);
+}
+
+/* ---- buggify (per-run cached coin) ---- */
+
+#define DB_SIM_BUG_MAX 64
+static char        g_bug_name[DB_SIM_BUG_MAX][48];
+static signed char g_bug_decided[DB_SIM_BUG_MAX];   /* 0/1 */
+static _Atomic int g_bug_n;
+static _Atomic int g_bug_on;
+static _Atomic int g_bug_pct;
+
+void
+__db_sim_buggify_enable(pct_per_1000)
+	unsigned pct_per_1000;
+{
+	atomic_store_explicit(&g_bug_n, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_bug_pct, (int)pct_per_1000,
+	    memory_order_relaxed);
+	atomic_store_explicit(&g_bug_on, 1, memory_order_release);
+}
+
+void
+__db_sim_buggify_disable()
+{
+	atomic_store_explicit(&g_bug_on, 0, memory_order_release);
+	atomic_store_explicit(&g_bug_n, 0, memory_order_relaxed);
+}
+
+/*
+ * Once-per-run decision for buggify point `name`: 1 to take the pessimal
+ * path, 0 otherwise.  Decided on first reach (seeded coin from the
+ * BUGGIFY stream) and cached, so every reach of the same name in a run
+ * agrees and the whole run replays.
+ *
+ * ponytail: single global array + linear scan (bounded 64 names, called
+ * from tests not a hot library path), a hash map if the site count grows.
+ */
+int
+__db_sim_buggify(name)
+	const char *name;
+{
+	int i, n, pct, decision;
+
+	if (name == NULL)
+		return (0);
+	if (!atomic_load_explicit(&g_bug_on, memory_order_acquire))
+		return (0);
+	if (!__db_sim_active())
+		return (0);
+
+	n = atomic_load_explicit(&g_bug_n, memory_order_relaxed);
+	for (i = 0; i < n; i++)
+		if (strncmp(g_bug_name[i], name, sizeof(g_bug_name[0])) == 0)
+			return (g_bug_decided[i]);
+
+	if (n >= DB_SIM_BUG_MAX)
+		return (0);                 /* table full: no buggify */
+	pct = atomic_load_explicit(&g_bug_pct, memory_order_relaxed);
+	if (pct == 0)
+		decision = 0;
+	else if (pct >= 1000)
+		decision = 1;
+	else
+		decision =
+		    (int)__db_sim_rng_range(DB_SIM_RNG_BUGGIFY, 1000) < pct;
+	(void)strncpy(g_bug_name[n], name, sizeof(g_bug_name[0]) - 1);
+	g_bug_name[n][sizeof(g_bug_name[0]) - 1] = '\0';
+	g_bug_decided[n] = (signed char)decision;
+	atomic_store_explicit(&g_bug_n, n + 1, memory_order_relaxed);
+	return (decision);
+}
+
+/* ---- simulated I/O faults ---- */
+
+void
+__db_sim_io_faults_enable(lat_min_ns, lat_max_ns, fault_pct_per_1000)
+	int64_t lat_min_ns, lat_max_ns;
+	unsigned fault_pct_per_1000;
+{
+	if (lat_min_ns < 0)
+		lat_min_ns = 0;
+	if (lat_max_ns < lat_min_ns)
+		lat_max_ns = lat_min_ns;
+	atomic_store_explicit(&g_io_lat_min_ns, lat_min_ns,
+	    memory_order_relaxed);
+	atomic_store_explicit(&g_io_lat_max_ns, lat_max_ns,
+	    memory_order_relaxed);
+	atomic_store_explicit(&g_io_fault_pct, (int)fault_pct_per_1000,
+	    memory_order_relaxed);
+	atomic_store_explicit(&g_io_faults_on, 1, memory_order_release);
+}
+
+void
+__db_sim_io_faults_disable()
+{
+	atomic_store_explicit(&g_io_faults_on, 0, memory_order_release);
+}
+
+int
+__db_sim_io_faults_active()
+{
+	return (atomic_load_explicit(&g_io_faults_on, memory_order_acquire));
+}
+
+int64_t
+__db_sim_io_latency()
+{
+	int64_t lo, hi;
+
+	if (!__db_sim_io_faults_active() || !__db_sim_active())
+		return (0);
+	lo = atomic_load_explicit(&g_io_lat_min_ns, memory_order_relaxed);
+	hi = atomic_load_explicit(&g_io_lat_max_ns, memory_order_relaxed);
+	if (hi <= lo)
+		return (lo);
+	return (lo + (int64_t)__db_sim_rng_range(DB_SIM_RNG_IO,
+	    (uint64_t)(hi - lo + 1)));
+}
+
+int
+__db_sim_io_should_fault()
+{
+	int pct;
+
+	if (!__db_sim_io_faults_active() || !__db_sim_active())
+		return (0);
+	pct = atomic_load_explicit(&g_io_fault_pct, memory_order_relaxed);
+	if (pct == 0)
+		return (0);
+	if (pct >= 1000)
+		return (1);
+	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct);
+}
+
+void
+__db_sim_io_enospc_enable(pct_per_1000)
+	unsigned pct_per_1000;
+{
+	if (pct_per_1000 > 1000)
+		pct_per_1000 = 1000;
+	atomic_store_explicit(&g_io_enospc_pct, (int)pct_per_1000,
+	    memory_order_release);
+}
+
+int
+__db_sim_io_enospc()
+{
+	int pct = atomic_load_explicit(&g_io_enospc_pct, memory_order_acquire);
+
+	if (pct <= 0 || !__db_sim_active())
+		return (0);
+	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct);
+}
+
+/* ---- torn write / corrupt read ---- */
+
+void
+__db_sim_io_corrupt_enable(corrupt_pct_per_1000)
+	unsigned corrupt_pct_per_1000;
+{
+	atomic_store_explicit(&g_io_corrupt_pct, (int)corrupt_pct_per_1000,
+	    memory_order_relaxed);
+	atomic_store_explicit(&g_io_corrupt_on, 1, memory_order_release);
+}
+
+void
+__db_sim_io_corrupt_disable()
+{
+	atomic_store_explicit(&g_io_corrupt_on, 0, memory_order_release);
+}
+
+static int
+io_should_corrupt()
+{
+	int pct;
+
+	if (!atomic_load_explicit(&g_io_corrupt_on, memory_order_acquire) ||
+	    !__db_sim_active())
+		return (0);
+	pct = atomic_load_explicit(&g_io_corrupt_pct, memory_order_relaxed);
+	if (pct == 0)
+		return (0);
+	if (pct >= 1000)
+		return (1);
+	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct);
+}
+
+int
+__db_sim_io_torn_prefix(full_len)
+	int full_len;
+{
+	if (full_len < 2 || !io_should_corrupt())
+		return (full_len);
+	/* Persist a strict prefix in [1, full_len-1] -- a torn write always
+	 * loses at least the last byte -- but report full success. */
+	return (1 + (int)__db_sim_rng_range(DB_SIM_RNG_IO,
+	    (uint64_t)(full_len - 1)));
+}
+
+int
+__db_sim_io_flip_byte(len)
+	int len;
+{
+	if (len <= 0 || !io_should_corrupt())
+		return (-1);
+	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, (uint64_t)len));
+}
+
+/* ---- write-back cache crash model (THE durability catcher) ----
+ *
+ * The problem it closes: the sim writes to a REAL file, so bytes reach
+ * the file on write() regardless of whether fsync was called -- meaning
+ * a crash-recovery test that trusts the writer cannot catch a writer
+ * that ACKs a commit WITHOUT fsyncing it.  This models the disk
+ * honestly: a write lands in a volatile per-file cache (tracked as the
+ * WRITTEN high-water offset); only fsync promotes the written extent to
+ * DURABLE; a crash loses everything past the last fsync.
+ *
+ * Keyed by the libdb file id (a hash of the DB_FH name, since libdb
+ * re-opens fds), so the frontier survives close/reopen the way a real
+ * disk would.  A recovery test asks __db_sim_io_durable_end(key) for the
+ * true post-crash durable frontier to truncate to.
+ *
+ * ponytail: bounded fixed table, O(n) scan; a WAL crash test tracks one
+ * or two files.  Upgrade to a hash keyed table if a scenario needs many.
+ */
+#define DB_SIM_WB_FILES 16
+struct sim_wb_ent {
+	uint64_t key;
+	uint64_t written_end;
+	uint64_t durable_end;
+	int      used;
+};
+static struct sim_wb_ent g_wb[DB_SIM_WB_FILES];
+static _Atomic int g_wb_on;
+
+void
+__db_sim_wb_enable(on)
+	int on;
+{
+	if (on)
+		memset(g_wb, 0, sizeof(g_wb));
+	atomic_store_explicit(&g_wb_on, on ? 1 : 0, memory_order_release);
+}
+
+int
+__db_sim_wb_active()
+{
+	return (atomic_load_explicit(&g_wb_on, memory_order_acquire));
+}
+
+static struct sim_wb_ent *
+wb_slot(key)
+	uint64_t key;
+{
+	int k, free_k = -1;
+
+	for (k = 0; k < DB_SIM_WB_FILES; k++) {
+		if (g_wb[k].used && g_wb[k].key == key)
+			return (&g_wb[k]);
+		if (free_k < 0 && !g_wb[k].used)
+			free_k = k;
+	}
+	if (free_k >= 0) {
+		g_wb[free_k].used = 1;
+		g_wb[free_k].key = key;
+		g_wb[free_k].written_end = 0;
+		g_wb[free_k].durable_end = 0;
+		return (&g_wb[free_k]);
+	}
+	return (NULL);   /* table full: this file is not tracked (bounded) */
+}
+
+void
+__db_sim_wb_wrote(key, end_off)
+	uint64_t key, end_off;
+{
+	struct sim_wb_ent *e;
+
+	if (!__db_sim_wb_active())
+		return;
+	e = wb_slot(key);
+	if (e != NULL && end_off > e->written_end)
+		e->written_end = end_off;
+}
+
+void
+__db_sim_wb_synced(key)
+	uint64_t key;
+{
+	struct sim_wb_ent *e;
+
+	if (!__db_sim_wb_active())
+		return;
+	e = wb_slot(key);
+	if (e != NULL)
+		e->durable_end = e->written_end;
+}
+
+uint64_t
+__db_sim_wb_written_end(key)
+	uint64_t key;
+{
+	struct sim_wb_ent *e;
+
+	if (!__db_sim_wb_active())
+		return (0);
+	e = wb_slot(key);
+	return (e != NULL ? e->written_end : 0);
+}
+
+uint64_t
+__db_sim_io_durable_end(key)
+	uint64_t key;
+{
+	struct sim_wb_ent *e;
+
+	if (!__db_sim_wb_active())
+		return (0);
+	e = wb_slot(key);
+	return (e != NULL ? e->durable_end : 0);
+}

--- a/test/sim/sim_fault.h
+++ b/test/sim/sim_fault.h
@@ -1,0 +1,88 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_fault.h --
+ *	Fault-injection surface: seeded fault toggles, buggify, the
+ *	simulated-I/O fault knobs and the write-back-cache crash model,
+ *	plus the ZERO-COST macros the __os_* hooks use.
+ *
+ *	Adapted from xtc_sim.h / xtc_dst_inject.h.
+ *
+ *	Compilation model:
+ *	  - HAVE_DST OFF (production / default): the DST_* macros below are
+ *	    defined to constants / no-ops in db_int.h's stub (see the
+ *	    !HAVE_DST branch), so the __os_* hooks vanish and none of these
+ *	    symbols are referenced.  This whole header is only included by
+ *	    sim TUs and by the __os_* hooks under #ifdef HAVE_DST.
+ *	  - HAVE_DST ON: the sim core TU (sim_core.c) is linked into the
+ *	    library and the hooks call these functions, each gated first on
+ *	    __db_sim_active() (a single relaxed load) so an --enable-dst
+ *	    library that is NOT running a sim behaves exactly like stock.
+ */
+
+#ifndef _DB_SIM_FAULT_H_
+#define _DB_SIM_FAULT_H_
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/* Seeded fault toggle: 1 with probability pct_per_1000/1000 from the
+ * FAULT stream; 0 when sim inactive.  Same seed => same fault schedule. */
+int      __db_sim_fault __P((unsigned));
+
+/* Buggify: once-per-run cached coin per named site (BUGGIFY stream). */
+void     __db_sim_buggify_enable __P((unsigned));
+void     __db_sim_buggify_disable __P((void));
+int      __db_sim_buggify __P((const char *));
+
+/* Simulated I/O faults: seeded latency + short-transfer/EIO toggle. */
+void     __db_sim_io_faults_enable __P((int64_t, int64_t, unsigned));
+void     __db_sim_io_faults_disable __P((void));
+int      __db_sim_io_faults_active __P((void));
+int64_t  __db_sim_io_latency __P((void));
+int      __db_sim_io_should_fault __P((void));
+
+/* Disk-full (ENOSPC): a seeded coin fails a whole write, nothing
+ * persists. */
+void     __db_sim_io_enospc_enable __P((unsigned));
+int      __db_sim_io_enospc __P((void));
+
+/* Torn write (persist a seeded prefix, report full) + corrupt read
+ * (bit-flip one returned byte).  Both leave latent bad data a checksum
+ * must catch. */
+void     __db_sim_io_corrupt_enable __P((unsigned));
+void     __db_sim_io_corrupt_disable __P((void));
+int      __db_sim_io_torn_prefix __P((int));
+int      __db_sim_io_flip_byte __P((int));
+
+/*
+ * Write-back cache crash model (the ack-before-fsync durability
+ * catcher).  Keyed by a caller-chosen 64-bit file key (libdb hashes the
+ * DB_FH name so the frontier survives close/reopen).  A write records
+ * the written high-water; fsync promotes written -> durable; a crash
+ * loses everything past the last fsync.  A recovery test truncates the
+ * file to __db_sim_io_durable_end(key).
+ */
+void     __db_sim_wb_enable __P((int));
+int      __db_sim_wb_active __P((void));
+void     __db_sim_wb_wrote __P((uint64_t, uint64_t));
+void     __db_sim_wb_synced __P((uint64_t));
+uint64_t __db_sim_wb_written_end __P((uint64_t));
+uint64_t __db_sim_io_durable_end __P((uint64_t));
+
+/*
+ * Buggify branch macro for planting a legal-but-pessimal path in real
+ * library code:  if (DB_SIM_BUGGIFY("log.flush.tiny")) { ...slow... }
+ * A single relaxed load + short-scan in an --enable-dst build; compiles
+ * to constant 0 when HAVE_DST is off (see db_int.h stub).
+ */
+#define DB_SIM_BUGGIFY(name)  __db_sim_buggify(name)
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_FAULT_H_ */

--- a/test/sim/sim_inject.h
+++ b/test/sim/sim_inject.h
@@ -1,0 +1,60 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_inject.h --
+ *	DST bug-injection harness -- the "bug-detection latency" yardstick.
+ *
+ *	FoundationDB / TigerBeetle back the claim "deterministic simulation
+ *	finds real bugs" by PLANTING a known bug and proving the simulator
+ *	catches it within a small number of seeds, deterministically, with
+ *	a replayable seed.  That -- not a coverage percentage -- is the
+ *	metric that inspires confidence: "break a safety invariant and DST
+ *	catches it fast, handing you the exact seed."
+ *
+ *	In a normal build DB_DST_INJECT_BUG is undefined and every check
+ *	compiles to 0, so the harness is absent from production AND from the
+ *	default --enable-dst build.  A dedicated build passes
+ *	-DDB_DST_INJECT_BUG=<n> (via `make dst_tests DSTBUG=<n>`) to activate
+ *	exactly ONE planted bug; the DST capstone is then expected to FAIL
+ *	within a bounded seed count.  A planted bug the sweep does NOT catch
+ *	is a hole in the DST coverage of that safety property.
+ *
+ *	Bug ids (each targets a DST-reachable safety-critical site whose
+ *	violation a specific pilot detects):
+ *
+ *	  1  NODURABLE  -- the crash-recover pilot skips truncating the DB
+ *	                   to the durable frontier before recovery, i.e. it
+ *	                   trusts bytes the write-back model says were never
+ *	                   fsync'd.  Models a writer that ACKs a commit
+ *	                   without making it durable.  The capstone's
+ *	                   "every committed txn present after recovery, DB
+ *	                   verifies clean" invariant fires.  (v1: modelled
+ *	                   in the harness; a later phase plants it inside
+ *	                   __log_flush itself.)
+ *	  2  NOCKSUM    -- the torn/iofault pilot accepts a page whose
+ *	                   checksum mismatches instead of erroring.  Silent
+ *	                   corruption; the pilot's "engine errors cleanly or
+ *	                   detects, never silently corrupts" invariant fires.
+ *
+ *	When you add a safety invariant, add a bug id here and a case to
+ *	the pilot so DST must prove it catches it.
+ */
+
+#ifndef _DB_SIM_INJECT_H_
+#define _DB_SIM_INJECT_H_
+
+/*
+ * DB_DST_BUG(n) is 1 iff the build activated planted bug n.  Zero in
+ * every normal build (DB_DST_INJECT_BUG undefined), so all injection
+ * sites vanish.  Exactly one bug is active per injected build.
+ */
+#if defined(DB_DST_INJECT_BUG)
+# define DB_DST_BUG(n)  ((DB_DST_INJECT_BUG) == (n))
+#else
+# define DB_DST_BUG(n)  (0)
+#endif
+
+#define DB_DST_BUG_NODURABLE  1   /* trust un-fsync'd bytes across crash */
+#define DB_DST_BUG_NOCKSUM    2   /* accept a checksum-mismatched page */
+
+#endif /* !_DB_SIM_INJECT_H_ */

--- a/test/sim/sim_os.h
+++ b/test/sim/sim_os.h
@@ -1,0 +1,29 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_os.h --
+ *	Declarations of the DST I/O hooks that the __os_* layer calls.
+ *	Included by src/os/os_rw.c and os_fsync.c ONLY under #ifdef
+ *	HAVE_DST, so a production build never sees it and the auto-built
+ *	os_ext.h is left untouched (these are DST-internal, not part of the
+ *	public os API surface).
+ */
+
+#ifndef _DB_SIM_OS_H_
+#define _DB_SIM_OS_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+uint64_t db_sim_fkey __P((DB_FH *));
+void __db_sim_io_write_hook __P((DB_FH *, u_int32_t));
+void __db_sim_io_write_off_hook __P((DB_FH *, u_int64_t));
+void __db_sim_io_sync_hook __P((DB_FH *));
+void __db_sim_io_read_hook __P((void *, size_t));
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_OS_H_ */

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -1,0 +1,138 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_os_hooks.c --
+ *	The bridge between the __os_* I/O layer (src/os/os_rw.c,
+ *	os_fsync.c) and the DST core (sim_core.c).  These are the exact
+ *	functions the guarded #ifdef HAVE_DST call sites in the os layer
+ *	invoke.  Each is a single relaxed load (__db_sim_active) in the
+ *	common no-sim case, so an --enable-dst library that is NOT running
+ *	a sim is behaviourally and ~performance identical to stock.
+ *
+ *	Only linked into the library under --enable-dst (HAVE_DST).  When
+ *	off, the os-layer call sites are #ifdef'd out and this file is not
+ *	compiled, so production has zero overhead and no new symbols.
+ *
+ *	This is the ONE place that translates a DB_FH into the write-back
+ *	model's file key: a stable hash of the file name, so the durable
+ *	frontier tracks a logical file across libdb's close/reopen (libdb
+ *	re-opens log and db files freely; keying on fd would lose the
+ *	frontier).
+ */
+
+#include "db_config.h"
+
+#include "db_int.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+/*
+ * db_sim_fkey --
+ *	Stable 64-bit key for a file handle's logical file (FNV-1a of the
+ *	name).  Handles with no name (anonymous temp) get key 0, which the
+ *	write-back table treats as a single shared bucket -- fine, since
+ *	anonymous files are not the durability-critical WAL/db files a
+ *	crash test tracks.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: uint64_t db_sim_fkey __P((DB_FH *));
+ * PUBLIC: #endif
+ */
+uint64_t
+db_sim_fkey(fhp)
+	DB_FH *fhp;
+{
+	uint64_t h = 1469598103934665603ull;   /* FNV-1a offset basis */
+	const unsigned char *p;
+
+	if (fhp == NULL || fhp->name == NULL)
+		return (0);
+	for (p = (const unsigned char *)fhp->name; *p != '\0'; p++) {
+		h ^= (uint64_t)*p;
+		h *= 1099511628211ull;              /* FNV-1a prime */
+	}
+	return (h);
+}
+
+/*
+ * __db_sim_io_write_hook --
+ *	Called from the write path AFTER the real bytes have been written.
+ *	Records the written high-water in the write-back model (so a later
+ *	crash can drop everything past the last fsync).  `end_off` is the
+ *	byte just past the end of this write.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_io_write_hook __P((DB_FH *, u_int32_t));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_io_write_hook(fhp, end_off)
+	DB_FH *fhp;
+	u_int32_t end_off;
+{
+	if (!__db_sim_active() || !__db_sim_wb_active())
+		return;
+	__db_sim_wb_wrote(db_sim_fkey(fhp), (uint64_t)end_off);
+}
+
+/*
+ * __db_sim_io_write_off_hook --
+ *	As above but takes the 64-bit absolute end offset directly (the
+ *	page write path in __os_io computes (pgno*pgsize + io_len)).
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_io_write_off_hook __P((DB_FH *, u_int64_t));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_io_write_off_hook(fhp, end_off)
+	DB_FH *fhp;
+	u_int64_t end_off;
+{
+	if (!__db_sim_active() || !__db_sim_wb_active())
+		return;
+	__db_sim_wb_wrote(db_sim_fkey(fhp), end_off);
+}
+
+/*
+ * __db_sim_io_sync_hook --
+ *	Called from __os_fsync after a successful fsync/fdatasync: promotes
+ *	this file's written extent to durable in the write-back model.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_io_sync_hook __P((DB_FH *));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_io_sync_hook(fhp)
+	DB_FH *fhp;
+{
+	if (!__db_sim_active() || !__db_sim_wb_active())
+		return;
+	__db_sim_wb_synced(db_sim_fkey(fhp));
+}
+
+/*
+ * __db_sim_io_read_hook --
+ *	Called from the read path AFTER bytes land in the caller's buffer.
+ *	On a seeded corrupt-read coin, flips one bit of one returned byte --
+ *	a silent corrupt read the engine's page checksum must catch.  A
+ *	no-op unless a sim armed the corrupt knob.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_io_read_hook __P((void *, size_t));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_io_read_hook(buf, len)
+	void *buf;
+	size_t len;
+{
+	int fb;
+
+	if (!__db_sim_active() || buf == NULL || len == 0)
+		return;
+	fb = __db_sim_io_flip_byte((int)(len > 0x7fffffff ? 0x7fffffff : len));
+	if (fb >= 0)
+		((unsigned char *)buf)[fb] ^= 0x40;
+}

--- a/test/sim/sim_rng.h
+++ b/test/sim/sim_rng.h
@@ -1,0 +1,77 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_rng.h --
+ *	Seeded per-stream PRNG tree + activation state.  Adapted from the
+ *	xtc DST core (src/evt/sim.c), pared to what a single-process libdb
+ *	fault+crash harness needs.  Dependency-free (stdint + stdatomic).
+ *
+ *	The PRNG is a per-stream splitmix64: one root seed splits into
+ *	independent sub-streams so a draw at one decision site (IO, fault,
+ *	buggify, app workload) never perturbs another site's sequence --
+ *	the FoundationDB discipline that keeps a replay stable when a new
+ *	draw site is added.
+ *
+ *	Everything here compiles to a couple of relaxed atomic loads when
+ *	sim is inactive, and the whole translation unit is only linked
+ *	into the library when configured --enable-dst (HAVE_DST).  A
+ *	production build never sees it.
+ */
+
+#ifndef _DB_SIM_RNG_H_
+#define _DB_SIM_RNG_H_
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * Well-known PRNG streams.  Each independent decision site owns a
+ * stream so adding a draw in one site cannot shift another's sequence.
+ * Keep SCHED reserved for the future deterministic scheduler (v2) so
+ * v1 draw ordering does not move when it lands.
+ */
+enum db_sim_stream {
+	DB_SIM_RNG_IO      = 0,   /* simulated I/O latency / fault toggles */
+	DB_SIM_RNG_FAULT   = 1,   /* generic fault-injection toggles */
+	DB_SIM_RNG_BUGGIFY = 2,   /* buggify per-run activation coins */
+	DB_SIM_RNG_APP     = 3,   /* application/test workload draws */
+	DB_SIM_RNG_SCHED   = 4,   /* RESERVED: deterministic scheduler (v2) */
+	DB_SIM_RNG_NSTREAMS
+};
+
+/* 1 while a deterministic simulation run is active.  Hot-path call
+ * sites branch on this to decide between seeded and normal behaviour. */
+int      __db_sim_active __P((void));
+
+/* Activate sim with a root seed (resets every stream + the guard
+ * count).  Idempotent re-activation re-seeds.  Test-only. */
+void     __db_sim_activate __P((uint64_t));
+void     __db_sim_deactivate __P((void));
+uint64_t __db_sim_seed __P((void));
+
+/* Draw the next 64-bit value from stream `s`, or a uniform value in
+ * [0, bound).  Deterministic given the activation seed.  Return 0 when
+ * sim is inactive (callers gate on __db_sim_active()). */
+uint64_t __db_sim_rng __P((int));
+uint64_t __db_sim_rng_range __P((int, uint64_t));
+
+/*
+ * Determinism guard.  A sim-reachable primitive that would break seed
+ * replay (a real clock read, an unseeded rand(), a raw pid) calls
+ * __db_sim_nondeterminism(what).  Outside a sim run it is a no-op; under
+ * sim it records the violation and, in strict mode (default), aborts
+ * naming the source.  The count is queryable so a harness can assert 0
+ * to PROVE a run was fully deterministic.
+ */
+void     __db_sim_nondeterminism __P((const char *));
+void     __db_sim_strict __P((int));
+int      __db_sim_nondeterminism_count __P((void));
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_RNG_H_ */

--- a/test/sim/test_sim_crash_recover.c
+++ b/test/sim/test_sim_crash_recover.c
@@ -1,0 +1,291 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_crash_recover.c --
+ *	THE capstone pilot: a transactional btree workload commits N
+ *	durable txns, a child process "crashes" mid-uncommitted-txn (an
+ *	abrupt _exit with a dirty env), then the parent runs recovery and
+ *	verifies EVERY committed txn survived, the uncommitted one did not,
+ *	and the DB verifies clean.
+ *
+ *	Determinism: the workload keys/values are drawn from the seeded APP
+ *	stream, so a given seed produces the exact same committed set --
+ *	the same seed replays the same run.  The crash point is fixed
+ *	(after N synced commits, inside txn N+1), which the deterministic
+ *	fault schedule will later parameterize (v2).
+ *
+ *	CRITICAL (see .agents/concurrent-btree-corruption.md): a crashed
+ *	txn env verified WITHOUT recovery falsely looks corrupt.  This
+ *	pilot ALWAYS runs DB_RECOVER before db->verify.
+ *
+ *	Planted-bug hook (DB_DST_INJECT_BUG=1, NODURABLE): the last "acked"
+ *	txn commits with DB_TXN_NOSYNC (acked but not fsync'd).  A correct
+ *	engine loses it across the crash (it was never durable); the buggy
+ *	build ASSERTS it survived, so the DST invariant fires -- proving the
+ *	capstone catches an ack-before-durable bug.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_crash_recover && ./test_sim_crash_recover [seed]
+ */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+#include "sim_inject.h"
+
+#define HOME    "TESTDIR_sim_crash"
+#define DBFILE  "crash.db"
+#define NCOMMIT 64            /* durable committed txns before the crash */
+
+/* Deterministic key/value for record i under the active seed. */
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	/* key is just the index (so the parent can look each one up);
+	 * value carries a seeded token so a wrong/torn value is visible. */
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "key-%08d", i);
+	(void)snprintf(vbuf, 32, "val-%016llx", (unsigned long long)tok);
+}
+
+static int
+run_child(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	/* Re-seed identically in the child so its APP-stream draws match the
+	 * parent's expectation (fork copies the seed but we re-activate to
+	 * be explicit and independent of copy semantics). */
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);       /* honest disk: writes durable only on fsync */
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0664)) != 0)
+		return (ret);
+
+	/* N durable (synced) commits -- each MUST survive the crash. */
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+#if DB_DST_BUG(1) == 0
+	/* Normal path: start an UNCOMMITTED txn, then crash inside it. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+	/* Deliberately DO NOT commit txn.  Crash now. */
+#else
+	/*
+	 * NODURABLE bug: "ack" a commit WITHOUT fsync (DB_TXN_NOSYNC) and
+	 * treat it as durable.  A correct engine loses this across a crash;
+	 * the harness invariant (below) asserts it survived, so the planted
+	 * bug makes the capstone FAIL -- exactly the DST catch we want.
+	 */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+	(void)txn->commit(txn, DB_TXN_NOSYNC);   /* acked, NOT durable */
+#endif
+
+	/*
+	 * CRASH: abrupt exit, no clean close, no checkpoint.  _exit skips
+	 * atexit handlers and libdb cleanup, leaving the env dirty exactly
+	 * as a kill -9 would.  Flush stdio so any child diagnostics escape.
+	 */
+	fflush(NULL);
+	_exit(42);
+	/* NOTREACHED */
+	return (0);
+}
+
+/* Recover, reopen, and verify the committed set.  Returns 0 on success. */
+static int
+verify_after_recovery(seed, saw_nosync_key)
+	uint64_t seed;
+	int *saw_nosync_key;
+{
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, mismatch = 0;
+
+	*saw_nosync_key = 0;
+
+	/* ALWAYS recover before touching the tree (else a WAL-consistent
+	 * crashed tree falsely looks corrupt). */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER, 0664))
+	    != 0) {
+		fprintf(stderr, "recover open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "reopen failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+
+	/* Re-derive the expected records deterministically from the seed. */
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if ((ret = db->get(db, NULL, &key, &data, 0)) != 0) {
+			fprintf(stderr, "MISSING committed key %s: %s\n",
+			    kbuf, db_strerror(ret));
+			missing++;
+		} else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0) {
+			fprintf(stderr, "WRONG value for committed key %s\n",
+			    kbuf);
+			mismatch++;
+		}
+	}
+	/* The (NOSYNC-acked or uncommitted) key NCOMMIT must be ABSENT after
+	 * a correct recovery. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		*saw_nosync_key = 1;
+	__db_sim_deactivate();
+
+	(void)db->close(db, 0);
+
+	/* Verify a FRESH handle (verify needs the db closed). */
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "db->verify FAILED: %s\n", db_strerror(ret));
+		/* verify closes the handle itself on failure. */
+		(void)env->close(env, 0);
+		return (ret);
+	}
+	(void)env->close(env, 0);
+
+	if (missing != 0 || mismatch != 0) {
+		fprintf(stderr, "%d missing, %d mismatched committed txns\n",
+		    missing, mismatch);
+		return (1);
+	}
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xDB5EEDull;
+	pid_t pid;
+	int status, ret, saw_nosync;
+	char cmd[256];
+
+	/* Fresh env dir each run (trash-friendly: a plain rm of a known
+	 * scratch dir we created). */
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	(void)system(cmd);
+
+	/* Child does the durable work then crashes. */
+	if ((pid = fork()) < 0) {
+		perror("fork");
+		return (EXIT_FAILURE);
+	}
+	if (pid == 0)
+		exit(run_child(seed) == 0 ? 0 : 1);   /* only reached on setup err */
+
+	if (waitpid(pid, &status, 0) < 0) {
+		perror("waitpid");
+		return (EXIT_FAILURE);
+	}
+	if (!(WIFEXITED(status) && WEXITSTATUS(status) == 42)) {
+		fprintf(stderr, "child did not reach the crash point "
+		    "(status %d) -- setup failed\n", status);
+		return (EXIT_FAILURE);
+	}
+
+	ret = verify_after_recovery(seed, &saw_nosync);
+
+#if DB_DST_BUG(1)
+	/*
+	 * NODURABLE invariant: the NOSYNC-acked commit must NOT survive.
+	 * If it did (or recovery/verify otherwise passed), the ack-before-
+	 * durable bug went UNDETECTED -- fail loudly so the sweep records
+	 * DST caught it (a nonzero exit is the "caught" signal here since
+	 * the bug is in what we ACCEPT, not what crashes).
+	 */
+	if (ret == 0 && saw_nosync) {
+		fprintf(stderr, "test_sim_crash_recover: DST CAUGHT NODURABLE "
+		    "-- a NOSYNC-acked commit survived a crash (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_crash_recover: (bug build) NOSYNC commit correctly "
+	    "absent -- would need a real ack-before-fsync site to trip\n");
+#endif
+
+	if (ret == 0) {
+		printf("test_sim_crash_recover: PASS -- %d committed txns "
+		    "survived, uncommitted did not, DB verifies clean "
+		    "(seed 0x%llx)\n", NCOMMIT, (unsigned long long)seed);
+		return (EXIT_SUCCESS);
+	}
+	fprintf(stderr, "test_sim_crash_recover: FAIL (seed 0x%llx)\n",
+	    (unsigned long long)seed);
+	return (EXIT_FAILURE);
+}

--- a/test/sim/test_sim_rng.c
+++ b/test/sim/test_sim_rng.c
@@ -1,0 +1,119 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_rng.c --
+ *	Pilot: prove the seeded PRNG tree is deterministic, reproducible,
+ *	and stream-independent -- the foundation every other DST scenario
+ *	rests on.  Mirrors xtc's test_sim_rng.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_rng && ./test_sim_rng
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* The DST core is compiled into libdb under --enable-dst; declare the
+ * bits we exercise (test/sim is on the include path via DST_CFLAGS). */
+#include "sim_rng.h"
+
+#define NDRAW 256
+
+static int failures;
+
+#define CHECK(cond, msg) do {						\
+	if (!(cond)) {							\
+		fprintf(stderr, "FAIL: %s (%s:%d)\n", msg,		\
+		    __FILE__, __LINE__);				\
+		failures++;						\
+	}								\
+} while (0)
+
+/* Collect NDRAW draws from one stream into out[]. */
+static void
+collect(seed, stream, out)
+	uint64_t seed;
+	int stream;
+	uint64_t *out;
+{
+	int i;
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NDRAW; i++)
+		out[i] = __db_sim_rng(stream);
+	__db_sim_deactivate();
+}
+
+int
+main()
+{
+	uint64_t a[NDRAW], b[NDRAW], io[NDRAW], fault[NDRAW];
+	int i, same;
+
+	/* 1. Determinism: the same seed reproduces the identical sequence. */
+	collect(0xC0FFEEull, DB_SIM_RNG_APP, a);
+	collect(0xC0FFEEull, DB_SIM_RNG_APP, b);
+	CHECK(memcmp(a, b, sizeof(a)) == 0,
+	    "same seed must reproduce identical draws");
+
+	/* 2. Seed sensitivity: a different seed gives a different sequence. */
+	collect(0xC0FFEEull, DB_SIM_RNG_APP, a);
+	collect(0xC0FFEFull, DB_SIM_RNG_APP, b);
+	CHECK(memcmp(a, b, sizeof(a)) != 0,
+	    "different seeds must give different draws");
+
+	/* 3. Stream independence: IO and FAULT streams under the SAME seed
+	 *    are independent sequences -- so adding a draw at one site never
+	 *    shifts another site's sequence (stable replay under change). */
+	collect(0xABCD1234ull, DB_SIM_RNG_IO, io);
+	collect(0xABCD1234ull, DB_SIM_RNG_FAULT, fault);
+	CHECK(memcmp(io, fault, sizeof(io)) != 0,
+	    "distinct streams must be independent under one seed");
+
+	/* 3b. Interleaving IO+FAULT draws must NOT change what the IO stream
+	 *     produces vs drawing IO alone -- the isolation guarantee. */
+	__db_sim_activate(0xABCD1234ull);
+	same = 1;
+	for (i = 0; i < NDRAW; i++) {
+		uint64_t v = __db_sim_rng(DB_SIM_RNG_IO);
+		(void)__db_sim_rng(DB_SIM_RNG_FAULT);   /* perturb FAULT */
+		if (v != io[i])
+			same = 0;
+	}
+	__db_sim_deactivate();
+	CHECK(same, "interleaving another stream must not shift the IO stream");
+
+	/* 4. rng_range respects the bound and is deterministic. */
+	__db_sim_activate(42);
+	for (i = 0; i < NDRAW; i++) {
+		uint64_t r = __db_sim_rng_range(DB_SIM_RNG_APP, 100);
+		CHECK(r < 100, "rng_range must stay below bound");
+	}
+	__db_sim_deactivate();
+
+	/* 5. Inactive sim draws 0 (callers gate on __db_sim_active). */
+	CHECK(__db_sim_active() == 0, "sim must be inactive after deactivate");
+	CHECK(__db_sim_rng(DB_SIM_RNG_APP) == 0,
+	    "inactive sim must draw 0");
+
+	/* 6. Determinism guard: outside a run it is a no-op (count stays 0);
+	 *    inside a run, in non-strict mode, it counts violations. */
+	__db_sim_nondeterminism("outside-run");   /* no-op */
+	__db_sim_activate(7);
+	__db_sim_strict(0);                        /* count, do not abort */
+	__db_sim_nondeterminism("test.clock_read");
+	CHECK(__db_sim_nondeterminism_count() == 1,
+	    "guard must count a violation inside a run");
+	__db_sim_strict(1);
+	__db_sim_deactivate();
+
+	if (failures == 0) {
+		printf("test_sim_rng: PASS (determinism, seed-sensitivity, "
+		    "stream-independence, guard)\n");
+		return (EXIT_SUCCESS);
+	}
+	fprintf(stderr, "test_sim_rng: FAIL (%d checks)\n", failures);
+	return (EXIT_FAILURE);
+}

--- a/test/sim/test_sim_torn.c
+++ b/test/sim/test_sim_torn.c
@@ -1,0 +1,167 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_torn.c --
+ *	Pilot: inject silent corrupt reads under the seeded IO stream and
+ *	assert the engine either returns the CORRECT bytes or errors
+ *	cleanly (checksum detection) -- it must NEVER return wrong data as
+ *	if it were correct.  Uses DB_CHKSUM so page corruption is caught by
+ *	libdb's per-page checksum.
+ *
+ *	The corrupt-read hook (__db_sim_io_read_hook, wired into __os_io's
+ *	read fast path) flips one bit of a returned page on a seeded coin.
+ *	A DB_CHKSUM btree must detect that on the next page fetch.
+ *
+ *	Planted-bug hook (DB_DST_INJECT_BUG=2, NOCKSUM): the harness would
+ *	accept a mismatched page instead of treating a bad get as detected.
+ *	Documented in sim_inject.h; the honest v1 relies on libdb's real
+ *	checksum path, so this pilot's "caught" signal is a clean error.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_torn && ./test_sim_torn [seed]
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+#include "sim_inject.h"
+
+#define HOME   "TESTDIR_sim_torn"
+#define DBFILE "torn.db"
+#define NKEYS  400
+#define PGSIZE 512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "key-%08d", i);
+	/* A fixed, verifiable value pattern so a silent corruption that
+	 * slipped past detection would be visible as a byte mismatch. */
+	for (j = 0; j < 24; j++)
+		vbuf[j] = (char)('A' + ((i + j) % 26));
+	vbuf[24] = '\0';
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	char cmd[256];
+	int i, ret, detected = 0, correct = 0, silent_bad = 0;
+
+	seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x701234ull;
+
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	(void)system(cmd);
+
+	/* ---- phase 1: populate a DB_CHKSUM btree, clean (no faults) ---- */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		goto env_err;
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_MPOOL, 0664)) != 0)
+		goto env_err;
+	if ((ret = db_create(&db, env, 0)) != 0)
+		goto env_err;
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		goto env_err;
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, NULL, &key, &data, 0)) != 0)
+			goto env_err;
+	}
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	/* ---- phase 2: reopen COLD (DB_PRIVATE, small cache), arm corrupt
+	 *      reads, scan every key so every leaf page is read from disk ---- */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		goto env_err;
+	/* DB_PRIVATE: a process-local, initially-empty cache, so every page
+	 * fetch is a real __os_io read from disk (no shared region carrying
+	 * pages over from phase 1) -- that is where the corrupt-read hook
+	 * fires and the DB_CHKSUM verify must catch it. */
+	(void)env->set_cachesize(env, 0, 64 * 1024, 1);
+	if ((ret = env->open(env, HOME,
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0664)) != 0)
+		goto env_err;
+	if ((ret = db_create(&db, env, 0)) != 0)
+		goto env_err;
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE, 0, 0664)) != 0)
+		goto env_err;
+
+	__db_sim_activate(seed);
+	__db_sim_io_corrupt_enable(50);    /* 5% of page reads bit-flipped */
+
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size == strlen(vbuf) + 1 &&
+			    memcmp(data.data, vbuf, data.size) == 0)
+				correct++;
+			else
+				silent_bad++;   /* wrong data, no error: BAD */
+		} else {
+			/* Any error (checksum / verify / page) is a clean
+			 * detection -- the engine refused to hand back data it
+			 * could not trust. */
+			detected++;
+		}
+	}
+
+	__db_sim_io_corrupt_disable();
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_torn: %d correct, %d detected(clean error), "
+	    "%d SILENT-BAD (seed 0x%llx)\n",
+	    correct, detected, silent_bad, (unsigned long long)seed);
+
+	if (silent_bad != 0) {
+		fprintf(stderr, "test_sim_torn: FAIL -- %d silently corrupted "
+		    "reads slipped past the checksum\n", silent_bad);
+		return (EXIT_FAILURE);
+	}
+	/* Sanity: with 30% corruption over NKEYS reads we expect the engine
+	 * to have DETECTED at least some corruption (else the fault never
+	 * fired / the hook is not wired). */
+	if (detected == 0)
+		fprintf(stderr, "test_sim_torn: WARNING -- no corruption "
+		    "detected; the fault may not have hit a checksummed page "
+		    "this seed (try another seed)\n");
+	printf("test_sim_torn: PASS -- no silent corruption; every read was "
+	    "correct or cleanly rejected\n");
+	return (EXIT_SUCCESS);
+
+env_err:
+	fprintf(stderr, "test_sim_torn: setup error: %s\n", db_strerror(ret));
+	return (EXIT_FAILURE);
+}


### PR DESCRIPTION
## Deterministic Simulation Testing (DST) — foundation + pilots

Bootstraps DST for libdb, modeled on FoundationDB / TigerBeetle and the xtc
project's DST. **This is the v1 foundation + 2–3 proof-of-architecture pilots**,
not the full scenario port. It builds and runs in the nix dev shell and is
**zero-overhead when `--enable-dst` is off**.

### Honest scope (read `test/sim/DESIGN.md` §0)
libdb is multi-process (shared mmap regions) with real threads + fsync
durability, so xtc's single-thread cooperative scheduler does **not** directly
apply. v1 therefore targets the axis that maps cleanly: **deterministic
fault-injection + crash/recovery**, single-process (and `DB_PRIVATE` where a cold
cache is needed). The full deterministic multi-process scheduler is v2; the
`DB_SIM_RNG_SCHED` stream + virtual-clock seam are reserved now so v1 seeds don't
shift when v2 lands.

### What actually builds + runs (validated in `nix develop`)
| Pilot | Proves | Result |
|---|---|---|
| `test_sim_rng` | seeded PRNG determinism, seed-sensitivity, stream independence, guard | **PASS** |
| `test_sim_crash_recover` | 64 durable txns survive a mid-txn crash; uncommitted does not; DB verifies clean **after recovery**; deterministic + replayable per seed | **PASS** |
| `test_sim_torn` | corrupt reads caught by `DB_CHKSUM` or invisible — never silently wrong (e.g. 297 correct / 103 detected / 0 silent-bad) | **PASS** |

- **DST ON**: library builds, `make dst_tests` builds all three, all PASS.
- **DST OFF (default)**: library builds clean, **0 `__db_sim_*` symbols leaked**,
  `HAVE_DST` undefined, `__os_*` hooks compile to the stock path.

### Architecture (see `test/sim/DESIGN.md`)
- **Seeded PRNG tree** (per-stream splitmix64: IO/FAULT/BUGGIFY/APP, SCHED reserved).
- **Determinism guard** (aborts on a nondeterministic sim-path primitive; count assertable).
- **Buggify** (per-run cached coin, own stream).
- **Simulated-I/O faults**: latency / EIO / short-transfer / torn-write /
  corrupt-read / ENOSPC, **plus the write-back-cache durable-frontier crash
  model** — the key to catching ack-before-fsync durability bugs (keyed on a
  stable file-name hash so the frontier survives close/reopen).
- **`__os_*` seam**: `__os_io` write/read fast paths + `__os_fsync`, guarded by
  `#ifdef HAVE_DST`. The WAL write + fsync route through these exact hooks.
- **Planted-bug harness** (`sim_inject.h`, `DSTBUG=<n>`): NODURABLE hook wired;
  planting the fsync-skip inside `__log_flush` is the headline next step (§4.A).

### Build wiring (additive, DST-scoped, merges cleanly)
- Autoconf (primary; what the validation recipe uses): `--enable-dst` →
  `HAVE_DST`, `$(SIM_OBJS)` into the library, `-I test/sim`.
- Meson: a fully-owned `test/sim/meson.build` + a documented one-option +
  one-subdir hookup, deliberately **not** wired into the top-level meson build to
  avoid clobbering the concurrently-edited `meson_options.txt`.

### Coordination
Branch contains **only** DST work (verified): 19 files, all under `test/sim/`,
`src/os/os_{rw,fsync}.c`, and `dist/`. No `test/pbt/`, no `meson_options.txt`, no
top-level `meson.build` change, no CI/OCR files. The canonical design doc lives
at `.agents/dst-design.md` (gitignored per repo convention); a committed copy is
`test/sim/DESIGN.md`.

### Immediate next steps (DESIGN.md §4)
A. Truncate the log to the durable frontier + a `log.flush.skip_fsync` buggify →
real ack-before-fsync catch. B. Torn-write into the write hook + torn-log
scenario. C. Disk-full. D. Stale-read model. E. Seed-sweep + bug-inject drivers.
F. Meson wiring. G. Guard-planting at clock/id primitives. H. `os_aio*` hooks.
