### PR TITLE
test: SQLite-style malloc-failure injection at the __os_* seam (Tier B1)

### DIFF
--- a/.github/workflows/faultinject.yml
+++ b/.github/workflows/faultinject.yml
@@ -1,0 +1,128 @@
+# Malloc-failure injection (SQLite-style) — advisory fault-injection tier.
+#
+# Dedicated workflow (does NOT touch ci.yml). Builds libdb with the opt-in
+# --enable-faultinject allocation hook (zero-overhead when off) and runs the
+# test/faultinject/ sweep: measure the workload's baseline allocation count M,
+# then for K = 1..M fail the Kth allocation and assert the library returns a
+# clean error, holds no lock (a hang is caught by a per-run watchdog), and
+# leaves a re-openable environment.
+#
+# This is the dynamic complement to the Coccinelle malloc-leak /
+# mutex-unbalanced static rules — it exercises the OOM RETURN PATHS the static
+# rules can only inspect, and it catches exactly the #47 class of bug (a lock
+# or handle mishandled on the error return).
+#
+# continue-on-error is set so this tier is ADVISORY: the sweep is expected to
+# surface pre-existing OOM-path bugs (it already found several — see
+# test/faultinject/README.md), and this job reports them without gating merges
+# while those bugs are fixed separately.
+
+name: faultinject
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - 'test/faultinject/**'
+      - 'src/os/os_alloc.c'
+      - 'dist/configure.ac'
+      - 'dist/aclocal/options.m4'
+      - 'dist/Makefile.in'
+      - '.github/workflows/faultinject.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: faultinject-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    name: malloc-failure sweep
+    runs-on: ubuntu-latest
+    continue-on-error: true   # advisory tier: surfaces pre-existing OOM bugs
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf
+
+      # --- Gate signal: plain debug build, clean crash/hang/dirty
+      #     classification, completes fast. ---
+      - name: Configure (debug + faultinject)
+        run: |
+          mkdir -p build_unix
+          cd build_unix
+          ../dist/configure --enable-debug --enable-faultinject
+
+      - name: Build library + sweep driver
+        run: |
+          cd build_unix
+          make -j"$(nproc)"
+          make fi_tests
+
+      - name: Run the malloc-failure sweep
+        id: sweep
+        run: |
+          cd build_unix
+          # The driver forks + watchdogs each K, so a crash/hang in one
+          # failure point cannot wedge the sweep. It exits non-zero iff any
+          # run crashed, hung, or left the env un-reopenable.
+          set +e
+          ./libtool --mode=execute ./fi_sweep 2>fi_stderr.log | tee fi_result.log
+          echo "sweep_rc=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          set -e
+          echo "----- summary -----"
+          grep -E 'CRASH|HANG|DIRTY|BADSTATE|RESULT|baseline|exercised|= [0-9]' fi_result.log || true
+
+      # --- Advisory ASan pass: catch heap-UAF / leak on the CLEAN paths a
+      #     plain segfault-check misses. Bounded one-shot loop (not the
+      #     forking sweep) so ASan's halt-on-first-error stays contained. ---
+      - name: Configure ASan build
+        run: |
+          mkdir -p build_asan
+          cd build_asan
+          ../dist/configure --enable-debug --enable-faultinject \
+            CFLAGS="-g -O1 -fsanitize=address -fno-omit-frame-pointer" \
+            LDFLAGS="-fsanitize=address"
+
+      - name: Build ASan library + driver
+        run: |
+          cd build_asan
+          make -j"$(nproc)"
+          make fi_tests
+
+      - name: Run bounded ASan one-shot pass
+        run: |
+          cd build_asan
+          export LD_LIBRARY_PATH="$PWD/.libs:$LD_LIBRARY_PATH"
+          export ASAN_OPTIONS=abort_on_error=0:detect_leaks=1:halt_on_error=1
+          # Sweep a bounded K range one-shot; report any ASan-flagged K.
+          # Bounded (not full M) to keep CI time reasonable; widen locally.
+          hits=0
+          for K in $(seq 1 260); do
+            rm -rf TESTDIR_fi_sweep; mkdir -p TESTDIR_fi_sweep
+            out=$(DB_FI_FAIL_AT=$K ./.libs/fi_sweep --one 2>&1 || true)
+            if echo "$out" | grep -q "ERROR: AddressSanitizer"; then
+              site=$(echo "$out" | grep -m1 -oE 'in __[a-z_]+ .*\.c:[0-9]+' || echo '(site unknown)')
+              echo "ASan K=$K: $site"
+              hits=$((hits+1))
+            fi
+          done
+          echo "ASan flagged $hits failure point(s) in K=1..260 (advisory)."
+
+      - name: Upload sweep logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: faultinject-logs
+          path: |
+            build_unix/fi_result.log
+            build_unix/fi_stderr.log
+          if-no-files-found: ignore

--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -214,6 +214,10 @@ DTRACE_PROVIDER=	$(distdir)/db_provider.d
 # ADDITIONAL_OBJS by configure only when --enable-dst.  Compile rules below.
 SIM_OBJS=	sim_core@o@ sim_os_hooks@o@
 
+# Malloc-failure injection state -- added to the library's ADDITIONAL_OBJS
+# by configure only when --enable-faultinject.  Compile rule below.
+FI_OBJS=	fi_alloc@o@
+
 BTREE_OBJS=\
 	bt_compare@o@ bt_compress@o@ bt_conv@o@ bt_curadj@o@ bt_cursor@o@ \
 	bt_delete@o@ bt_method@o@ bt_open@o@ bt_put@o@ bt_rec@o@ \
@@ -1516,6 +1520,24 @@ test_sim_torn: test_sim_torn@o@ $(DEF_LIB)
 	$(POSTLINK) $@
 
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn
+
+##################################################
+# Malloc-failure injection (SQLite-style) -- test/faultinject/.
+#
+# fi_alloc.c is added to the library's ADDITIONAL_OBJS by configure when
+# --enable-faultinject; its compile rule lives here.  `make fi_tests`
+# builds the sweep driver; requires --enable-faultinject.
+##################################################
+fi_alloc@o@: $(testdir)/faultinject/fi_alloc.c
+	$(CC) $(CFLAGS) $(DEPFLAGS) -I$(testdir)/faultinject $<
+
+fi_sweep@o@: $(testdir)/faultinject/fi_sweep.c
+	$(CC) $(CFLAGS) $(DEPFLAGS) -I$(testdir)/faultinject $<
+fi_sweep: fi_sweep@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ $(LDFLAGS) fi_sweep@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+fi_tests: fi_sweep
 
 ##################################################
 # Targets for example programs.

--- a/dist/aclocal/options.m4
+++ b/dist/aclocal/options.m4
@@ -202,6 +202,13 @@ AC_ARG_ENABLE(dst,
 	[db_cv_dst="$enable_dst"], [db_cv_dst="no"])
 AC_MSG_RESULT($db_cv_dst)
 
+AC_MSG_CHECKING(if --enable-faultinject option specified)
+AC_ARG_ENABLE(faultinject,
+	[AS_HELP_STRING([--enable-faultinject],
+			[Build with SQLite-style malloc-failure injection hooks at the __os_* allocation seam.])],
+	[db_cv_faultinject="$enable_faultinject"], [db_cv_faultinject="no"])
+AC_MSG_RESULT($db_cv_faultinject)
+
 AC_MSG_CHECKING(if --enable-dump185 option specified)
 AC_ARG_ENABLE(dump185,
 	[AS_HELP_STRING([--enable-dump185],

--- a/dist/config.hin
+++ b/dist/config.hin
@@ -132,6 +132,9 @@
 /* Define to 1 if platform has EXIT_SUCCESS/EXIT_FAILURE #defines. */
 #undef HAVE_EXIT_SUCCESS
 
+/* Define to 1 to build with SQLite-style malloc-failure injection hooks. */
+#undef HAVE_FAULT_INJECT
+
 /* Define to 1 if you have the 'fchmod' function. */
 #undef HAVE_FCHMOD
 

--- a/dist/configure
+++ b/dist/configure
@@ -871,6 +871,7 @@ enable_debug_rop
 enable_debug_wop
 enable_diagnostic
 enable_dst
+enable_faultinject
 enable_dump185
 enable_java
 enable_mingw
@@ -1577,6 +1578,8 @@ Optional Features:
   --enable-diagnostic     Build a version with run-time diagnostics.
   --enable-dst            Build with Deterministic Simulation Testing (DST)
                           fault-injection hooks.
+  --enable-faultinject    Build with SQLite-style malloc-failure injection
+                          hooks at the __os_* allocation seam.
   --enable-dump185        Build db_dump185(1) to dump 1.85 databases.
   --enable-java           Build Java API.
   --enable-mingw          Build Berkeley DB for MinGW.
@@ -3945,6 +3948,20 @@ fi
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $db_cv_dst" >&5
 printf '%s\n' "$db_cv_dst" >&6; }
 
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking if --enable-faultinject option specified" >&5
+printf %s "checking if --enable-faultinject option specified... " >&6; }
+# Check whether --enable-faultinject was given.
+if test ${enable_faultinject+y}
+then :
+  enableval=$enable_faultinject; db_cv_faultinject="$enable_faultinject"
+else case e in #(
+  e) db_cv_faultinject="no" ;;
+esac
+fi
+
+{ printf '%s\n' "$as_me:${as_lineno-$LINENO}: result: $db_cv_faultinject" >&5
+printf '%s\n' "$db_cv_faultinject" >&6; }
+
 { printf '%s\n' "$as_me:${as_lineno-$LINENO}: checking if --enable-dump185 option specified" >&5
 printf %s "checking if --enable-dump185 option specified... " >&6; }
 # Check whether --enable-dump185 was given.
@@ -4555,6 +4572,19 @@ if test "$db_cv_dst" = "yes"; then
 
 	ADDITIONAL_OBJS="$ADDITIONAL_OBJS \$(SIM_OBJS)"
 	CPPFLAGS="$CPPFLAGS -I\$(topdir)/test/sim"
+fi
+
+# Malloc-failure injection (SQLite-style): compile the fault-injection
+# state into the library and enable the guarded __os_* allocation hook.
+# Additive and faultinject-scoped: when off (the default) HAVE_FAULT_INJECT
+# is undefined, the hook vanishes, fi_alloc.c is not built, and a
+# production build is bit-for-bit the stock library.
+if test "$db_cv_faultinject" = "yes"; then
+	printf '%s\n' "#define HAVE_FAULT_INJECT 1" >>confdefs.h
+
+
+	ADDITIONAL_OBJS="$ADDITIONAL_OBJS \$(FI_OBJS)"
+	CPPFLAGS="$CPPFLAGS -I\$(topdir)/test/faultinject"
 fi
 if test "$db_cv_debug_rop" = "yes"; then
 	printf '%s\n' "#define DEBUG_ROP 1" >>confdefs.h
@@ -20362,7 +20392,7 @@ else case e in #(
 JAVA_TEST=Test.java
 CLASS_TEST=Test.class
 cat << \EOF > $JAVA_TEST
-/* #line 20365 "configure" */
+/* #line 20395 "configure" */
 public class Test {
 }
 EOF
@@ -20657,7 +20687,7 @@ EOF
 if uudecode$EXEEXT Test.uue; then
         ac_cv_prog_uudecode_base64=yes
 else
-        echo "configure: 20660: uudecode had trouble decoding base 64 file 'Test.uue'" >&5
+        echo "configure: 20690: uudecode had trouble decoding base 64 file 'Test.uue'" >&5
         echo "configure: failed file was:" >&5
         cat Test.uue >&5
         ac_cv_prog_uudecode_base64=no
@@ -20789,7 +20819,7 @@ else case e in #(
 JAVA_TEST=Test.java
 CLASS_TEST=Test.class
 cat << \EOF > $JAVA_TEST
-/* #line 20792 "configure" */
+/* #line 20822 "configure" */
 public class Test {
 }
 EOF
@@ -20826,7 +20856,7 @@ JAVA_TEST=Test.java
 CLASS_TEST=Test.class
 TEST=Test
 cat << \EOF > $JAVA_TEST
-/* [#]line 20829 "configure" */
+/* [#]line 20859 "configure" */
 public class Test {
 public static void main (String args[]) {
         System.exit (0);

--- a/dist/configure.ac
+++ b/dist/configure.ac
@@ -147,6 +147,19 @@ if test "$db_cv_dst" = "yes"; then
 	ADDITIONAL_OBJS="$ADDITIONAL_OBJS \$(SIM_OBJS)"
 	CPPFLAGS="$CPPFLAGS -I\$(topdir)/test/sim"
 fi
+
+# Malloc-failure injection (SQLite-style): compile the fault-injection
+# state into the library and enable the guarded __os_* allocation hook.
+# Additive and faultinject-scoped: when off (the default) HAVE_FAULT_INJECT
+# is undefined, the hook vanishes, fi_alloc.c is not built, and a
+# production build is bit-for-bit the stock library.
+if test "$db_cv_faultinject" = "yes"; then
+	AC_DEFINE(HAVE_FAULT_INJECT)
+	AH_TEMPLATE(HAVE_FAULT_INJECT,
+    [Define to 1 to build with SQLite-style malloc-failure injection hooks.])
+	ADDITIONAL_OBJS="$ADDITIONAL_OBJS \$(FI_OBJS)"
+	CPPFLAGS="$CPPFLAGS -I\$(topdir)/test/faultinject"
+fi
 if test "$db_cv_debug_rop" = "yes"; then
 	AC_DEFINE(DEBUG_ROP)
 	AH_TEMPLATE(DEBUG_ROP,

--- a/src/os/os_alloc.c
+++ b/src/os/os_alloc.c
@@ -10,6 +10,21 @@
 
 #include "db_int.h"
 
+#ifdef HAVE_FAULT_INJECT
+#include "fi_alloc.h"		/* Malloc-failure injection (--enable-faultinject). */
+/*
+ * FI_FAIL() --
+ *	Consulted once per allocation from the __os_* seam.  Non-zero when
+ *	injection is armed and this is the allocation that should fail; the
+ *	caller then skips the real allocator and its existing OOM branch
+ *	runs exactly as for a real malloc() failure.  Compiles to constant
+ *	0 in production, so a stock build is bit-for-bit unchanged.
+ */
+#define	FI_FAIL()	__db_fi_fail()
+#else
+#define	FI_FAIL()	0
+#endif
+
 #ifdef DIAGNOSTIC
 static void __os_guard __P((ENV *));
 
@@ -62,7 +77,9 @@ __os_umalloc(env, size, storep)
 		++size;
 
 	if (dbenv == NULL || dbenv->db_malloc == NULL) {
-		if (DB_GLOBAL(j_malloc) != NULL)
+		if (FI_FAIL())
+			*(void **)storep = NULL;
+		else if (DB_GLOBAL(j_malloc) != NULL)
 			*(void **)storep = DB_GLOBAL(j_malloc)(size);
 		else
 			*(void **)storep = malloc(size);
@@ -81,7 +98,8 @@ __os_umalloc(env, size, storep)
 		return (0);
 	}
 
-	if ((*(void **)storep = dbenv->db_malloc(size)) == NULL) {
+	if ((*(void **)storep =
+	    FI_FAIL() ? NULL : dbenv->db_malloc(size)) == NULL) {
 		__db_errx(env, DB_STR("0144",
 		    "user-specified malloc function returned NULL"));
 		return (ENOMEM);
@@ -119,7 +137,9 @@ __os_urealloc(env, size, storep)
 		if (ptr == NULL)
 			return (__os_umalloc(env, size, storep));
 
-		if (DB_GLOBAL(j_realloc) != NULL)
+		if (FI_FAIL())
+			*(void **)storep = NULL;
+		else if (DB_GLOBAL(j_realloc) != NULL)
 			*(void **)storep = DB_GLOBAL(j_realloc)(ptr, size);
 		else
 			*(void **)storep = realloc(ptr, size);
@@ -138,7 +158,8 @@ __os_urealloc(env, size, storep)
 		return (0);
 	}
 
-	if ((*(void **)storep = dbenv->db_realloc(ptr, size)) == NULL) {
+	if ((*(void **)storep =
+	    FI_FAIL() ? NULL : dbenv->db_realloc(ptr, size)) == NULL) {
 		__db_errx(env, DB_STR("0146",
 		    "User-specified realloc function returned NULL"));
 		return (ENOMEM);
@@ -249,7 +270,9 @@ __os_malloc(env, size, storep)
 	size += sizeof(db_allocinfo_t) + 1;
 #endif
 
-	if (DB_GLOBAL(j_malloc) != NULL)
+	if (FI_FAIL())
+		p = NULL;
+	else if (DB_GLOBAL(j_malloc) != NULL)
 		p = DB_GLOBAL(j_malloc)(size);
 	else
 		p = malloc(size);
@@ -333,7 +356,9 @@ __os_realloc(env, size, storep)
 	 * Don't overwrite the original pointer, there are places in DB we
 	 * try to continue after realloc fails.
 	 */
-	if (DB_GLOBAL(j_realloc) != NULL)
+	if (FI_FAIL())
+		p = NULL;
+	else if (DB_GLOBAL(j_realloc) != NULL)
 		p = DB_GLOBAL(j_realloc)(ptr, size);
 	else
 		p = realloc(ptr, size);

--- a/test/faultinject/README.md
+++ b/test/faultinject/README.md
@@ -1,0 +1,183 @@
+# Malloc-failure injection (SQLite-style) for libdb
+
+SQLite's most powerful correctness technique is to **fail the Nth memory
+allocation**, sweep N across a workload, and assert at *every* failure point
+that the library returns a clean error, leaks nothing, holds no lock, and
+leaves no corruption. libdb routes essentially all allocation through one
+seam — `__os_malloc` / `__os_calloc` / `__os_realloc` / `__os_umalloc` /
+`__os_urealloc` in `src/os/os_alloc.c` — so a single injection point covers
+the library. This is the dynamic complement to the Coccinelle `malloc-leak` /
+`mutex-unbalanced` static rules (Tier B1 of `.agents/test-suite-maturity-plan.md`).
+
+## What's here
+
+| File | Role |
+|------|------|
+| `fi_alloc.h` / `fi_alloc.c` | The injection hook + runtime knobs. Compiled into the library only under `--enable-faultinject`; absent from production. |
+| `fi_sweep.c` | The driver: measure baseline allocation count M, then sweep K = 1..M failing the Kth allocation, classifying each run. |
+
+The hook lives behind `HAVE_FAULT_INJECT`. When off (the default), the
+`FI_FAIL()` calls in `os_alloc.c` expand to constant `0`, fold away at
+compile time, and a stock build is **bit-for-bit unchanged and zero-overhead**.
+Even in an `--enable-faultinject` build, injection is inactive until armed, so
+the library behaves like stock until a sweep arms it.
+
+## Build
+
+From a fresh `build_unix` (autotools) in the nix dev shell:
+
+```sh
+cd build_unix
+../dist/configure --enable-debug --enable-faultinject
+make -j4          # builds libdb with the hook compiled in
+make fi_tests     # builds ./fi_sweep
+```
+
+`--enable-faultinject` was added to `dist/aclocal/options.m4` +
+`dist/configure.ac`; `dist/configure` is regenerated via `dist/s_config`.
+It does **not** require `--enable-tcl` (unlike `--enable-test`).
+
+## Run the sweep
+
+```sh
+./libtool --mode=execute ./fi_sweep            # full sweep, K = 1..M
+./libtool --mode=execute ./fi_sweep 100        # cap at K = 1..100
+FI_MAXK=100 ./libtool --mode=execute ./fi_sweep  # same, via env
+```
+
+The driver:
+
+1. **Phase 1 (baseline):** run the workload with injection OFF to count the
+   total allocations `M` (a transactional `DB_PRIVATE` env + a btree AND a
+   hash DB, put/get, a cursor walk, a committed txn, an aborted txn, a
+   checkpoint).
+2. **Phase 2 (sweep):** for `K = 1..M`, run the SAME workload with "fail the
+   Kth allocation." Each K runs in a **forked, watchdogged child** so a
+   crash/hang/leak in one failure point can't wedge the sweep.
+
+## Interpret the results
+
+Each K's child is classified:
+
+| Class | Meaning |
+|-------|---------|
+| **clean/tolerated (OK)** | Workload finished; the OOM was beyond this run's alloc count or was tolerated. |
+| **clean error return** | The injected OOM surfaced as a non-zero error AND the env re-opened cleanly under `DB_RECOVER` afterwards. The good OOM case. |
+| **CRASH** | The child died by signal (segfault/abort): a NULL-deref or use-after-free on the OOM return path. **A real bug.** |
+| **HANG (lock leak?)** | The per-run watchdog fired: an operation blocked, almost always a lock held on the OOM return path (the #47 class). **A real bug.** |
+| **DIRTY teardown/state** | The failure left the env un-reopenable even with recovery. **A real bug.** |
+
+The process exits non-zero iff any run crashed, hung, or left dirty.
+
+## Reproduce a specific failure point
+
+```sh
+# In-process single run for K, easy to attach a debugger / ASan to:
+DB_FI_FAIL_AT=<K> DB_FI_VERBOSE=1 ./libtool --mode=execute ./fi_sweep --one
+
+# Under gdb (point LD_LIBRARY_PATH at the built lib):
+export LD_LIBRARY_PATH="$PWD/.libs:$LD_LIBRARY_PATH"
+DB_FI_FAIL_AT=<K> gdb -ex 'run --one' -ex bt .libs/fi_sweep
+
+# Under ASan (build a second tree with -fsanitize=address), catches
+# heap-UAF / leaks a plain segfault check misses:
+DB_FI_FAIL_AT=<K> ./.libs/fi_sweep --one
+```
+
+Runtime knobs (read lazily on the first allocation, so setting them before any
+libdb call arms the sweep):
+
+- `DB_FI_FAIL_AT=<K>` — fail the Kth allocation (K ≥ 1; 0/unset = inactive).
+- `DB_FI_VERBOSE=1` — trace each fired failure to stderr.
+- `FI_TIMEOUT_SEC=<n>` — per-run watchdog seconds (default 20).
+- `FI_MAXK=<n>` — cap the sweep.
+
+The in-process API (`fi_alloc.h`) — `__db_fi_arm(K)`, `__db_fi_disarm()`,
+`__db_fi_reset()`, `__db_fi_count()`, `__db_fi_fired()` — is what the driver
+uses to sweep without rebuilding.
+
+## Measured results (this branch, 2026-07-27)
+
+Workload baseline: **M = 506 allocations.**
+
+| Metric | Count |
+|--------|------:|
+| Failure points exercised (K = 1..506) | 506 |
+| Clean error return (OOM → error, env re-openable) | 467 |
+| Clean/tolerated | 31 |
+| **CRASH** | **8** |
+| HANG | 0 |
+| DIRTY | 0 |
+
+The 467 clean-error paths are the good news: the vast majority of OOM sites
+return a clean error and leave a recoverable environment (many print a `PANIC`
+to stderr and return an error — that is BDB's *defined* in-region-OOM
+behavior, not a crash). The 8 crashes are **real pre-existing bugs** on OOM
+return paths, listed below.
+
+## Bugs found (report only — NOT fixed in this PR)
+
+Per the task, this PR is the harness; engine bugs are for the maintainer to
+fix separately. Four distinct root causes, all NULL-deref / use-after-free on
+allocation-failure paths — exactly the #47 class the Coccinelle static rules
+target statically and this sweep confirms dynamically.
+
+### Bug 1 — NULL-deref in `db_env_create` OOM teardown (K=2)
+`src/rep/rep_method.c:95` (`__rep_env_destroy`), via
+`src/env/env_method.c:105,123`.
+
+In `db_env_create`, alloc #1 is the `DB_ENV`, alloc #2 is the `ENV`. When the
+`ENV` alloc fails (`env_method.c:87`), `dbenv->env` is still NULL and the
+`err:` path calls `__db_env_destroy(dbenv)` → `__rep_env_destroy(dbenv)`, which
+does `env = dbenv->env; if (env->rep_handle != NULL)` → dereferences NULL.
+Fix shape: guard `__rep_env_destroy` (and siblings) on `dbenv->env == NULL`.
+
+Repro: `DB_FI_FAIL_AT=2 ./fi_sweep --one`
+
+### Bug 2 — NULL-deref in `__lock_getlocker_int` shared-region OOM (K=212, 214, 220, 353, 359)
+`src/lock/lock_id.c:349`.
+
+When the free-locker list is empty and `__env_alloc` (shared-region alloc) can
+never satisfy the request, the `while (__env_alloc(...) != 0) if ((nlockers >> 1) == 0) break;`
+loop breaks with `nlockers` still ≥ 1 and `sh_locker` still NULL, then the
+`for (i = 0; i < nlockers; i++) SH_TAILQ_INSERT_HEAD(..., sh_locker, ...)`
+loop dereferences the NULL `sh_locker`. The `if (nlockers == 0)` nomem check
+comes *after* the deref and never fires. Reached via `__txn_begin_int` and
+`__db_open`/`__fop_file_setup`'s `__lock_id`.
+Fix shape: on the `break`, set `nlockers = 0` (or bail to `__lock_nomem`)
+*before* the insert loop.
+
+Repro: `DB_FI_FAIL_AT=212 ./fi_sweep --one`
+
+### Bug 3 — NULL-deref in `__db_pgin` with a NULL pgin cookie (K=375, 376)
+`src/db/db_conv.c:76`, via `__memp_pg`/`__memp_pgread`/`__memp_fget` ←
+`__ham_get_meta` ← `__ham_open`.
+
+`__db_pgin` does `pginfo = (DB_PGINFO *)cookie->data;` with `cookie == NULL` —
+the pgin cookie / DB_PGINFO allocation failed upstream (in the hash-open page
+read setup) but the page-in proceeds and dereferences the NULL cookie.
+Fix shape: propagate the upstream alloc failure so `__db_pgin` is never called
+with a NULL cookie (or guard it).
+
+Repro: `DB_FI_FAIL_AT=375 ./fi_sweep --one`
+
+### Bug 4 — heap-use-after-free in txn/lock OOM cleanup (K≈213, 215, 216; ASan-only)
+`src/lock/lock_id.c:507` (`__lock_freelocker_int` → `__os_atomic_read`), via
+`src/txn/txn.c:1854` (`__txn_end`) ← `__txn_abort`.
+
+When `__txn_begin_int` partially fails under OOM (locker allocated at
+`txn.c:423`), the abort path's `__txn_end` frees the locker once (`txn.c:1816`)
+and then calls `__lock_freelocker` again at `txn.c:1854` on the already-freed
+locker, whose `__os_atomic_read` reads freed memory. A double-cleanup on the
+transaction OOM path. Caught by the ASan build; the plain-debug build
+tolerates the adjacent reads and instead segfaults at the nearby K in Bug 2.
+Fix shape: null out / de-link the locker after the first free so `__txn_end`
+does not free it twice.
+
+Repro (ASan build): `DB_FI_FAIL_AT=213 ./.libs/fi_sweep --one`
+
+## CI
+
+`.github/workflows/faultinject.yml` runs the plain-debug sweep as the primary
+signal plus a bounded ASan one-shot pass, both `continue-on-error: true`
+(advisory) until the bugs above are fixed. See the workflow header for detail.

--- a/test/faultinject/fi_alloc.c
+++ b/test/faultinject/fi_alloc.c
@@ -1,0 +1,112 @@
+/*-
+ * SQLite-style malloc-failure injection for libdb.
+ *
+ * fi_alloc.c --
+ *	Process-global allocation fault-injection state.  Compiled into the
+ *	library ONLY under --enable-faultinject (HAVE_FAULT_INJECT); absent
+ *	from a production build.  See fi_alloc.h for the model.
+ *
+ *	The state is a single process-global counter plus an armed target.
+ *	__db_fi_fail() is called once per allocation from the __os_* seam:
+ *	it increments the counter and, if the counter reaches the armed K,
+ *	returns 1 exactly once per run so the caller returns NULL/ENOMEM
+ *	just as a real OOM would.
+ */
+
+#include "db_config.h"
+#include "db_int.h"
+
+#include "fi_alloc.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+
+/*
+ * ponytail: process-global, single-threaded sweep. The driver runs a
+ * DB_PRIVATE single-process workload, so plain (non-atomic) globals are
+ * fine and keep the hook a couple of instructions. If a future
+ * multi-threaded sweep needs it, make fi_count atomic and key the arm
+ * per-thread.
+ */
+static long fi_count = 0;	/* allocations seen since last reset/arm */
+static long fi_fail_at = 0;	/* fail this allocation number; 0 = disarmed */
+static int  fi_fired = 0;	/* the armed failure has fired this run */
+static int  fi_env_checked = 0;	/* DB_FI_FAIL_AT consulted yet? */
+static int  fi_verbose = 0;	/* DB_FI_VERBOSE: trace fired failures */
+
+/*
+ * fi_check_env --
+ *	Lazily honor DB_FI_FAIL_AT / DB_FI_VERBOSE on the first allocation,
+ *	so setting the env var before running any libdb code arms the
+ *	sweep without an API call.  An explicit __db_fi_arm() overrides it.
+ */
+static void
+fi_check_env()
+{
+	char *p;
+
+	fi_env_checked = 1;
+	if ((p = getenv("DB_FI_VERBOSE")) != NULL && atoi(p) != 0)
+		fi_verbose = 1;
+	if (fi_fail_at == 0 &&
+	    (p = getenv("DB_FI_FAIL_AT")) != NULL) {
+		long k = atol(p);
+		if (k > 0)
+			fi_fail_at = k;
+	}
+}
+
+int
+__db_fi_fail()
+{
+	if (!fi_env_checked)
+		fi_check_env();
+
+	++fi_count;
+
+	if (fi_fail_at != 0 && !fi_fired && fi_count == fi_fail_at) {
+		fi_fired = 1;
+		if (fi_verbose)
+			fprintf(stderr,
+			    "fi: injecting OOM at allocation #%ld\n",
+			    fi_count);
+		return (1);
+	}
+	return (0);
+}
+
+void
+__db_fi_arm(k)
+	long k;
+{
+	fi_env_checked = 1;	/* explicit arm overrides the env var */
+	fi_count = 0;
+	fi_fired = 0;
+	fi_fail_at = k > 0 ? k : 0;
+}
+
+void
+__db_fi_disarm()
+{
+	fi_fail_at = 0;
+	fi_fired = 0;
+}
+
+void
+__db_fi_reset()
+{
+	fi_count = 0;
+	fi_fired = 0;
+}
+
+long
+__db_fi_count()
+{
+	return (fi_count);
+}
+
+int
+__db_fi_fired()
+{
+	return (fi_fired);
+}

--- a/test/faultinject/fi_alloc.h
+++ b/test/faultinject/fi_alloc.h
@@ -1,0 +1,71 @@
+/*-
+ * SQLite-style malloc-failure injection for libdb.
+ *
+ * fi_alloc.h --
+ *	The allocation fault-injection hook the __os_malloc/__os_calloc/
+ *	__os_realloc/__os_umalloc/__os_urealloc seam calls.  Declares one
+ *	predicate, __db_fi_fail(), plus the runtime knobs a test uses to
+ *	sweep the failing allocation over a workload.
+ *
+ *	SQLite's most powerful correctness technique: fail the Nth memory
+ *	allocation, sweep N across a workload, and assert at EVERY failure
+ *	point that the library returns a clean error, leaks nothing, holds
+ *	no lock and leaves no corruption.  BDB routes essentially all
+ *	allocation through the __os_* seam, so a single injection point
+ *	covers the library.
+ *
+ *	Compilation model (mirrors the DST hooks in test/sim/):
+ *	  - HAVE_FAULT_INJECT OFF (production / default): this header is
+ *	    never included and os_alloc.c's hook calls vanish, so a stock
+ *	    build is bit-for-bit unchanged and zero-overhead.
+ *	  - HAVE_FAULT_INJECT ON (--enable-faultinject): fi_alloc.c is
+ *	    linked into the library.  Every allocation first consults
+ *	    __db_fi_fail(); when injection is inactive (the default even in
+ *	    a faultinject build) that is a single relaxed load returning 0,
+ *	    so an --enable-faultinject library not running a sweep behaves
+ *	    like stock.
+ *
+ *	Runtime control (so a test can sweep K without rebuilding):
+ *	  - Environment: DB_FI_FAIL_AT=<K> arms "fail the Kth allocation"
+ *	    at process start (read lazily on first allocation).  K<=0 means
+ *	    inactive.  DB_FI_VERBOSE=1 traces each fired failure to stderr.
+ *	  - API: __db_fi_arm(K)/__db_fi_disarm()/__db_fi_count()/
+ *	    __db_fi_fired() let a driver sweep in-process.
+ */
+
+#ifndef _DB_FI_ALLOC_H_
+#define _DB_FI_ALLOC_H_
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * __db_fi_fail --
+ *	Consulted once per allocation.  Returns non-zero (inject an OOM)
+ *	when injection is armed and this is the allocation that should
+ *	fail; else 0.  Also bumps the total-allocation counter used to
+ *	measure the workload's baseline M.
+ */
+int __db_fi_fail __P((void));
+
+/* Arm "fail the Kth allocation from now" (K>=1).  Resets counters. */
+void __db_fi_arm __P((long));
+
+/* Disarm injection; allocations always succeed.  Counter keeps counting. */
+void __db_fi_disarm __P((void));
+
+/* Reset the allocation counter to 0 (call before a measured workload). */
+void __db_fi_reset __P((void));
+
+/* Total successful+injected allocations seen since the last reset/arm. */
+long __db_fi_count __P((void));
+
+/* Non-zero once the armed failure has actually fired this run. */
+int __db_fi_fired __P((void));
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_FI_ALLOC_H_ */

--- a/test/faultinject/fi_sweep.c
+++ b/test/faultinject/fi_sweep.c
@@ -1,0 +1,446 @@
+/*-
+ * SQLite-style malloc-failure injection sweep for libdb.
+ *
+ * fi_sweep.c --
+ *	THE driver: run a representative libdb workload once with injection
+ *	OFF to measure the baseline allocation count M, then for K = 1..M
+ *	run the SAME workload with "fail the Kth allocation" and assert at
+ *	every failure point that the library:
+ *	  - returns a non-zero error (ENOMEM / a DB error) rather than
+ *	    crashing on the OOM return path;
+ *	  - lets the env be torn down cleanly afterwards;
+ *	  - holds NO mutex on the OOM path -- a hang here (a lock leaked on
+ *	    the error return, the #47 class of bug) is caught by a per-run
+ *	    watchdog timeout.
+ *
+ *	Each K runs in a forked child so a crash/abort/hang in one failure
+ *	point can't take down the sweep; the parent classifies the child's
+ *	exit (clean / expected-error / CRASH / HANG) and keeps going.  This
+ *	is the dynamic complement to the Coccinelle malloc-leak /
+ *	mutex-unbalanced static rules.
+ *
+ *	Build/run (from build_unix, after configure --enable-faultinject):
+ *	    make fi_tests && ./fi_sweep [maxK]
+ *	Reproduce one failure point:
+ *	    DB_FI_FAIL_AT=<K> DB_FI_VERBOSE=1 ./fi_sweep --one
+ *
+ *	Env knobs:
+ *	    FI_TIMEOUT_SEC   per-run watchdog (default 20s; hang -> HANG).
+ *	    FI_MAXK          cap the sweep (also positional argv[1]).
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "fi_alloc.h"
+
+#define HOME     "TESTDIR_fi_sweep"
+#define BTFILE   "fi_bt.db"
+#define HFILE    "fi_h.db"
+#define NREC     40
+
+/* Child exit codes the parent interprets. */
+#define EX_OK        0   /* workload completed with no injected failure   */
+#define EX_ERR       1   /* an operation returned an error, torn down OK  */
+#define EX_DIRTY     2   /* an error path could not tear the env down     */
+#define EX_BADSTATE  3   /* post-failure sanity/consistency check failed  */
+
+static int workload __P((int *));
+static int reopen_ok __P((void));
+static int run_child __P((long));
+static void cleanup __P((void));
+
+/*
+ * cleanup --
+ *	Remove the env home so each run starts clean.  Best-effort.
+ */
+static void
+cleanup()
+{
+	(void)system("rm -rf " HOME " >/dev/null 2>&1");
+	(void)mkdir(HOME, 0755);
+}
+
+/*
+ * workload --
+ *	A representative single-process DB_PRIVATE workload touching the
+ *	paths a real app hits: open a transactional env, a btree AND a
+ *	hash DB, put/get, a cursor walk, a committed txn and an aborted
+ *	txn, and a checkpoint.  Returns the first non-zero DB error it
+ *	sees (so an injected OOM surfaces as that op's error), or 0.
+ *
+ *	The point is NOT that every op succeeds under injection -- it is
+ *	that whichever op the injected OOM lands in returns cleanly and
+ *	everything can still be closed.  So we STOP at the first error and
+ *	tear down; the teardown itself is part of what we're testing.
+ *
+ *	*heldp is set non-zero while a lock/cursor/txn is outstanding, so
+ *	the caller can tell whether teardown had resources to release.
+ */
+static int
+workload(heldp)
+	int *heldp;
+{
+	DB_ENV *env = NULL;
+	DB *bt = NULL, *h = NULL;
+	DB_TXN *txn = NULL;
+	DBC *dbc = NULL;
+	DBT key, data;
+	int i, ret, t_ret;
+	char kbuf[32], vbuf[64];
+
+	*heldp = 0;
+
+	/* Env: private, transactional, in-memory-ish home on disk. */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	env->set_errpfx(env, "fi_sweep");
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_PRIVATE, 0)) != 0)
+		goto done;
+
+	/* --- Btree DB, committed transaction --- */
+	if ((ret = db_create(&bt, env, 0)) != 0)
+		goto done;
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	if ((ret = bt->open(bt, txn, BTFILE, NULL, DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		goto done;
+
+	for (i = 0; i < NREC; i++) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		(void)snprintf(kbuf, sizeof(kbuf), "bkey-%06d", i);
+		(void)snprintf(vbuf, sizeof(vbuf), "bval-%06d-payload", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = bt->put(bt, txn, &key, &data, 0)) != 0)
+			goto done;
+	}
+	ret = txn->commit(txn, 0);
+	txn = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
+
+	/* Get back a few of the records we committed. */
+	for (i = 0; i < 5; i++) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		(void)snprintf(kbuf, sizeof(kbuf), "bkey-%06d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if ((ret = bt->get(bt, NULL, &key, &data, 0)) != 0)
+			goto done;
+	}
+
+	/* Cursor walk of the btree. */
+	if ((ret = bt->cursor(bt, NULL, &dbc, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	while ((ret = dbc->get(dbc, &key, &data, DB_NEXT)) == 0)
+		;
+	if (ret == DB_NOTFOUND)
+		ret = 0;
+	{
+		int cret = dbc->close(dbc);
+		dbc = NULL;
+		*heldp = 0;
+		if (ret == 0)
+			ret = cret;
+	}
+	if (ret != 0)
+		goto done;
+
+	/* --- Hash DB, aborted transaction (exercise the abort path) --- */
+	if ((ret = db_create(&h, env, 0)) != 0)
+		goto done;
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	if ((ret = h->open(h, txn, HFILE, NULL, DB_HASH,
+	    DB_CREATE, 0664)) != 0)
+		goto done;
+	for (i = 0; i < NREC; i++) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		(void)snprintf(kbuf, sizeof(kbuf), "hkey-%06d", i);
+		(void)snprintf(vbuf, sizeof(vbuf), "hval-%06d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = h->put(h, txn, &key, &data, 0)) != 0)
+			goto done;
+	}
+	/* Abort -- the hash inserts must roll back cleanly even mid-OOM. */
+	ret = txn->abort(txn);
+	txn = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
+
+	/* Checkpoint the environment. */
+	ret = env->txn_checkpoint(env, 0, 0, 0);
+
+done:
+	/*
+	 * Teardown IS part of the test.  Release anything still held, in
+	 * the right order, and remember the FIRST real error -- but keep
+	 * going so a leaked handle can't wedge the process.  If teardown
+	 * itself fails (e.g. a close hits a still-held mutex), the caller
+	 * treats that as a dirty error path.
+	 */
+	if (dbc != NULL)
+		(void)dbc->close(dbc);
+	if (txn != NULL)
+		(void)txn->abort(txn);
+	if (h != NULL) {
+		if ((t_ret = h->close(h, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
+	if (bt != NULL) {
+		if ((t_ret = bt->close(bt, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
+	if (env != NULL) {
+		if ((t_ret = env->close(env, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
+	return (ret);
+}
+
+/*
+ * reopen_ok --
+ *	With injection DISARMED, open a fresh env on the same home and the
+ *	btree DB we created, do one get, and close.  Returns 0 iff the
+ *	environment left behind by a failed injection run is still usable.
+ *	A non-zero return means the OOM error path left the env in a state
+ *	it cannot recover from without external recovery -- a dirty path.
+ */
+static int
+reopen_ok()
+{
+	DB_ENV *env = NULL;
+	int ret, t_ret;
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	/* DB_RECOVER: a crashed/half-written env is expected to need it;
+	 * requiring recovery to succeed is the real "still consistent"
+	 * bar, not "opens with no recovery". */
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER |
+	    DB_PRIVATE, 0)) != 0)
+		goto done;
+done:
+	if (env != NULL) {
+		if ((t_ret = env->close(env, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
+	return (ret);
+}
+
+/*
+ * run_child --
+ *	Arm "fail the Kth allocation" (K==0 => baseline, no injection), run
+ *	the workload, and exit with a code the parent classifies.  Runs in
+ *	a forked child; a crash here becomes a signal the parent sees, and
+ *	the child's own alarm() turns a hung lock into SIGALRM.
+ *
+ *	Classification of a non-crash, non-hang injection run:
+ *	  EX_OK    the injected OOM did not change the outcome (K beyond
+ *	           this run's alloc count, or an allocation the workload
+ *	           tolerates): workload returned 0 and tore down clean.
+ *	  EX_ERR   the injected OOM surfaced as a clean non-zero error AND
+ *	           the env still tore down cleanly -- the good OOM case.
+ *	  EX_DIRTY workload reported an error but a consistency re-check
+ *	           after teardown failed, i.e. the failure left the env
+ *	           un-reopenable / a resource stuck.  This is where a
+ *	           lock leaked on the OOM return path (the #47 class)
+ *	           shows up if it makes close fail rather than hang.
+ */
+static int
+run_child(k)
+	long k;
+{
+	int ret, held, recheck;
+
+	cleanup();
+	if (k > 0)
+		__db_fi_arm(k);
+	else
+		__db_fi_reset();
+
+	ret = workload(&held);
+
+	if (k == 0)
+		return (ret == 0 ? EX_OK : EX_BADSTATE);
+
+	if (ret == 0)
+		return (EX_OK);		/* OOM tolerated / not reached. */
+
+	/*
+	 * The workload reported an error (from the injected OOM or its
+	 * teardown).  Confirm the failure left a re-openable environment:
+	 * with injection now DISARMED, a fresh env open+close on the same
+	 * home must succeed.  If it can't (a stuck region, a leaked lock
+	 * that blocks reopen, on-disk corruption), that is a dirty error
+	 * path -- exactly what this sweep exists to catch.
+	 */
+	__db_fi_disarm();
+	recheck = reopen_ok();
+	return (recheck == 0 ? EX_ERR : EX_DIRTY);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	long k, maxk, M;
+	int held, ret, status, one_shot;
+	const char *p;
+	int n_fired, n_error, n_ok, n_crash, n_hang, n_dirty;
+	int timeout_sec;
+	pid_t pid;
+
+	one_shot = 0;
+	if (argc > 1 && strcmp(argv[1], "--one") == 0)
+		one_shot = 1;
+
+	timeout_sec = (p = getenv("FI_TIMEOUT_SEC")) != NULL ?
+	    atoi(p) : 20;
+	if (timeout_sec <= 0)
+		timeout_sec = 20;
+
+	/*
+	 * One-shot mode: honor DB_FI_FAIL_AT from the environment (armed
+	 * lazily inside the library) and run a single workload in-process
+	 * so it's easy to run under a debugger / ASan for a specific K.
+	 */
+	if (one_shot) {
+		cleanup();
+		ret = workload(&held);
+		printf("fi: one-shot: DB_FI_FAIL_AT=%s -> ret=%d (%s), "
+		    "allocs=%ld, fired=%d\n",
+		    getenv("DB_FI_FAIL_AT") ? getenv("DB_FI_FAIL_AT") : "(unset)",
+		    ret, ret == 0 ? "clean" : db_strerror(ret),
+		    __db_fi_count(), __db_fi_fired());
+		return (0);
+	}
+
+	/* --- Phase 1: baseline, injection OFF, measure M in-process. --- */
+	__db_fi_disarm();
+	__db_fi_reset();
+	cleanup();
+	ret = workload(&held);
+	M = __db_fi_count();
+	if (ret != 0) {
+		fprintf(stderr,
+		    "fi: FATAL: baseline workload failed with no injection: "
+		    "ret=%d (%s)\n", ret, db_strerror(ret));
+		return (2);
+	}
+	printf("fi: baseline allocation count M = %ld "
+	    "(clean run, no injection)\n", M);
+
+	maxk = M;
+	if ((p = getenv("FI_MAXK")) != NULL && atol(p) > 0 && atol(p) < maxk)
+		maxk = atol(p);
+	if (argc > 1 && !one_shot && atol(argv[1]) > 0 && atol(argv[1]) < maxk)
+		maxk = atol(argv[1]);
+
+	printf("fi: sweeping K = 1..%ld (per-run watchdog %ds)\n",
+	    maxk, timeout_sec);
+
+	/* --- Phase 2: sweep K, one forked+watchdogged child per K. --- */
+	n_fired = n_error = n_ok = n_crash = n_hang = n_dirty = 0;
+	for (k = 1; k <= maxk; k++) {
+		fflush(stdout);
+		fflush(stderr);
+		if ((pid = fork()) < 0) {
+			perror("fork");
+			return (2);
+		}
+		if (pid == 0) {
+			/* Child: watchdog itself so a hung mutex -> SIGALRM. */
+			alarm((unsigned)timeout_sec);
+			_exit(run_child(k));
+		}
+
+		/* Parent: wait for the child; the child's own alarm() turns
+		 * a hang into SIGALRM, which we see as a signal exit. */
+		if (waitpid(pid, &status, 0) < 0) {
+			perror("waitpid");
+			return (2);
+		}
+
+		if (WIFSIGNALED(status)) {
+			int sig = WTERMSIG(status);
+			if (sig == SIGALRM) {
+				n_hang++;
+				printf("fi: K=%ld HANG (watchdog; likely a "
+				    "lock held on the OOM return path)\n", k);
+			} else {
+				n_crash++;
+				printf("fi: K=%ld CRASH (signal %d: %s)\n",
+				    k, sig, strsignal(sig));
+			}
+			continue;
+		}
+		if (!WIFEXITED(status)) {
+			n_crash++;
+			printf("fi: K=%ld CRASH (abnormal exit)\n", k);
+			continue;
+		}
+		switch (WEXITSTATUS(status)) {
+		case EX_OK:      n_ok++;    break;
+		case EX_ERR:     n_error++; break;
+		case EX_DIRTY:
+			n_dirty++;
+			printf("fi: K=%ld DIRTY (error path could not tear "
+			    "down the env cleanly)\n", k);
+			break;
+		case EX_BADSTATE:
+			n_dirty++;
+			printf("fi: K=%ld BADSTATE (post-failure consistency "
+			    "check failed)\n", k);
+			break;
+		default:
+			n_crash++;
+			printf("fi: K=%ld CRASH (unexpected exit %d)\n",
+			    k, WEXITSTATUS(status));
+			break;
+		}
+	}
+
+	printf("\nfi: sweep complete over K=1..%ld\n", maxk);
+	printf("fi:   baseline allocations M   = %ld\n", M);
+	printf("fi:   failure points exercised = %ld\n", maxk);
+	printf("fi:   clean/tolerated (OK)     = %d\n", n_ok);
+	printf("fi:   clean error return       = %d\n", n_error);
+	printf("fi:   CRASH                    = %d\n", n_crash);
+	printf("fi:   HANG (lock leak?)        = %d\n", n_hang);
+	printf("fi:   DIRTY teardown/state     = %d\n", n_dirty);
+
+	/* Fail the process iff any run crashed, hung, or left dirty. */
+	if (n_crash != 0 || n_hang != 0 || n_dirty != 0) {
+		printf("\nfi: RESULT: FAIL -- %d crash, %d hang, %d dirty. "
+		    "Reproduce a point with: "
+		    "DB_FI_FAIL_AT=<K> DB_FI_VERBOSE=1 ./fi_sweep --one\n",
+		    n_crash, n_hang, n_dirty);
+		return (1);
+	}
+	printf("\nfi: RESULT: PASS -- every failure point returned cleanly, "
+	    "held no lock, tore down cleanly.\n");
+	return (0);
+}


### PR DESCRIPTION
## What

SQLite-style **malloc-failure injection**: fail the Nth allocation at libdb's single allocation seam (`__os_malloc`/`__os_calloc`/`__os_realloc`/`__os_umalloc`/`__os_urealloc`), sweep N across a representative workload, and assert at **every** failure point that the library returns a clean error, holds no lock, and leaves a re-openable environment. Tier B1 of `.agents/test-suite-maturity-plan.md` — the dynamic complement to the Coccinelle `malloc-leak` / `mutex-unbalanced` static rules, and the class of test that would have caught the #47 mutex leaks.

This PR is the **harness only**. It found real pre-existing OOM-path bugs (below); per the task those are for the maintainer to fix separately.

## How

- **Hook** (`src/os/os_alloc.c` + `test/faultinject/fi_alloc.{h,c}`), behind a new `--enable-faultinject` build option. Zero-overhead in production: when `HAVE_FAULT_INJECT` is undefined, `FI_FAIL()` is constant `0` and folds away — the stock library is bit-for-bit unchanged (verified). A process-global "fail after K allocations" countdown, armed at runtime via `DB_FI_FAIL_AT`/`DB_FI_VERBOSE` env vars or the `__db_fi_arm/disarm/reset/count/fired` API, so a test sweeps K without rebuilding. Mirrors the existing DST fault seam (`--enable-dst`).
- **Driver** (`test/faultinject/fi_sweep.c`): measures baseline allocation count M with injection off, then for K=1..M runs the same workload (transactional `DB_PRIVATE` env + btree AND hash DB, put/get, cursor walk, committed txn, aborted txn, checkpoint) failing the Kth allocation. Each K runs in a **forked, watchdogged child**; the parent classifies clean / clean-error / **CRASH** / **HANG** (lock leak) / **DIRTY** and fails iff any run crashed/hung/left dirty.
- **CI** (`.github/workflows/faultinject.yml`, new file — does not touch ci.yml): plain-debug sweep as the gate signal + a bounded ASan one-shot pass for heap-UAF/leaks. `continue-on-error: true` (advisory) until the bugs below are fixed.
- `dist/configure` regenerated via `dist/s_config` (autoconf 2.73).

## Measured results (M = 506 allocations)

| Metric | Count |
|--------|------:|
| Failure points exercised (K = 1..506) | 506 |
| Clean error return (OOM → error, env re-openable) | 467 |
| Clean/tolerated | 31 |
| **CRASH** | **8** |
| HANG | 0 |
| DIRTY | 0 |

467 OOM sites return a clean error and leave a recoverable env. The 8 crashes are 4 distinct real bugs.

## Bugs found (report only — NOT fixed here)

1. **NULL-deref in `db_env_create` OOM teardown** (K=2) — `src/rep/rep_method.c:95` via `src/env/env_method.c:105,123`. When the `ENV` alloc fails, `dbenv->env` is NULL and `__db_env_destroy` → `__rep_env_destroy` does `env->rep_handle` on a NULL `env`. Repro: `DB_FI_FAIL_AT=2 ./fi_sweep --one`.
2. **NULL-deref in `__lock_getlocker_int` shared-region OOM** (K=212,214,220,353,359) — `src/lock/lock_id.c:349`. The `while (__env_alloc(...)) if ((nlockers>>1)==0) break;` loop breaks with `nlockers>=1` and `sh_locker` still NULL, then the insert loop dereferences the NULL `sh_locker`; the `if (nlockers==0)` nomem check comes too late. Repro: `DB_FI_FAIL_AT=212 ./fi_sweep --one`.
3. **NULL-deref in `__db_pgin` with a NULL pgin cookie** (K=375,376) — `src/db/db_conv.c:76` via `__ham_get_meta`/`__ham_open`. `pginfo = cookie->data` with `cookie==NULL` after an upstream alloc failure. Repro: `DB_FI_FAIL_AT=375 ./fi_sweep --one`.
4. **heap-use-after-free in txn/lock OOM cleanup** (K≈213,215,216; ASan-only) — `src/lock/lock_id.c:507` via `src/txn/txn.c:1854` (`__txn_end` ← `__txn_abort`). `__txn_end` frees the locker (txn.c:1816) then calls `__lock_freelocker` again at txn.c:1854 on the freed locker. Repro (ASan): `DB_FI_FAIL_AT=213 ./.libs/fi_sweep --one`.

Full detail, build/run/reproduce instructions in `test/faultinject/README.md`.