### PR TITLE
fix(mpool,crypto): release mutex on allocation-failure error paths

### DIFF
--- a/src/crypto/mersenne/mt19937db.c
+++ b/src/crypto/mersenne/mt19937db.c
@@ -72,8 +72,10 @@ __db_generate_iv(env, iv)
 	MUTEX_LOCK(env, env->mtx_mt);
 	if (env->mt == NULL) {
 		if ((ret = __os_calloc(env, 1, N*sizeof(unsigned long),
-		    &env->mt)) != 0)
+		    &env->mt)) != 0) {
+			MUTEX_UNLOCK(env, env->mtx_mt);
 			return (ret);
+		}
 		/* mti==N+1 means mt[N] is not initialized */
 		env->mti = N + 1;
 	}

--- a/src/mp/mp_register.c
+++ b/src/mp/mp_register.c
@@ -102,8 +102,10 @@ __memp_register(env, ftype, pgin, pgout)
 		}
 
 	if (mpreg == NULL) {			/* New entry. */
-		if ((ret = __os_malloc(env, sizeof(DB_MPREG), &mpreg)) != 0)
+		if ((ret = __os_malloc(env, sizeof(DB_MPREG), &mpreg)) != 0) {
+			MUTEX_UNLOCK(env, dbmp->mutex);
 			return (ret);
+		}
 		mpreg->ftype = ftype;
 		mpreg->pgin = pgin;
 		mpreg->pgout = pgout;


### PR DESCRIPTION
Two genuine lock leaks surfaced by the new Coccinelle `rule_mutex_unbalanced` convention check (PR #46) — a `return` between `MUTEX_LOCK` and its `MUTEX_UNLOCK` with no unlock in between.

## Bugs fixed
- **`__memp_register`** (`src/mp/mp_register.c`): registering a new pgin/pgout entry, if `__os_malloc(DB_MPREG)` fails while holding `dbmp->mutex`, the function returned without releasing it — permanently wedging the mpool registration mutex, so every later `__memp_register` (and any contender) would hang.
- **`__db_generate_iv`** (`src/crypto/mersenne/mt19937db.c`): lazily allocating the Mersenne-Twister state, if `__os_calloc` fails while holding `env->mtx_mt`, the function returned without releasing it — wedging the crypto IV-generation mutex.

Both are OOM paths (rare) but leave a core mutex held **forever**, escalating a transient ENOMEM into a permanent deadlock. Fix: `MUTEX_UNLOCK` before the error return.

## Verified, not blindly applied
The `rule_mutex_unbalanced` rule flagged 7 sites; I reviewed all 7. **Only these 2 are genuine.** The other 5 are false positives:
- `mp_fset.c` — intentional lock downgrade (UNLOCK exclusive → READLOCK shared, return holding read lock)
- `bt_curadj.c` — deliberate re-acquire-before-return (`DB_LOCK_NOTGRANTED` restart protocol)
- `mp_alloc.c`, `mp_bh.c`, `rep_record.c` — `goto`-unlock control flow the rule can't trace

That rule is advisory precisely because of these FPs — which is why it found real bugs without forcing spurious churn.

## Testing
- Clean build with `--with-crypto --enable-debug --enable-diagnostic`
- `memp001/002/003` (exercise `__memp_register`) + `test001/003 btree` — all pass

Depends on / motivated by #46 (the Coccinelle scanning that found these).