### PR TITLE
fix(mpool): reject zero pagesize on a real file (SIGFPE on corrupt meta-page)

### DIFF
--- a/src/mp/mp_fopen.c
+++ b/src/mp/mp_fopen.c
@@ -395,6 +395,18 @@ mvcc_err:				__db_errx(env, DB_STR("3041",
 		 * Pagesize of 0 is only allowed for in-mem dbs.
 		 */
 		DB_ASSERT(env, pagesize != 0);
+		/*
+		 * A real file with a zero pagesize (a corrupt or hostile
+		 * meta-page) would divide by zero below; DB_ASSERT is compiled
+		 * out of production builds, so reject it with a hard check too.
+		 */
+		if (pagesize == 0) {
+			__db_errx(env, DB_STR_A("3037",
+		    "%s: file size not a multiple of the pagesize", "%s"),
+			    rpath);
+			ret = EINVAL;
+			goto err;
+		}
 		if (bytes % pagesize != 0) {
 			if (LF_ISSET(DB_ODDFILESIZE))
 				bytes -= (u_int32_t)(bytes % pagesize);


### PR DESCRIPTION
Found by the `fuzz_dbfile` libFuzzer harness (PR #51). Opening a malformed file whose meta-page reports pagesize 0 reaches `bytes % pagesize` in `__memp_fopen` → **SIGFPE** (divide by zero). The existing `DB_ASSERT(pagesize != 0)` only guards `--enable-diagnostic` builds; production crashes.

Fix: hard runtime EINVAL check for a zero pagesize on a real (non-in-memory) file.

**Verified:** the fuzz reproducer (`test/fuzz/crashes/dbfile_fpe_memp_fopen.seed`) now returns cleanly instead of SIGFPE; `test001 btree/hash` + `memp001` + `test003` pass (valid pagesizes unaffected).

This is the malformed/hostile-file threat model (distinct from the OOM fixes in #52). The related `__db_retcopy` OOB read (#51's other finding — a corrupt page-item length trusted by a cursor scan) needs the broader page-item bounds-validation hardening track and is tracked separately in `.agents/fuzz-found-bugs.md`.

Found by / depends on #51 (fuzz harnesses).