### PR TITLE
test(coverage): gcov/lcov branch-coverage measurement in CI (Tier B3)

### DIFF
--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -1,0 +1,142 @@
+# Code coverage (Tier B3)
+
+SQLite's testing ethic is **100% MC/DC branch coverage**. libdb is nowhere near
+that yet — but per Tier B3 of `.agents/test-suite-maturity-plan.md` the point is
+to **measure** branch coverage now, aim new DST/PBT/unit tests at the uncovered
+branches, and ratchet the number upward over time. This directory holds the
+measurement machinery.
+
+## What it does
+
+`run_coverage.sh` builds libdb with gcov instrumentation
+(`CFLAGS="-O0 -g --coverage"`, `LDFLAGS="--coverage"`), runs a bounded,
+representative subset of the Tcl regression suite, then aggregates with `lcov`
+into a line + branch coverage summary, an HTML report, and a ranked
+least-covered-files list.
+
+## Run it locally
+
+```sh
+# from the repo root, inside the nix dev shell (has gcc/gcov/tclsh; pulls lcov
+# via `nix run nixpkgs#lcov` automatically):
+nix develop --command test/coverage/run_coverage.sh
+
+# or, outside nix, with lcov + tcl installed from your distro:
+test/coverage/run_coverage.sh
+```
+
+Knobs (all optional env vars):
+
+| Var          | Default                                   | Meaning                          |
+|--------------|-------------------------------------------|----------------------------------|
+| `COV_TESTS`  | `lock001: txn001: test001:btree ssi001: ssi002: recd001:btree` | `test:arg` pairs to run |
+| `COV_JOBS`   | `nproc`                                   | build parallelism                |
+| `TCL_LIB`    | autodetected (nix store or `/usr/lib/tcl8.6`) | Tcl lib dir for `--with-tcl` |
+| `COV_TIMEOUT`| `2400`                                    | seconds ceiling for the test run |
+
+Outputs land in `build_unix/` (gitignored):
+
+- `coverage-summary.txt` — the line/branch/function totals
+- `coverage-html/index.html` — the browsable report
+- `coverage-src.info` — the raw lcov data (src/ only)
+
+## Reading the HTML report
+
+Open `build_unix/coverage-html/index.html`. lcov colours each source line:
+**blue = executed**, **red = never executed**. Branch coverage is shown per
+line (e.g. `+`/`-` markers and a `taken` count) — a line can be 100% line-covered
+but 50% branch-covered if only the true side of an `if` ever ran. **Branch
+coverage is the number that matters** for the SQLite ethic: it's what tells you
+a conditional's false path is untested.
+
+Directory drill-down: the index lists per-directory then per-file rates; click
+into `src/btree/`, `src/lock/`, etc. to find red regions.
+
+## Finding the least-covered files (where to aim next)
+
+`run_coverage.sh` prints this at the end, or run it directly:
+
+```sh
+python3 test/coverage/rank_coverage.py build_unix/coverage-src.info | head -20
+```
+
+It ranks src files (>= 50 lines) by ascending line coverage, largest first — so
+the top of the list is the biggest untested surface. Point new DST scenarios
+(Tier A3), PBT generators (Tier B4), or unit tests at those files, then re-run
+and watch the number climb.
+
+## The ratchet
+
+`baseline.txt` holds the last-known good `line=` and `branch=` percentages. The
+`Coverage` CI workflow (`coverage.yml.workflow`, see below) warns (advisory,
+never gates) if branch coverage drops more than 0.5% below the baseline. When
+you land tests that raise coverage, update `baseline.txt` — ratchet **up**,
+never down.
+
+## CI
+
+`test/coverage/coverage.yml.workflow` is the GitHub Actions workflow. It runs
+nightly (cron) and on `workflow_dispatch`, is **not** on every PR (coverage
+builds are slow), and is `continue-on-error: true` (advisory). It uploads
+`coverage-html/` as a build artifact and prints the summary + ratchet result in
+the job log.
+
+> **Install note:** it is committed here as `coverage.yml.workflow`, *not* at
+> `.github/workflows/coverage.yml`, because agent OAuth tokens lack the
+> `workflow` scope and cannot push files under `.github/workflows/` (same
+> constraint that landed pbt.yml/cocci.yml via a separate SSH push — see commit
+> `6224220`). A maintainer installs it with:
+> ```sh
+> git mv test/coverage/coverage.yml.workflow .github/workflows/coverage.yml
+> ```
+> then pushes over SSH.
+
+---
+
+## Measured baseline (2026-07-27)
+
+`CC=gcc`, `--coverage`, src/-only, subset
+`lock001 txn001 test001:btree ssi001 ssi002 recd001:btree`
+(278 source files, ~72.7k lines, ~78.2k branches):
+
+| Metric    | Coverage                    |
+|-----------|-----------------------------|
+| **Lines** | **18.6%** (13534 / 72681)   |
+| **Branches** | **12.3%** (9631 / 78233) |
+| Functions | 25.6% (712 / 2781)          |
+
+This subset exercises the transaction/lock/btree/SSI/recovery core. The full
+Tcl suite (`run_std`) and the PBT/DST tiers would raise these substantially —
+the nightly job can widen `COV_TESTS` toward that. The point is the *floor is
+now measured* and every future test can be aimed at a specific red file below.
+
+## Top 15 least-covered source files (aim tests here next)
+
+Entirely-untested subsystems in this subset — the biggest actionable gaps
+(the recovery-critical and access-method files near the top are the highest
+leverage for DST scenarios):
+
+| line% | br% | lines | branches | file | subsystem |
+|------:|----:|------:|---------:|------|-----------|
+| 0.0 | 0.0 | 1769 | 1565 | `log/log_verify_int.c` | log verification |
+| 0.0 | 0.0 | 1397 | 1702 | `btree/bt_compact.c` | btree compaction |
+| 0.0 | 0.0 | 1385 | 1590 | `hash/hash_page.c` | hash access method |
+| 0.0 | 0.0 | 1307 | 1838 | `heap/heap.c` | heap access method |
+| 0.0 | 0.0 | 1089 | 933 | `hash/hash.c` | hash access method |
+| 0.0 | 0.0 | 1064 | 1619 | `rep/rep_record.c` | replication |
+| 0.0 | 0.0 | 1017 | 644 | `log/log_verify_util.c` | log verification |
+| 0.0 | 0.0 | 923 | 942 | `rep/rep_util.c` | replication |
+| 0.0 | 0.0 | 883 | 620 | `db/partition.c` | partitioning |
+| 0.0 | 0.0 | 864 | 540 | `repmgr/repmgr_sel.c` | replication manager |
+| 0.0 | 0.0 | 842 | 1129 | `qam/qam.c` | queue access method |
+| 0.0 | 0.0 | 836 | 2069 | `hash/hash_rec.c` | hash recovery records |
+| 0.0 | 0.0 | 704 | 556 | `repmgr/repmgr_net.c` | replication manager |
+| 0.0 | 0.0 | 701 | 556 | `repmgr/repmgr_msg.c` | replication manager |
+| 0.0 | 0.0 | 556 | 656 | `rep/rep_elect.c` | replication elections |
+
+Grouped by subsystem, the biggest untested surfaces are **replication /
+repmgr** (`rep_*`, `repmgr_*`), the **hash** and **heap** and **queue** access
+methods (only btree is exercised by `test001:btree`), **log/db verification**
+(`log_verify_*`, `db_vrfy.c`, `bt_verify.c`), **btree compaction**, and
+**partitioning**. Adding a hash/queue/heap variant of the access-method tests
+and a replication smoke test to `COV_TESTS` would move the needle most.

--- a/test/coverage/baseline.txt
+++ b/test/coverage/baseline.txt
@@ -1,0 +1,6 @@
+# libdb coverage baseline (Tier B3, .agents/test-suite-maturity-plan.md).
+# src/-only, gcov/lcov, representative test subset (see test/coverage/README.md).
+# The Coverage workflow warns (advisory) if branch coverage drops >0.5% below this.
+# Update after landing new tests that raise coverage (ratchet upward, never down).
+line=18.6
+branch=12.3

--- a/test/coverage/coverage.yml.workflow
+++ b/test/coverage/coverage.yml.workflow
@@ -1,0 +1,97 @@
+# Code coverage (gcov/lcov) -- advisory measurement tier.
+#
+# SQLite's ethic is 100% MC/DC branch coverage. We are nowhere near that, but
+# Tier B3 of .agents/test-suite-maturity-plan.md says: MEASURE branch coverage,
+# then aim new DST/PBT/unit tests at the uncovered branches, and ratchet the
+# number upward. This workflow does the measuring.
+#
+# Coverage builds are slow (instrumented -O0 build + test run), so this does
+# NOT run on every PR: nightly (cron) + on-demand (workflow_dispatch) only.
+# Dedicated workflow -- does NOT touch ci.yml. Advisory (continue-on-error):
+# it informs and warns on regressions but never gates a merge.
+
+name: Coverage
+
+on:
+  schedule:
+    # Nightly at 05:41 UTC, staggered after ci.yml (03:17) and ci-extended (04:23).
+    - cron: '41 5 * * *'
+  workflow_dispatch:
+    inputs:
+      tests:
+        description: 'Space-separated "test:arg" pairs (blank = default subset)'
+        type: string
+        default: ''
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  coverage:
+    name: gcov/lcov branch coverage
+    runs-on: ubuntu-latest
+    continue-on-error: true   # advisory tier
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install toolchain (gcc, gcov, lcov, tcl)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc lcov tcl-dev tcl python3
+
+      - name: Build with coverage + run test subset + aggregate
+        id: cov
+        env:
+          # gcov must match the compiler; run_coverage.sh forces CC=gcc.
+          TCL_LIB: /usr/lib/tcl8.6
+          COV_TESTS: ${{ github.event.inputs.tests }}
+        run: |
+          # Empty COV_TESTS => script uses its built-in representative subset.
+          [ -z "$COV_TESTS" ] && unset COV_TESTS
+          test/coverage/run_coverage.sh | tee /tmp/cov.out
+          # Surface the summary as a job notice.
+          summary=$(grep -E 'lines|branches|functions' build_unix/coverage-summary.txt | tr '\n' ' ')
+          echo "::notice title=Coverage (src/)::$summary"
+          # Extract the branch % (e.g. "12.3%") for the ratchet.
+          br=$(grep -E 'branches' build_unix/coverage-summary.txt \
+               | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
+          ln=$(grep -E 'lines' build_unix/coverage-summary.txt \
+               | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
+          echo "branch=$br" >> "$GITHUB_OUTPUT"
+          echo "line=$ln" >> "$GITHUB_OUTPUT"
+
+      - name: Ratchet (advisory) -- warn if branch coverage dropped
+        run: |
+          base_file=test/coverage/baseline.txt
+          br="${{ steps.cov.outputs.branch }}"
+          ln="${{ steps.cov.outputs.line }}"
+          if [ -f "$base_file" ]; then
+            base_br=$(grep -E '^branch=' "$base_file" | cut -d= -f2)
+            base_ln=$(grep -E '^line=' "$base_file" | cut -d= -f2)
+            echo "baseline: line=${base_ln}% branch=${base_br}%  now: line=${ln}% branch=${br}%"
+            # bc may be absent; use awk for the float compare.
+            drop=$(awk -v a="$br" -v b="$base_br" 'BEGIN{print (a+0 < b-0.5) ? 1 : 0}')
+            if [ "$drop" = "1" ]; then
+              echo "::warning title=Coverage ratchet::branch coverage dropped ${base_br}% -> ${br}% (advisory)"
+            else
+              echo "::notice title=Coverage ratchet::branch coverage ${br}% >= baseline ${base_br}% (ok)"
+            fi
+          else
+            echo "::notice title=Coverage ratchet::no baseline file yet; current branch=${br}% line=${ln}%"
+          fi
+          echo "To update the committed baseline: put 'line=${ln}' and 'branch=${br}' in $base_file"
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html
+          path: |
+            build_unix/coverage-html/
+            build_unix/coverage-summary.txt
+          if-no-files-found: warn

--- a/test/coverage/rank_coverage.py
+++ b/test/coverage/rank_coverage.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Rank libdb source files by coverage from an lcov .info file.
+
+Prints the least-covered files first (lowest line %, then largest), so future
+DST/PBT/unit test work can aim at the biggest uncovered surfaces. Files under
+50 lines are skipped as noise. This is the actionable output of Tier B3
+(coverage in CI) in .agents/test-suite-maturity-plan.md.
+
+Usage: rank_coverage.py <coverage.info> [min_lines]
+"""
+import sys
+
+def parse(path):
+    files, cur = {}, None
+    for ln in open(path):
+        ln = ln.rstrip()
+        if ln.startswith("SF:"):
+            cur = ln[3:]
+            files[cur] = {"la": 0, "lh": 0, "ba": 0, "bh": 0}
+        elif ln.startswith("DA:") and cur:
+            cnt = ln[3:].rsplit(",", 1)[1]
+            files[cur]["la"] += 1
+            files[cur]["lh"] += (cnt != "0")
+        elif ln.startswith("BRDA:") and cur:
+            taken = ln.split(",")[-1]
+            files[cur]["ba"] += 1
+            files[cur]["bh"] += (taken not in ("-", "0"))
+    return files
+
+def main():
+    if len(sys.argv) < 2:
+        sys.exit("usage: rank_coverage.py <coverage.info> [min_lines]")
+    min_lines = int(sys.argv[2]) if len(sys.argv) > 2 else 50
+    rows = []
+    for f, d in parse(sys.argv[1]).items():
+        if d["la"] < min_lines:
+            continue
+        lr = 100.0 * d["lh"] / d["la"] if d["la"] else 0.0
+        br = 100.0 * d["bh"] / d["ba"] if d["ba"] else 0.0
+        short = f.split("/src/", 1)[-1] if "/src/" in f else f.split("/")[-1]
+        rows.append((lr, br, d["la"], d["lh"], d["ba"], d["bh"], short))
+    rows.sort(key=lambda r: (r[0], -r[2]))  # lowest line%, then biggest file
+    print(f"{'line%':>6} {'br%':>6} {'lines':>6} {'lhit':>5} {'branch':>7} {'bhit':>5}  file")
+    for lr, br, la, lh, ba, bh, short in rows:
+        print(f"{lr:6.1f} {br:6.1f} {la:6d} {lh:5d} {ba:7d} {bh:5d}  {short}")
+
+if __name__ == "__main__":
+    try:
+        main()
+    except BrokenPipeError:
+        # allow `... | head` to close the pipe without a traceback
+        try:
+            sys.stdout.close()
+        except BrokenPipeError:
+            pass

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+#
+# run_coverage.sh -- build libdb with gcov instrumentation, run a bounded
+# representative test subset, and report line + branch coverage (SQLite-style:
+# measure branch coverage, then aim new tests at the gaps).
+#
+# See test/coverage/README.md for how to read the report and find the
+# least-covered files. Tier B3 of .agents/test-suite-maturity-plan.md.
+#
+# Usage:
+#   test/coverage/run_coverage.sh              # subset build + report
+#   COV_TESTS="lock001 txn001" test/coverage/run_coverage.sh   # custom tests
+#   COV_JOBS=4 test/coverage/run_coverage.sh   # limit build parallelism
+#
+# Requires: gcc, gcov (matching gcc), lcov + genhtml, tclsh. In the nix dev
+# shell gcov comes from gcc; lcov/genhtml are pulled via `nix run nixpkgs#lcov`
+# automatically if not on PATH. On CI (ubuntu) install `lcov` from apt.
+#
+# Everything lands in build_unix/ (gitignored build tree); the HTML report is
+# written to build_unix/coverage-html/ and a text summary to
+# build_unix/coverage-summary.txt.
+
+set -euo pipefail
+
+# --- locate the repo (this script lives in test/coverage/) -------------------
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+bld="$root/build_unix"
+
+# --- config ------------------------------------------------------------------
+# Bounded, representative subset: lock/txn/basic-access + SSI + one access
+# method + a recovery test. Runs in a few minutes, exercises the core engine.
+# Format: "test arg" pairs (arg blank for tests that take none).
+: "${COV_TESTS:=lock001: txn001: test001:btree ssi001: ssi002: recd001:btree}"
+: "${COV_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
+: "${TCLSH:=tclsh}"
+# TCL lib dir: nix store on this box, /usr/lib/tcl8.6 on ubuntu CI.
+: "${TCL_LIB:=}"
+if [ -z "$TCL_LIB" ]; then
+  for d in /nix/store/*tcl-8.6*/lib /usr/lib/tcl8.6 /usr/lib; do
+    [ -d "$d" ] && { TCL_LIB="$d"; break; }
+  done
+fi
+
+# gcov MUST match the compiler that built the .gcno files. We force CC=gcc
+# (BDB's configure otherwise picks `cc`, which in the nix shell is clang and
+# emits LLVM-format .gcda that gcc's gcov cannot read -- the "B11 vs B52"
+# version mismatch). gcov ships alongside gcc.
+export CC=gcc
+GCOV="${GCOV:-gcov}"
+
+# lcov/genhtml: prefer PATH, else pull via nix (dev shell has neither on PATH).
+LCOV=lcov
+GENHTML=genhtml
+if ! command -v lcov >/dev/null 2>&1; then
+  if command -v nix >/dev/null 2>&1; then
+    LCOV_BIN="$(nix build nixpkgs#lcov --no-link --print-out-paths 2>/dev/null)/bin"
+    LCOV="$LCOV_BIN/lcov"
+    GENHTML="$LCOV_BIN/genhtml"
+  else
+    echo "error: lcov not found on PATH and nix unavailable; install lcov" >&2
+    exit 1
+  fi
+fi
+
+# lcov error classes we tolerate: version (LLVM/gcc tag noise), source/mismatch
+# (generated headers), inconsistent (gcov line/branch quirks), empty/unused.
+IGN="mismatch,source,gcov,unused,negative,empty,inconsistent,version"
+
+echo "== libdb coverage =="
+echo "  repo:    $root"
+echo "  CC:      $CC ($($CC -dumpversion 2>/dev/null || echo '?'))"
+echo "  gcov:    $GCOV ($($GCOV --version 2>/dev/null | head -1))"
+echo "  tcl lib: $TCL_LIB"
+echo "  tests:   $COV_TESTS"
+echo
+
+# --- clean any prior coverage artifacts (idempotent) -------------------------
+find "$bld" \( -name '*.gcda' -o -name '*.gcno' \) -delete 2>/dev/null || true
+rm -f "$bld/coverage.info" "$bld/coverage-src.info" 2>/dev/null || true
+
+# --- configure + build with instrumentation ---------------------------------
+echo "== configure (--coverage) =="
+cd "$bld"
+CC=gcc ../dist/configure --enable-test --with-tcl="$TCL_LIB" \
+  CFLAGS="-O0 -g --coverage" LDFLAGS="--coverage" >/tmp/cov-configure.log 2>&1 \
+  || { echo "configure failed:"; tail -30 /tmp/cov-configure.log; exit 1; }
+
+echo "== build (-j$COV_JOBS) =="
+make -j"$COV_JOBS" >/tmp/cov-build.log 2>&1 \
+  || { echo "build failed:"; tail -40 /tmp/cov-build.log; exit 1; }
+echo "  .gcno files: $(find . -name '*.gcno' | wc -l)"
+
+# --- run the test subset (produces .gcda) ------------------------------------
+echo "== run tests =="
+runtcl="$bld/.cov-run.tcl"
+{
+  echo 'source ../test/tcl/test.tcl'
+  for pair in $COV_TESTS; do
+    t="${pair%%:*}"; a="${pair#*:}"
+    printf 'source ../test/tcl/%s.tcl\n' "$t"
+    printf 'if {[catch {eval %s %s} res]} { puts "FAIL %s: $res"; exit 1 }\n' "$t" "$a" "$t"
+    printf 'puts "PASS %s"\n' "$t"
+  done
+} > "$runtcl"
+# tclsh8.6 preferred if present (nix); fall back to tclsh.
+TCLBIN="$TCLSH"; command -v tclsh8.6 >/dev/null 2>&1 && TCLBIN=tclsh8.6
+timeout "${COV_TIMEOUT:-2400}" "$TCLBIN" "$runtcl" 2>&1 | tee /tmp/cov-tests.log \
+  | grep -E '^PASS|^FAIL' || true
+rm -f "$runtcl"
+if grep -q '^FAIL' /tmp/cov-tests.log; then
+  echo "warning: a test FAILED; coverage still aggregated below" >&2
+fi
+echo "  .gcda files: $(find . -name '*.gcda' | wc -l)"
+
+# --- aggregate ---------------------------------------------------------------
+echo "== capture (lcov) =="
+"$LCOV" --capture --directory . --output-file coverage.info \
+  --gcov-tool "$GCOV" --rc geninfo_unexecuted_blocks=1 --branch-coverage \
+  --ignore-errors "$IGN" >/tmp/cov-lcov.log 2>&1 \
+  || { echo "lcov capture failed:"; tail -20 /tmp/cov-lcov.log; exit 1; }
+
+# Keep only the library sources under src/ (drop tcl harness, examples, system).
+"$LCOV" --extract coverage.info "*/src/*" --output-file coverage-src.info \
+  --branch-coverage --ignore-errors "$IGN" >/dev/null 2>&1
+
+echo "== summary =="
+"$LCOV" --summary coverage-src.info --branch-coverage --ignore-errors "$IGN" 2>&1 \
+  | grep -E 'source files|lines|functions|branches' | tee coverage-summary.txt
+
+# --- HTML report -------------------------------------------------------------
+echo "== genhtml =="
+rm -rf coverage-html
+"$GENHTML" coverage-src.info --output-directory coverage-html --branch-coverage \
+  --ignore-errors "empty,inconsistent,source,category,unmapped" >/tmp/cov-genhtml.log 2>&1 \
+  && echo "  report: $bld/coverage-html/index.html" \
+  || { echo "genhtml failed:"; tail -10 /tmp/cov-genhtml.log; }
+
+# --- least-covered files (the actionable list) -------------------------------
+echo
+echo "== least-covered src files (>=50 lines) -- aim new tests here =="
+"${PYTHON:-python3}" "$here/rank_coverage.py" coverage-src.info | head -20
+echo
+echo "Done. See test/coverage/README.md for how to read the report."


### PR DESCRIPTION
## Tier B3: coverage measurement (SQLite-style)

SQLite's ethic is 100% MC/DC branch coverage. libdb is far from that — the point
of this PR is to **start measuring** branch coverage so we can target uncovered
branches and ratchet the number upward (Tier B3, `.agents/test-suite-maturity-plan.md`).

### What's here
- **`test/coverage/run_coverage.sh`** — builds libdb with `--coverage`
  instrumentation, runs a bounded representative Tcl subset, aggregates with
  lcov, emits an HTML report + line/branch summary, and prints the ranked
  least-covered files. Auto-pulls lcov via `nix run nixpkgs#lcov` if it isn't on
  PATH. Forces `CC=gcc` (the nix shell's default `cc` is clang, whose
  LLVM-format `.gcda` gcc's gcov can't read — the "B11 vs B52" mismatch).
- **`test/coverage/rank_coverage.py`** — parses the lcov `.info` and lists the
  biggest untested source files.
- **`test/coverage/coverage.yml.workflow`** — nightly + `workflow_dispatch`
  Coverage workflow (does **not** touch ci.yml; not per-PR; `continue-on-error`
  advisory). Uploads the HTML report as an artifact, prints the summary, and
  warns (never gates) if branch coverage drops >0.5% below baseline.
  Committed as `.workflow` because agent OAuth lacks the `workflow` scope
  (same as pbt.yml/cocci.yml, commit 6224220) — a maintainer installs it over SSH.
- **`test/coverage/baseline.txt`** — the measured floor for the ratchet.
- **`test/coverage/README.md`** — how to run, read the report, find gaps.

### Measured baseline (verified in the nix dev shell)
`CC=gcc`, `--coverage`, src/-only, subset `lock001 txn001 test001:btree ssi001 ssi002 recd001:btree`
(278 source files, ~72.7k lines, ~78.2k branches):

| Metric | Coverage |
|---|---|
| **Lines** | **18.6%** (13534 / 72681) |
| **Branches** | **12.3%** (9631 / 78233) |
| Functions | 25.6% (712 / 2781) |

### Top least-covered subsystems (where to aim next)
Entirely untested by this core subset — the actionable gap list:
**replication/repmgr** (`rep_*`, `repmgr_*`), the **hash / heap / queue** access
methods (only btree is exercised), **log/db verification** (`log_verify_*`,
`db_vrfy.c`, `bt_verify.c`), **btree compaction** (`bt_compact.c`), and
**partitioning** (`partition.c`). Full top-15 table in the README.

### Notes
- No build artifacts committed (`build_unix/**` is gitignored; `.gcda`/`.gcno`/HTML cleaned up).
- Does not touch ci.yml, ci-extended.yml, or any other workflow.
