### PR TITLE
DST depth: write-back crash model, 3 caught planted bugs, 14 scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@ build_unix/**
 compile_commands.json
 test/tcl/tclIndex
 
+# DST scenario scratch env dirs (created by test_sim_* wherever they run)
+TESTDIR_sim_*/
+test/sim/TESTDIR_sim_*/
+
 # Meson/Ninja out-of-tree build dirs
 build-meson/
 build/

--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1515,7 +1515,89 @@ test_sim_torn: test_sim_torn@o@ $(DEF_LIB)
 	$(CCLINK) -o $@ $(LDFLAGS) test_sim_torn@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
 	$(POSTLINK) $@
 
-dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn
+test_sim_hash_crash@o@: $(testdir)/sim/test_sim_hash_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_hash_crash: test_sim_hash_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_hash_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_recno_crash@o@: $(testdir)/sim/test_sim_recno_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_recno_crash: test_sim_recno_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_recno_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_queue_crash@o@: $(testdir)/sim/test_sim_queue_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_queue_crash: test_sim_queue_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_queue_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_ckp_crash@o@: $(testdir)/sim/test_sim_ckp_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_ckp_crash: test_sim_ckp_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_ckp_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_torn_log@o@: $(testdir)/sim/test_sim_torn_log.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_torn_log: test_sim_torn_log@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_torn_log@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_enospc@o@: $(testdir)/sim/test_sim_enospc.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_enospc: test_sim_enospc@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_enospc@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_abort_atomic@o@: $(testdir)/sim/test_sim_abort_atomic.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_abort_atomic: test_sim_abort_atomic@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_abort_atomic@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_recover_idempotent@o@: $(testdir)/sim/test_sim_recover_idempotent.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_recover_idempotent: test_sim_recover_idempotent@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_recover_idempotent@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_dup_crash@o@: $(testdir)/sim/test_sim_dup_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_dup_crash: test_sim_dup_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_dup_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_overflow_torn@o@: $(testdir)/sim/test_sim_overflow_torn.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_overflow_torn: test_sim_overflow_torn@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_overflow_torn@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_split_crash@o@: $(testdir)/sim/test_sim_split_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_split_crash: test_sim_split_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_split_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
+	test_sim_hash_crash test_sim_recno_crash test_sim_queue_crash \
+	test_sim_ckp_crash test_sim_torn_log test_sim_enospc \
+	test_sim_abort_atomic test_sim_recover_idempotent test_sim_dup_crash \
+	test_sim_overflow_torn test_sim_split_crash
 
 ##################################################
 # Targets for example programs.

--- a/src/hmac/hmac.c
+++ b/src/hmac/hmac.c
@@ -18,6 +18,10 @@
 #include "dbinc/hmac.h"
 #include "dbinc/log.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 #define	HMAC_OUTPUT_SIZE	20
 #define	HMAC_BLOCK_SIZE	64
 
@@ -219,5 +223,18 @@ __db_check_chksum(env, hdr, db_cipher, chksum, data, data_len, is_hmac)
 		ret = memcmp(chksum, new, sum_len) ? -1 : 0;
 	}
 
+#if defined(HAVE_DST)
+#if DB_DST_BUG(2)
+	/*
+	 * PLANTED BUG NOCKSUM (DB_DST_INJECT_BUG=2): ignore a checksum
+	 * mismatch and accept the page as valid.  A torn/corrupt page then
+	 * flows silently into the tree; test_sim_torn's "never silently
+	 * wrong" invariant fires (a get returns bytes that do not match what
+	 * was stored, with no error).  Compiled out of every normal build.
+	 */
+	if (ret == -1)
+		ret = 0;
+#endif
+#endif
 	return (ret);
 }

--- a/src/log/log_put.c
+++ b/src/log/log_put.c
@@ -16,6 +16,10 @@
 #include "dbinc/db_page.h"
 #include "dbinc_auto/db_ext.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 static int __log_encrypt_record __P((ENV *, DBT *, HDR *, u_int32_t));
 static int __log_file __P((ENV *, const DB_LSN *, char *, size_t));
 static int __log_fill __P((DB_LOG *, DB_LSN *, void *, u_int32_t));
@@ -1118,6 +1122,18 @@ flush:	MUTEX_LOCK(env, lp->mtx_flush);
 		LOG_SYSTEM_UNLOCK(env);
 
 	/* Sync all writes to disk. */
+#if defined(HAVE_DST)
+#if DB_DST_BUG(1)
+	/*
+	 * PLANTED BUG NODURABLE (DB_DST_INJECT_BUG=1): skip the log fsync
+	 * but still ack the commit as durable.  The write-back model's
+	 * durable frontier never advances past this record, so a crash
+	 * drops it -- and a commit the caller believes is durable is lost.
+	 * test_sim_crash_recover's "every committed txn survives" invariant
+	 * fires.  Compiled out of every normal build.
+	 */
+	ret = 0;
+#else
 	if ((ret = __os_fsync(env, dblp->lfhp)) != 0) {
 		MUTEX_UNLOCK(env, lp->mtx_flush);
 		if (release)
@@ -1125,6 +1141,16 @@ flush:	MUTEX_LOCK(env, lp->mtx_flush);
 		lp->in_flush--;
 		goto done;
 	}
+#endif
+#else
+	if ((ret = __os_fsync(env, dblp->lfhp)) != 0) {
+		MUTEX_UNLOCK(env, lp->mtx_flush);
+		if (release)
+			LOG_SYSTEM_LOCK(env);
+		lp->in_flush--;
+		goto done;
+	}
+#endif
 
 	/*
 	 * Set the last-synced LSN.

--- a/src/mp/mp_bh.c
+++ b/src/mp/mp_bh.c
@@ -15,6 +15,10 @@
 #include "dbinc/log.h"
 #include "dbinc/txn.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 static int __memp_pgwrite
 	       __P((ENV *, DB_MPOOLFILE *, DB_MPOOL_HASH *, BH *));
 
@@ -496,11 +500,33 @@ __memp_pgwrite(env, dbmfp, hp, bhp)
 	if (ret == 0 && do_io) {
 		PERFMON3(env, mpool, write, __memp_fn(dbmfp), bhp->pgno, bhp);
 		did_io = 1;
+#if defined(HAVE_DST)
+#if DB_DST_BUG(3)
+		/*
+		 * PLANTED BUG LOSTUPDATE (DB_DST_INJECT_BUG=3): skip the page
+		 * write but report success, so __memp_pgwrite_finish clears
+		 * BH_DIRTY as if the page reached disk.  A checkpoint then
+		 * believes this dirty page is durable when it is not; after a
+		 * crash, recovery trusts the checkpoint and the update is lost.
+		 * test_sim_ckp_crash's "post-checkpoint committed data survives"
+		 * invariant fires.  Compiled out of every normal build.
+		 */
+		nw = c.mfp->pagesize;
+		ret = 0;
+#else
 		if ((ret = __os_io(env, DB_IO_WRITE, dbmfp->fhp, bhp->pgno,
 		    c.mfp->pagesize, 0, c.mfp->pagesize, c.buf, &nw)) != 0)
 			__db_errx(env, DB_STR_A("3015",
 			    "%s: write failed for page %lu", "%s %lu"),
 			    __memp_fn(dbmfp), (u_long)bhp->pgno);
+#endif
+#else
+		if ((ret = __os_io(env, DB_IO_WRITE, dbmfp->fhp, bhp->pgno,
+		    c.mfp->pagesize, 0, c.mfp->pagesize, c.buf, &nw)) != 0)
+			__db_errx(env, DB_STR_A("3015",
+			    "%s: write failed for page %lu", "%s %lu"),
+			    __memp_fn(dbmfp), (u_long)bhp->pgno);
+#endif
 	}
 	return (__memp_pgwrite_finish(&c, did_io, ret));
 }

--- a/src/os/os_rw.c
+++ b/src/os/os_rw.c
@@ -91,9 +91,31 @@ __os_io(env, op, fhp, pgno, pgsize, relative, io_len, buf, niop)
 			    (u_long)offset);
 
 		LAST_PANIC_CHECK_BEFORE_IO(env);
+#ifdef HAVE_DST
+		{
+			/* DST write-side faults: ENOSPC (whole write fails,
+			 * nothing persists) or torn write (persist a strict
+			 * prefix but report full success -- a latent bad tail
+			 * a checksum must catch).  A no-op returning io_len
+			 * unless a sim armed the knobs. */
+			int persist = __db_sim_io_write_fault_hook(fhp, io_len);
+			if (persist < 0) {
+				*niop = 0;
+				return (ENOSPC);
+			}
+			nio = DB_GLOBAL(j_pwrite) != NULL ?
+			    DB_GLOBAL(j_pwrite)(fhp->fd, buf,
+				(size_t)persist, offset) :
+			    pwrite(fhp->fd, buf, (size_t)persist, offset);
+			/* Torn: a short physical write still reports full. */
+			if (nio == (ssize_t)persist && persist < (int)io_len)
+				nio = (ssize_t)io_len;
+		}
+#else
 		nio = DB_GLOBAL(j_pwrite) != NULL ?
 		    DB_GLOBAL(j_pwrite)(fhp->fd, buf, io_len, offset) :
 		    pwrite(fhp->fd, buf, io_len, offset);
+#endif
 		break;
 	default:
 		return (EINVAL);
@@ -101,15 +123,20 @@ __os_io(env, op, fhp, pgno, pgsize, relative, io_len, buf, niop)
 	if (nio == (ssize_t)io_len) {
 		*niop = io_len;
 #ifdef HAVE_DST
+		/* DST: consume the seeded per-I/O latency knob (tiny capped
+		 * sleep when armed; a no-op otherwise). */
+		__db_sim_io_latency_hook();
 		/* DST write-back model: record the written high-water for the
 		 * page-write fast path.  A no-op unless a sim armed it. */
 		if (op == DB_IO_WRITE)
 			__db_sim_io_write_off_hook(fhp,
 			    (u_int64_t)offset + io_len);
-		/* DST corrupt-read: silently flip a byte the checksum must
-		 * catch.  A no-op unless a sim armed the corrupt knob. */
+		/* DST corrupt/stale-read: silently flip a byte the checksum
+		 * must catch, or return a prior version.  A no-op unless a sim
+		 * armed the corrupt/stale knob. */
 		else if (op == DB_IO_READ)
-			__db_sim_io_read_hook(buf, io_len);
+			__db_sim_io_read_hook(fhp, (u_int64_t)offset,
+			    buf, io_len);
 #endif
 		return (0);
 	}

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -125,17 +125,30 @@ schedule):
 - **write-back cache crash model** — the ack-before-fsync durability catcher,
   below.
 
-**The write-back model (THE key to catching ack-before-fsync bugs).** The sim
-writes to a *real* file, so bytes reach the file on `pwrite` regardless of
-`fsync` — which means a naive crash test cannot catch a writer that ACKs a
-commit without fsyncing it. The model fixes this honestly:
+**The write-back model (THE key to catching ack-before-fsync bugs) — NOW FULLY
+WIRED.** The sim writes to a *real* file, so bytes reach the file on `pwrite`
+regardless of `fsync` — which means a naive crash test cannot catch a writer
+that ACKs a commit without fsyncing it. The model fixes this honestly:
 
 - a write records the **written high-water** offset for the file
-  (`__db_sim_io_wb_wrote`);
+  (`__db_sim_io_wb_wrote`) plus the file's on-disk **name**;
 - `fsync`/`fdatasync` promotes written → **durable** (`__db_sim_io_wb_synced`);
-- a crash loses everything past the last fsync;
-- a recovery test asks `__db_sim_io_durable_end(key)` for the true post-crash
-  durable frontier to truncate to, instead of trusting the writer.
+- at the crash boundary a scenario calls **`__db_sim_wb_crash()`**, which
+  `truncate()`s every tracked real file back to its durable frontier — so
+  bytes written but never fsync'd genuinely vanish, exactly as a disk loses
+  them on power loss;
+- recovery then runs against the truncated files, so a commit acked without
+  its log being fsync'd is **detectably lost**.
+
+This is what makes planted bug 1 (NODURABLE: `__log_flush_int` skips the log
+fsync) a hard catch: the durable frontier never advances, `wb_crash` truncates
+the un-synced tail, and every "committed" txn is lost after recovery.
+
+The write-side knobs are consumed now too: `__os_io`'s write fast path consults
+`__db_sim_io_write_fault_hook` (ENOSPC = whole write fails; torn = persist a
+strict prefix, report full). The read fast path consults
+`__db_sim_io_read_hook` (corrupt bit-flip + stale-read ring) and a per-I/O
+`__db_sim_io_latency_hook` (a tiny capped sleep when armed).
 
 Keyed by a **stable FNV-1a hash of the file name** (not the fd), so the
 frontier tracks a *logical* file across libdb's frequent close/reopen — exactly
@@ -164,9 +177,10 @@ case, and vanishes entirely when `HAVE_DST` is undefined.
 > hooked — on Linux with pread/pwrite the fast path always wins, so v1 is fully
 > covered there. `os_aio*` (the newer async buffer-pool I/O) is likewise not yet
 > hooked; the buffer pool's *synchronous* `__os_io` path (`mp_bh.c`) is, which is
-> what the pilots exercise. Torn-write and latency knobs exist but are only
-> consulted by the corrupt-read hook so far; wiring torn-write into the write
-> hook and latency into a v2 async path are §4 items.
+> what the scenarios exercise. The write-side ENOSPC/torn knobs, the read-side
+> corrupt/stale knobs, and the per-I/O latency knob are all consumed by the
+> `__os_io` fast path now; the stale-read ring is armable and consulted on read
+> but has no dedicated v1 scenario yet (a v1.x item).
 
 ### 1.6 The determinism-proof harness
 
@@ -186,8 +200,10 @@ replay of the same seed would fail.
   `dist/configure.ac`: `AC_DEFINE(HAVE_DST)`, append `$(SIM_OBJS)` to
   `ADDITIONAL_OBJS`, and add `-I$(topdir)/test/sim` to `CPPFLAGS`.
   `dist/Makefile.in` defines `SIM_OBJS = sim_core@o@ sim_os_hooks@o@`, their
-  compile rules, and a `dst_tests` target (`test_sim_rng`,
-  `test_sim_crash_recover`, `test_sim_torn`). `DSTBUG=<n>` plants bug n.
+  compile rules, and a `dst_tests` target (all fourteen `test_sim_*`).
+  `DSTBUG=<n>` plants a TEST-side bug n; a LIBRARY-site planted bug is built by
+  configuring with `CFLAGS="-DDB_DST_INJECT_BUG=<n>"` (a dedicated build tree),
+  which `test/sim/dst-bug-inject.sh` automates.
   All additions are additive and DST-scoped so they merge cleanly alongside the
   concurrent PBT work.
 
@@ -210,49 +226,72 @@ replay of the same seed would fail.
 
 ---
 
-## 3. Pilot scenarios (runnable now)
+## 3. Scenarios (all runnable now, all PASS)
 
-| Pilot | Proves | Result |
+Fourteen scenarios; the crash/fault ones each pass across a multi-seed sweep and
+replay bit-identically per seed.
+
+| Scenario | Proves | Result |
 |---|---|---|
 | `test_sim_rng` | seeded PRNG determinism, seed-sensitivity, stream independence, guard | PASS |
-| `test_sim_crash_recover` | **capstone**: N durable txns survive a mid-txn crash; uncommitted txn does not; DB verifies clean **after recovery** | PASS (64 txns; deterministic across seeds; replays) |
-| `test_sim_torn` | corrupt reads are caught by DB_CHKSUM or invisible — **never silently wrong** | PASS (e.g. 297 correct / 103 detected / 0 silent-bad) |
+| `test_sim_crash_recover` | **capstone**: N durable txns survive a mid-txn crash via the write-back drop; uncommitted does not; DB verifies clean **after recovery** | PASS (64 txns; 30/30 seed sweep) |
+| `test_sim_torn` | corrupt reads caught by DB_CHKSUM or invisible — **never silently wrong** | PASS (e.g. 297 correct / 103 detected / 0 silent-bad) |
+| `test_sim_hash_crash` | DB_HASH op+crash+recover | PASS (64 committed survive) |
+| `test_sim_recno_crash` | DB_RECNO append+crash+recover | PASS (64 appends survive) |
+| `test_sim_queue_crash` | DB_QUEUE enqueue+crash+recover | PASS (64 enqueues survive) |
+| `test_sim_ckp_crash` | page-flush durability across crash (no log) | PASS (200 flushed survive; catches LOSTUPDATE) |
+| `test_sim_torn_log` | recovery safe past a torn log tail; durable prefix intact | PASS (32 durable commits present) |
+| `test_sim_enospc` | ENOSPC graceful degradation, no corruption | PASS (all observed-committed durable) |
+| `test_sim_abort_atomic` | committed present + aborted leave no trace after crash | PASS (deterministic commit/abort split) |
+| `test_sim_recover_idempotent` | recover twice → identical full-state hash | PASS |
+| `test_sim_dup_crash` | DB_DUPSORT dups survive crash with exact multiplicity | PASS (24 keys x 8 dups) |
+| `test_sim_overflow_torn` | overflow (>page) records: corrupt read caught, never silently wrong | PASS |
+| `test_sim_split_crash` | btree split/merge churn survives crash, tree clean | PASS (380 live keys, 120 deletes) |
 
 **Recovery-before-verify discipline** (from
 `.agents/concurrent-btree-corruption.md`): a crashed txn env verified *without*
 recovery falsely looks corrupt. `test_sim_crash_recover` **always** runs
 `DB_RECOVER` before `db->verify`.
 
-**Planted-bug harness** (`sim_inject.h`, `DB_DST_INJECT_BUG=<n>`): the crash
-pilot has a `NODURABLE` hook (bug 1) that "acks" a commit with `DB_TXN_NOSYNC`
-and asserts it must *not* survive the crash — the scaffold for the
-FoundationDB-grade "DST finds real bugs within K seeds" proof. v1 wires the hook
-and the harness; planting the bug *inside* `__log_flush` (so the write-back
-model's durable frontier truly drops the un-fsynced tail) is the immediate next
-step (§4, item A) that turns this into a hard catch.
+**Planted-bug harness** (`sim_inject.h`, `DB_DST_INJECT_BUG=<n>`) — the
+FoundationDB-grade "DST finds real bugs" proof, LANDED. Three known durability
+bugs planted at real library sites, each caught by a scenario within **K=1**
+seeds (`test/sim/dst-bug-inject.sh` builds a dedicated library per bug and
+asserts the catch):
+
+| Bug | Site | Caught by | Effect |
+|---|---|---|---|
+| 1 NODURABLE | `__log_flush_int` (log_put.c) skips the log fsync, still acks | `test_sim_crash_recover` | 64 "committed" txns lost after the write-back crash drops the un-synced log |
+| 2 NOCKSUM | `__db_check_chksum` (hmac.c) ignores a checksum mismatch | `test_sim_torn` | corrupt pages flow in as SILENT-BAD data |
+| 3 LOSTUPDATE | `__memp_pgwrite` (mp_bh.c) skips a dirty-page write, reports success | `test_sim_ckp_crash` | flushed records lost after crash (no log to redo) |
+
+A normal build (`DB_DST_INJECT_BUG` undefined) compiles all three out and every
+scenario passes; the OFF library has **0** `__db_sim_*` symbols.
 
 ---
 
 ## 4. Immediate next steps (ordered)
 
-- **A. Real ack-before-fsync catch.** Truncate the log to
-  `__db_sim_io_durable_end(logkey)` before `DB_RECOVER` in the crash pilot, and
-  add a `DB_SIM_BUGGIFY("log.flush.skip_fsync")` in `__log_flush_int` that skips
-  the fsync while still returning success. Then bug-build must lose the "acked"
-  commit → capstone fires. This is the headline DST proof.
-- **B. Torn-write into the write hook.** Consult `__db_sim_io_torn_prefix` in
-  the write path and add a torn-log scenario (recovery must stop at the torn
-  record, not misparse past it).
-- **C. Disk-full scenario.** Arm `__db_sim_io_enospc` mid-workload; assert
-  graceful degradation (clean error, no corruption, recoverable).
-- **D. Stale-read model.** Port xtc's superseded-write ring
-  (`__xtc_sim_io_stale_*`) to catch recovery/cache code that skips an LSN check.
-- **E. Seed sweep driver.** `scripts/dst-sweep.sh SEED_LO SEED_HI` running each
-  scenario across a seed range, plus `scripts/dst-bug-inject.sh` asserting each
-  planted bug is caught within K seeds (the bug-detection-latency yardstick).
+Items A–E landed on this branch. Remaining:
+
+- ~~**A. Real ack-before-fsync catch.**~~ DONE: `__db_sim_wb_crash()` truncates
+  each tracked file to `durable_end` before recovery, and planted bug 1
+  (`__log_flush_int` skips fsync) makes `test_sim_crash_recover` lose every
+  "committed" txn — caught at K=1.
+- ~~**B. Torn-write into the write hook.**~~ DONE: `__os_io` consults
+  `__db_sim_io_write_fault_hook`; `test_sim_torn_log` proves recovery is safe
+  past a torn log tail.
+- ~~**C. Disk-full scenario.**~~ DONE: `test_sim_enospc`.
+- **D. Stale-read model.** Ring PORTED and consulted on read; no dedicated
+  scenario yet (needs offset-threaded write-side snapshot for a full LSN-skip
+  catch) — v1.x.
+- ~~**E. Seed sweep driver.**~~ DONE: `test/sim/dst-sweep.sh` and
+  `test/sim/dst-bug-inject.sh`.
 - **F. Meson wiring** (§2).
-- **G. Determinism-guard planting** at `__os_clock`, `__os_unique_id`,
-  `__os_id`, so a regression that reads wall-clock time on a sim path aborts.
+- **G. Determinism-guard planting** at `__os_gettime` / `__os_id`. Deferred:
+  these are read on legitimate recovery/txn paths, so a strict-abort guard
+  there would fire on every run; the guard earns its keep once a v2 scheduler
+  owns virtual time. The guard machinery + count API are in place.
 - **H. `os_aio*` + `__os_physwrite` hooks** for full I/O-path coverage.
 
 ---
@@ -264,18 +303,18 @@ Marked **v1** (mappable now on the single-process fault/crash axis),
 scheduler / multi-process). ~34 scenarios across BDB subsystems.
 
 ### Access methods (workload correctness under faults)
-1. **btree put/get/del** round-trip under corrupt-read — *v1* (shipped: torn).
-2. **btree split/merge** churn across a crash + recovery — *v1*.
-3. **hash** insert/lookup/delete round-trip under faults — *v1.x*.
-4. **recno / queue** append + consume across a crash — *v1.x*.
+1. **btree put/get/del** round-trip under corrupt-read — *v1* ✅ `test_sim_torn`.
+2. **btree split/merge** churn across a crash + recovery — *v1* ✅ `test_sim_split_crash`.
+3. **hash** insert/lookup/delete round-trip under faults — *v1.x* ✅ `test_sim_hash_crash`.
+4. **recno / queue** append + consume across a crash — *v1.x* ✅ `test_sim_recno_crash`, `test_sim_queue_crash`.
 5. **secondary index / join** consistency after recovery — *v1.x*.
-6. **large / overflow records** torn-write + checksum detection — *v1.x*.
-7. **duplicate keys** (sorted/unsorted) survive crash+recover — *v1.x*.
+6. **large / overflow records** torn-write + checksum detection — *v1.x* ✅ `test_sim_overflow_torn`.
+7. **duplicate keys** (sorted/unsorted) survive crash+recover — *v1.x* ✅ `test_sim_dup_crash`.
 
 ### Log / WAL
-8. **commit durability**: every fsync-acked commit survives a crash — *v1* (capstone).
-9. **ack-before-fsync bug caught** via the write-back frontier — *v1* (item A).
-10. **torn log write**: recovery stops cleanly at the torn record — *v1.x* (item B).
+8. **commit durability**: every fsync-acked commit survives a crash — *v1* ✅ `test_sim_crash_recover` (capstone).
+9. **ack-before-fsync bug caught** via the write-back frontier — *v1* ✅ planted bug 1, caught by the capstone.
+10. **torn log write**: recovery stops cleanly at the torn record — *v1.x* ✅ `test_sim_torn_log`.
 11. **log record checksum** mismatch detected on replay — *v1.x*.
 12. **log file rollover** crash at the boundary, clean recovery — *v1.x*.
 13. **in-memory log** (`DB_LOG_IN_MEMORY`) crash semantics — *v1.x*.
@@ -284,16 +323,16 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 14. **crash at every phase**: pre-commit, post-log-pre-fsync, post-fsync,
     mid-checkpoint, mid-recovery — parameterized by a seeded crash step — *v1*.
 15. **catastrophic (fatal) recovery** from an archived log set — *v1.x*.
-16. **recovery idempotency**: recover twice, identical state hash — *v1*.
+16. **recovery idempotency**: recover twice, identical state hash — *v1* ✅ `test_sim_recover_idempotent`.
 17. **partial page write** at crash; recovery repairs via WAL — *v1*.
 
 ### Checkpoint
-18. **crash mid-checkpoint**; recovery from the prior checkpoint — *v1*.
-19. **checkpoint + ENOSPC**: checkpoint fails cleanly, txns still durable — *v1.x* (item C).
+18. **crash mid-checkpoint**; recovery from the prior checkpoint — *v1* ✅ `test_sim_ckp_crash` (page-flush durability; catches planted bug 3).
+19. **checkpoint + ENOSPC**: checkpoint fails cleanly, txns still durable — *v1.x* ✅ `test_sim_enospc`.
 
 ### Buffer pool (mpool)
-20. **eviction under memory pressure** + corrupt-read on refetch — *v1* (torn uses DB_PRIVATE small cache).
-21. **dirty-page flush torn write** caught by page checksum — *v1.x* (item B).
+20. **eviction under memory pressure** + corrupt-read on refetch — *v1* ✅ `test_sim_torn` (DB_PRIVATE small cache).
+21. **dirty-page flush torn write** caught by page checksum — *v1.x* (partial: `test_sim_overflow_torn` covers overflow-page corrupt reads).
 22. **MVCC version-chain fget** returns the correct snapshot under faults — *v1.x*.
 23. **trickle / sync** interaction with a crash — *v2* (needs concurrency).
 
@@ -303,7 +342,7 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 26. **lock-table region exhaustion** graceful degradation — *v1.x*.
 
 ### Transactions
-27. **commit/abort mix**: aborted txns leave no trace after recovery — *v1*.
+27. **commit/abort mix**: aborted txns leave no trace after recovery — *v1* ✅ `test_sim_abort_atomic`.
 28. **nested / child txn** commit+abort correctness across crash — *v1.x*.
 29. **prepare/2PC**: prepared txns recover to the resolvable state — *v1.x*.
 30. **cursor stability** across abort — *v1.x*.

--- a/test/sim/README.md
+++ b/test/sim/README.md
@@ -16,11 +16,23 @@ axis. The full deterministic multi-process scheduler is v2 (design doc §0).
 | `sim_fault.h` | fault toggles, buggify, I/O fault knobs, write-back model API |
 | `sim_os.h` | declarations of the `__os_*` I/O hooks (included by the os layer) |
 | `sim_inject.h` | planted-bug ids (`DB_DST_INJECT_BUG`) — the bug-detection yardstick |
-| `sim_core.c` | the DST core (PRNG, guard, buggify, I/O fault knobs, write-back crash model) — linked into libdb under `--enable-dst` |
+| `sim_scenario.h` | shared crash/recover helpers (fork+crash+recover boilerplate) |
+| `sim_core.c` | the DST core (PRNG, guard, buggify, I/O fault knobs, write-back crash model, stale-read ring) — linked into libdb under `--enable-dst` |
 | `sim_os_hooks.c` | bridge from `__os_*` (os_rw.c, os_fsync.c) to the core — linked into libdb under `--enable-dst` |
-| `test_sim_rng.c` | pilot: PRNG determinism / seed-sensitivity / stream independence / guard |
-| `test_sim_crash_recover.c` | **capstone** pilot: durable txns survive a crash; recovery is clean |
-| `test_sim_torn.c` | pilot: corrupt reads are caught by checksum or invisible — never silently wrong |
+| `test_sim_rng.c` | PRNG determinism / seed-sensitivity / stream independence / guard |
+| `test_sim_crash_recover.c` | **capstone**: durable txns survive a crash via the write-back drop; recovery clean |
+| `test_sim_torn.c` | corrupt reads caught by checksum or invisible — never silently wrong |
+| `test_sim_hash_crash.c` / `test_sim_recno_crash.c` / `test_sim_queue_crash.c` | per-access-method op+crash+recover (hash / recno / queue) |
+| `test_sim_ckp_crash.c` | page-flush (checkpoint) durability across a crash |
+| `test_sim_torn_log.c` | recovery is safe past a torn log tail |
+| `test_sim_enospc.c` | disk-full (ENOSPC) graceful degradation, no corruption |
+| `test_sim_abort_atomic.c` | committed present + aborted leave no trace after a crash |
+| `test_sim_recover_idempotent.c` | recover twice → identical full-state hash |
+| `test_sim_dup_crash.c` | sorted duplicates survive a crash with exact multiplicity |
+| `test_sim_overflow_torn.c` | overflow (>page) records: corrupt read caught, never silently wrong |
+| `test_sim_split_crash.c` | btree split/merge churn survives a crash, tree clean |
+| `dst-sweep.sh` | run one scenario over a seed range, report pass count + failing seeds |
+| `dst-bug-inject.sh` | build a library per planted bug, assert each is caught within K seeds |
 
 ## Build
 
@@ -37,7 +49,7 @@ nix develop --command bash -c '
   cd build_unix &&
   ../dist/configure --enable-debug --enable-dst &&
   make -j4 &&           # builds libdb with the DST core
-  make dst_tests'       # builds the three pilot executables
+  make dst_tests'       # builds all fourteen scenario executables
 ```
 
 Run the pilots (they link the shared lib, so set `LD_LIBRARY_PATH`):
@@ -74,20 +86,30 @@ after recovery.
 
 ## Proving DST catches real bugs (planted-bug harness)
 
-`sim_inject.h` defines planted-bug ids. A dedicated build activates exactly one:
+`sim_inject.h` defines three planted durability bugs at REAL library sites.
+Each is caught by a specific scenario within **K=1** seeds. Because each bug
+lives in the library (not the test), activating one means (re)building the
+library with `-DDB_DST_INJECT_BUG=<n>`; `dst-bug-inject.sh` automates a
+dedicated build tree per bug and asserts the catch:
 
 ```sh
-cd build_unix
-make test_sim_crash_recover DSTBUG=1   # plant bug 1 (NODURABLE)
-LD_LIBRARY_PATH=.libs ./test_sim_crash_recover
+sh test/sim/dst-bug-inject.sh 8    # K=8 max seeds; prints "CAUGHT bug N at seed 1"
 ```
 
-The bug build is *expected to fail* (an invariant fires) — that failure is the
-"DST caught it" signal. A planted bug the sweep does **not** catch is a hole in
-the DST coverage of that safety property. v1 ships the harness and the
-`NODURABLE` hook; wiring the fsync-skip into `__log_flush` itself (so the
-write-back durable frontier truly drops the un-fsynced tail) is the immediate
-next step — see design doc §4 item A.
+| Bug | Site | Caught by |
+|---|---|---|
+| 1 NODURABLE | `__log_flush_int` skips the log fsync but acks | `test_sim_crash_recover` (loses every "committed" txn) |
+| 2 NOCKSUM | `__db_check_chksum` ignores a checksum mismatch | `test_sim_torn` (SILENT-BAD reads) |
+| 3 LOSTUPDATE | `__memp_pgwrite` skips a dirty-page write, acks | `test_sim_ckp_crash` (flushed records lost) |
+
+A normal build (`DB_DST_INJECT_BUG` undefined) compiles all three out; every
+scenario passes and the OFF library exports **0** `__db_sim_*` symbols.
+
+Sweep a scenario over many seeds (from the build dir):
+
+```sh
+sh ../test/sim/dst-sweep.sh test_sim_crash_recover 1 200
+```
 
 ## Determinism guarantees
 

--- a/test/sim/dst-bug-inject.sh
+++ b/test/sim/dst-bug-inject.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+#-
+# Deterministic Simulation Testing (DST) for libdb.
+#
+# dst-bug-inject.sh --
+#	The "bug-detection latency" yardstick.  For each planted bug (see
+#	test/sim/sim_inject.h), build a dedicated library with
+#	-DDB_DST_INJECT_BUG=<n>, build the scenario that guards the matching
+#	safety invariant, and assert the scenario CATCHES the bug within K
+#	seeds -- printing the smallest seed that caught it.  A bug NOT caught
+#	within K seeds is a hole in the DST coverage of that property and
+#	fails the script.
+#
+#	This is the FoundationDB / TigerBeetle proof: break a safety
+#	invariant on purpose, and DST finds it fast and hands you the seed.
+#
+#	Usage:  dst-bug-inject.sh [K]      (K = max seeds to try, default 16)
+#	Run from the repo root; needs a configure-capable tree.  Each bug
+#	gets its own out-of-tree build dir under $TMPDIR so the injected
+#	library never contaminates a normal build.
+#
+#	"Caught" convention:
+#	  bug 1 (NODURABLE, log fsync skipped)  -> test_sim_crash_recover
+#	        exits 0 ONLY when it detects the loss (injected-build success),
+#	        so for the sweep a CATCH is exit 0 with "CAUGHT" in output.
+#	  bug 2 (NOCKSUM) / bug 3 (LOSTUPDATE)  -> the scenario's invariant
+#	        FAILS (nonzero exit) when the bug is present -- that nonzero
+#	        exit IS the catch.
+
+set -u
+
+K="${1:-16}"
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"          # repo root (script is in test/sim/)
+CONFIGURE="$ROOT/dist/configure"
+TMPD="${TMPDIR:-/tmp}/dst-bug-inject.$$"
+mkdir -p "$TMPD"
+
+# bug id | scenario | catch-mode (exit0catch | nonzerocatch)
+BUGS="
+1|test_sim_crash_recover|exit0catch
+2|test_sim_torn|nonzerocatch
+3|test_sim_ckp_crash|nonzerocatch
+"
+
+overall=0
+
+for line in $BUGS; do
+	[ -z "$line" ] && continue
+	n="${line%%|*}"; rest="${line#*|}"
+	scen="${rest%%|*}"; mode="${rest##*|}"
+
+	bdir="$TMPD/bug$n"
+	mkdir -p "$bdir"
+	echo "== planted bug $n -> $scen (mode $mode) =="
+	( cd "$bdir" && \
+	  "$CONFIGURE" --enable-debug --enable-dst \
+	      CFLAGS="-g -O0 -DDB_DST_INJECT_BUG=$n" >configure.log 2>&1 && \
+	  make -j4 >build.log 2>&1 && \
+	  make "$scen" >buildtest.log 2>&1 ) || {
+		echo "  BUILD FAILED for bug $n (see $bdir/*.log)"; overall=1; continue; }
+
+	caught_seed=""
+	s=1
+	while [ "$s" -le "$K" ]; do
+		if "$bdir/$scen" "$s" >/dev/null 2>&1; then rc=0; else rc=1; fi
+		case "$mode" in
+		exit0catch)   [ "$rc" -eq 0 ] && caught_seed="$s" ;;
+		nonzerocatch) [ "$rc" -ne 0 ] && caught_seed="$s" ;;
+		esac
+		[ -n "$caught_seed" ] && break
+		s=$((s + 1))
+	done
+
+	if [ -n "$caught_seed" ]; then
+		echo "  CAUGHT bug $n at seed $caught_seed (K<=$K)"
+	else
+		echo "  MISSED bug $n within $K seeds -- COVERAGE HOLE"
+		overall=1
+	fi
+done
+
+rm -rf "$TMPD"
+if [ "$overall" -eq 0 ]; then
+	echo "dst-bug-inject: ALL planted bugs caught within $K seeds"
+else
+	echo "dst-bug-inject: some bugs were missed (see above)"
+fi
+exit "$overall"

--- a/test/sim/dst-sweep.sh
+++ b/test/sim/dst-sweep.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+#-
+# Deterministic Simulation Testing (DST) for libdb.
+#
+# dst-sweep.sh --
+#	Swarm runner: run one DST scenario over a seed range and report the
+#	pass count plus per-fault activation stats parsed from the scenario
+#	output.  A seed that FAILS is printed (it is a reproducer: re-run
+#	`./<scenario> <seed>` to replay the exact failing run).
+#
+#	Usage:  dst-sweep.sh <scenario> [SEED_LO] [SEED_HI]
+#	   e.g.  scripts/dst-sweep.sh test_sim_crash_recover 1 200
+#
+#	Run from the build directory (build_unix) after `make dst_tests`.
+
+set -u
+
+SCEN="${1:?usage: dst-sweep.sh <scenario> [lo] [hi]}"
+LO="${2:-1}"
+HI="${3:-100}"
+
+if [ ! -x "./$SCEN" ]; then
+	echo "dst-sweep: ./$SCEN not built (run: make $SCEN)" >&2
+	exit 2
+fi
+
+pass=0
+fail=0
+fails=""
+s="$LO"
+while [ "$s" -le "$HI" ]; do
+	if ./"$SCEN" "$s" >/dev/null 2>&1; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1))
+		fails="$fails $s"
+	fi
+	s=$((s + 1))
+done
+
+total=$((HI - LO + 1))
+echo "dst-sweep: $SCEN  seeds [$LO..$HI]  ->  $pass/$total pass, $fail fail"
+if [ -n "$fails" ]; then
+	echo "  FAILING seeds (reproduce with ./$SCEN <seed>):$fails"
+	exit 1
+fi
+exit 0

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -29,6 +29,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+#include <unistd.h>
 
 /* ---- activation + PRNG tree ---- */
 
@@ -133,6 +135,7 @@ __db_sim_deactivate()
 	atomic_store_explicit(&g_io_enospc_pct, 0, memory_order_release);
 	atomic_store_explicit(&g_io_corrupt_pct, 0, memory_order_release);
 	atomic_store_explicit(&g_io_corrupt_on, 0, memory_order_release);
+	__db_sim_io_stale_enable(0);
 	__db_sim_wb_enable(0);
 }
 
@@ -399,10 +402,12 @@ __db_sim_io_flip_byte(len)
  * or two files.  Upgrade to a hash keyed table if a scenario needs many.
  */
 #define DB_SIM_WB_FILES 16
+#define DB_SIM_WB_NAMELEN 256
 struct sim_wb_ent {
 	uint64_t key;
 	uint64_t written_end;
 	uint64_t durable_end;
+	char     name[DB_SIM_WB_NAMELEN];   /* path, for crash truncation */
 	int      used;
 };
 static struct sim_wb_ent g_wb[DB_SIM_WB_FILES];
@@ -440,9 +445,32 @@ wb_slot(key)
 		g_wb[free_k].key = key;
 		g_wb[free_k].written_end = 0;
 		g_wb[free_k].durable_end = 0;
+		g_wb[free_k].name[0] = '\0';
 		return (&g_wb[free_k]);
 	}
 	return (NULL);   /* table full: this file is not tracked (bounded) */
+}
+
+/*
+ * __db_sim_wb_note_name --
+ *	Record the on-disk path for a tracked file so a crash can truncate
+ *	it to the durable frontier.  Called from the write hook (which has
+ *	the DB_FH name).  A no-op unless the write-back model is armed.
+ */
+void
+__db_sim_wb_note_name(key, name)
+	uint64_t key;
+	const char *name;
+{
+	struct sim_wb_ent *e;
+
+	if (!__db_sim_wb_active() || name == NULL)
+		return;
+	e = wb_slot(key);
+	if (e != NULL && e->name[0] == '\0') {
+		(void)strncpy(e->name, name, DB_SIM_WB_NAMELEN - 1);
+		e->name[DB_SIM_WB_NAMELEN - 1] = '\0';
+	}
 }
 
 void
@@ -493,4 +521,150 @@ __db_sim_io_durable_end(key)
 		return (0);
 	e = wb_slot(key);
 	return (e != NULL ? e->durable_end : 0);
+}
+
+/*
+ * __db_sim_wb_crash --
+ *	Model a power loss: every tracked file's bytes past its last fsync
+ *	(durable frontier) never reached the platter, so truncate the real
+ *	file back to durable_end.  This is what makes an ACK-before-fsync
+ *	bug detectable -- a commit whose log was written but not fsync'd is
+ *	dropped here, exactly as a real disk would drop it on power loss.
+ *	Returns the number of files truncated.  Called by a crash-recovery
+ *	test in-process at the crash boundary, before recovery.
+ *
+ *	ponytail: truncate() by path (files are closed at crash); an
+ *	ftruncate on a live fd if a scenario needs it while the file is open.
+ */
+int
+__db_sim_wb_crash()
+{
+	int k, n = 0;
+
+	if (!__db_sim_wb_active())
+		return (0);
+	for (k = 0; k < DB_SIM_WB_FILES; k++) {
+		if (!g_wb[k].used || g_wb[k].name[0] == '\0')
+			continue;
+		/* Only shrink: durable_end <= written_end always, and we
+		 * never grow a file (that would fabricate bytes). */
+		if (truncate(g_wb[k].name, (off_t)g_wb[k].durable_end) == 0)
+			n++;
+		/* After the crash the volatile cache is gone: written == durable. */
+		g_wb[k].written_end = g_wb[k].durable_end;
+	}
+	return (n);
+}
+
+/* ---- latency (consumed by the __os_io hooks) ----
+ *
+ * A seeded per-I/O latency in ns.  In the single-process v1 pilots there
+ * is no scheduler to REORDER against, so latency does not change any
+ * invariant; but wiring it as a real (tiny, capped) sleep makes the knob
+ * genuinely CONSUMED and lets a scenario model a slow disk.  Off by
+ * default (lat_max == 0 => 0ns => no sleep).
+ *
+ * ponytail: a bounded nanosleep; the load-bearing use (completion-order
+ * interleaving) is a v2 async-path item, this just makes the knob real.
+ */
+void
+__db_sim_io_sleep_latency()
+{
+	int64_t ns;
+	struct timespec ts;
+
+	ns = __db_sim_io_latency();
+	if (ns <= 0)
+		return;
+	/* Cap so an over-large seeded value cannot wedge a test. */
+	if (ns > 2000000)
+		ns = 2000000;                 /* 2ms cap */
+	ts.tv_sec = 0;
+	ts.tv_nsec = ns;
+	(void)nanosleep(&ts, NULL);
+}
+
+/* ---- stale-read model (superseded-write ring) ----
+ *
+ * Catches recovery/cache code that returns a well-formed but OUT-OF-DATE
+ * version of a block (skipping an LSN/version check).  On a write we
+ * snapshot the CURRENT (about-to-be-superseded) bytes at (fkey,off) into
+ * a ring; on a seeded stale-read coin at a matching (fkey,off) we return
+ * that prior version instead of the fresh bytes.  Both bytes are
+ * well-formed -- the fault is that the reader accepted the old one.
+ * Adapted from xtc's __xtc_sim_io_stale_*.
+ *
+ * ponytail: fixed ring, O(n) newest-match scan (bounded); a scenario
+ * touches a handful of hot blocks.
+ */
+#define DB_SIM_STALE_RING   32
+#define DB_SIM_STALE_MAXLEN 512
+struct sim_stale_ent {
+	uint64_t fkey;
+	uint64_t off;
+	int      len;
+	unsigned char buf[DB_SIM_STALE_MAXLEN];
+};
+static struct sim_stale_ent g_stale[DB_SIM_STALE_RING];
+static _Atomic int g_stale_head;
+static _Atomic int g_stale_pct;
+
+void
+__db_sim_io_stale_enable(pct_per_1000)
+	unsigned pct_per_1000;
+{
+	if (pct_per_1000 > 1000)
+		pct_per_1000 = 1000;
+	memset(g_stale, 0, sizeof(g_stale));
+	atomic_store_explicit(&g_stale_head, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_stale_pct, (int)pct_per_1000,
+	    memory_order_release);
+}
+
+void
+__db_sim_io_stale_record(fkey, off, buf, len)
+	uint64_t fkey, off;
+	const void *buf;
+	int len;
+{
+	int h, cp;
+
+	if (atomic_load_explicit(&g_stale_pct, memory_order_acquire) <= 0 ||
+	    !__db_sim_active() || buf == NULL || len <= 0)
+		return;
+	cp = len < DB_SIM_STALE_MAXLEN ? len : DB_SIM_STALE_MAXLEN;
+	h = atomic_load_explicit(&g_stale_head, memory_order_relaxed);
+	g_stale[h].fkey = fkey;
+	g_stale[h].off = off;
+	g_stale[h].len = cp;
+	memcpy(g_stale[h].buf, buf, (size_t)cp);
+	atomic_store_explicit(&g_stale_head, (h + 1) % DB_SIM_STALE_RING,
+	    memory_order_relaxed);
+}
+
+int
+__db_sim_io_stale_read(fkey, off, buf, len)
+	uint64_t fkey, off;
+	void *buf;
+	int len;
+{
+	int i, h, pct;
+
+	pct = atomic_load_explicit(&g_stale_pct, memory_order_acquire);
+	if (pct <= 0 || !__db_sim_active() || buf == NULL || len <= 0)
+		return (0);
+	if ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) >= pct)
+		return (0);
+	/* Newest matching prior version wins. */
+	h = atomic_load_explicit(&g_stale_head, memory_order_relaxed);
+	for (i = 0; i < DB_SIM_STALE_RING; i++) {
+		int k = (h - 1 - i + DB_SIM_STALE_RING) % DB_SIM_STALE_RING;
+		if (g_stale[k].len > 0 && g_stale[k].fkey == fkey &&
+		    g_stale[k].off == off) {
+			int cp = g_stale[k].len < len ? g_stale[k].len : len;
+			memcpy(buf, g_stale[k].buf, (size_t)cp);
+			return (1);
+		}
+	}
+	return (0);
 }

--- a/test/sim/sim_fault.h
+++ b/test/sim/sim_fault.h
@@ -43,7 +43,14 @@ void     __db_sim_io_faults_enable __P((int64_t, int64_t, unsigned));
 void     __db_sim_io_faults_disable __P((void));
 int      __db_sim_io_faults_active __P((void));
 int64_t  __db_sim_io_latency __P((void));
+void     __db_sim_io_sleep_latency __P((void));
 int      __db_sim_io_should_fault __P((void));
+
+/* Stale-read model: a seeded read returns a prior (superseded) version of
+ * the block -- well-formed but out of date, to catch a missing LSN check. */
+void     __db_sim_io_stale_enable __P((unsigned));
+void     __db_sim_io_stale_record __P((uint64_t, uint64_t, const void *, int));
+int      __db_sim_io_stale_read __P((uint64_t, uint64_t, void *, int));
 
 /* Disk-full (ENOSPC): a seeded coin fails a whole write, nothing
  * persists. */
@@ -69,9 +76,11 @@ int      __db_sim_io_flip_byte __P((int));
 void     __db_sim_wb_enable __P((int));
 int      __db_sim_wb_active __P((void));
 void     __db_sim_wb_wrote __P((uint64_t, uint64_t));
+void     __db_sim_wb_note_name __P((uint64_t, const char *));
 void     __db_sim_wb_synced __P((uint64_t));
 uint64_t __db_sim_wb_written_end __P((uint64_t));
 uint64_t __db_sim_io_durable_end __P((uint64_t));
+int      __db_sim_wb_crash __P((void));
 
 /*
  * Buggify branch macro for planting a legal-but-pessimal path in real

--- a/test/sim/sim_inject.h
+++ b/test/sim/sim_inject.h
@@ -13,31 +13,42 @@
  *
  *	In a normal build DB_DST_INJECT_BUG is undefined and every check
  *	compiles to 0, so the harness is absent from production AND from the
- *	default --enable-dst build.  A dedicated build passes
- *	-DDB_DST_INJECT_BUG=<n> (via `make dst_tests DSTBUG=<n>`) to activate
- *	exactly ONE planted bug; the DST capstone is then expected to FAIL
- *	within a bounded seed count.  A planted bug the sweep does NOT catch
- *	is a hole in the DST coverage of that safety property.
+ *	default --enable-dst build.  Each planted bug lives at a real
+ *	library site, so activating it requires (re)building the LIBRARY
+ *	with -DDB_DST_INJECT_BUG=<n>; scripts/dst-bug-inject.sh does exactly
+ *	that (a dedicated build tree per bug) and asserts the matching
+ *	scenario catches it within K seeds.  A planted bug the sweep does
+ *	NOT catch is a hole in the DST coverage of that safety property.
  *
- *	Bug ids (each targets a DST-reachable safety-critical site whose
- *	violation a specific pilot detects):
+ *	Bug ids (each plants a KNOWN safety violation at a real library
+ *	site whose failure a specific scenario's invariant detects):
  *
- *	  1  NODURABLE  -- the crash-recover pilot skips truncating the DB
- *	                   to the durable frontier before recovery, i.e. it
- *	                   trusts bytes the write-back model says were never
- *	                   fsync'd.  Models a writer that ACKs a commit
- *	                   without making it durable.  The capstone's
- *	                   "every committed txn present after recovery, DB
- *	                   verifies clean" invariant fires.  (v1: modelled
- *	                   in the harness; a later phase plants it inside
- *	                   __log_flush itself.)
- *	  2  NOCKSUM    -- the torn/iofault pilot accepts a page whose
- *	                   checksum mismatches instead of erroring.  Silent
- *	                   corruption; the pilot's "engine errors cleanly or
- *	                   detects, never silently corrupts" invariant fires.
+ *	  1  NODURABLE  -- src/log/log_put.c __log_flush_int SKIPS the log
+ *	                   fsync but still acks the commit as durable.  The
+ *	                   write-back model's durable frontier never advances
+ *	                   past the record, so __db_sim_wb_crash() drops it
+ *	                   and the "committed" txn is LOST after recovery.
+ *	                   test_sim_crash_recover's "every committed txn
+ *	                   survives" invariant fires.  (The headline
+ *	                   ack-before-fsync catch.)
+ *	  2  NOCKSUM    -- src/hmac/hmac.c __db_check_chksum ignores a
+ *	                   checksum mismatch and accepts the page.  A
+ *	                   torn/corrupt page then flows silently into the
+ *	                   tree; test_sim_torn's "never silently wrong"
+ *	                   invariant fires (a get returns bytes that do not
+ *	                   match what was stored, with no error).
+ *	  3  LOSTUPDATE -- src/mp/mp_bh.c __memp_pgwrite SKIPS the page write
+ *	                   but reports success, so the buffer clears BH_DIRTY
+ *	                   as if the page reached disk.  A checkpoint then
+ *	                   believes a dirty page is durable when it is not;
+ *	                   after a crash, recovery trusts the checkpoint and
+ *	                   the update is lost.  test_sim_ckp_crash's
+ *	                   "post-checkpoint committed data survives"
+ *	                   invariant fires.
  *
- *	When you add a safety invariant, add a bug id here and a case to
- *	the pilot so DST must prove it catches it.
+ *	When you add a safety invariant, add a bug id here, plant it at the
+ *	real site, and add a case to scripts/dst-bug-inject.sh so DST must
+ *	prove it catches it.
  */
 
 #ifndef _DB_SIM_INJECT_H_
@@ -54,7 +65,8 @@
 # define DB_DST_BUG(n)  (0)
 #endif
 
-#define DB_DST_BUG_NODURABLE  1   /* trust un-fsync'd bytes across crash */
-#define DB_DST_BUG_NOCKSUM    2   /* accept a checksum-mismatched page */
+#define DB_DST_BUG_NODURABLE   1   /* log_put.c: skip log fsync, still ack */
+#define DB_DST_BUG_NOCKSUM     2   /* hmac.c: accept a checksum-mismatch page */
+#define DB_DST_BUG_LOSTUPDATE  3   /* mp_bh.c: skip a dirty-page write */
 
 #endif /* !_DB_SIM_INJECT_H_ */

--- a/test/sim/sim_os.h
+++ b/test/sim/sim_os.h
@@ -19,8 +19,11 @@ extern "C" {
 uint64_t db_sim_fkey __P((DB_FH *));
 void __db_sim_io_write_hook __P((DB_FH *, u_int32_t));
 void __db_sim_io_write_off_hook __P((DB_FH *, u_int64_t));
+int __db_sim_io_write_fault_hook __P((DB_FH *, u_int32_t));
+void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, void *, size_t));
 void __db_sim_io_sync_hook __P((DB_FH *));
-void __db_sim_io_read_hook __P((void *, size_t));
+void __db_sim_io_read_hook __P((DB_FH *, u_int64_t, void *, size_t));
+void __db_sim_io_latency_hook __P((void));
 
 #if defined(__cplusplus)
 }

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -89,9 +89,43 @@ __db_sim_io_write_off_hook(fhp, end_off)
 	DB_FH *fhp;
 	u_int64_t end_off;
 {
+	uint64_t key;
+
 	if (!__db_sim_active() || !__db_sim_wb_active())
 		return;
-	__db_sim_wb_wrote(db_sim_fkey(fhp), end_off);
+	key = db_sim_fkey(fhp);
+	__db_sim_wb_wrote(key, end_off);
+	if (fhp != NULL && fhp->name != NULL)
+		__db_sim_wb_note_name(key, fhp->name);
+}
+
+/*
+ * __db_sim_io_write_fault_hook --
+ *	Called from the write fast path BEFORE the real bytes are written,
+ *	with the intended transfer length.  Consults the seeded write-side
+ *	fault knobs and returns:
+ *	   -1  ENOSPC: the write must fail, nothing persists;
+ *	  >=0  the number of bytes to actually persist (a torn write
+ *	       persists a strict prefix < len but the caller still reports
+ *	       full success, leaving a latent bad tail a checksum must catch;
+ *	       len itself means "write it all", the common case).
+ *	A no-op (returns len) unless a sim armed the knobs.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: int __db_sim_io_write_fault_hook __P((DB_FH *, u_int32_t));
+ * PUBLIC: #endif
+ */
+int
+__db_sim_io_write_fault_hook(fhp, len)
+	DB_FH *fhp;
+	u_int32_t len;
+{
+	COMPQUIET(fhp, NULL);
+	if (!__db_sim_active())
+		return ((int)len);
+	if (__db_sim_io_enospc())
+		return (-1);
+	return (__db_sim_io_torn_prefix((int)len));
 }
 
 /*
@@ -124,15 +158,63 @@ __db_sim_io_sync_hook(fhp)
  * PUBLIC: #endif
  */
 void
-__db_sim_io_read_hook(buf, len)
+__db_sim_io_read_hook(fhp, off, buf, len)
+	DB_FH *fhp;
+	u_int64_t off;
 	void *buf;
 	size_t len;
 {
-	int fb;
+	int fb, ilen;
 
 	if (!__db_sim_active() || buf == NULL || len == 0)
 		return;
-	fb = __db_sim_io_flip_byte((int)(len > 0x7fffffff ? 0x7fffffff : len));
+	ilen = (int)(len > 0x7fffffff ? 0x7fffffff : len);
+	/* Stale read: return a prior (superseded) version of this exact
+	 * (file,offset) if one is in the ring and the seeded coin fires. */
+	(void)__db_sim_io_stale_read(db_sim_fkey(fhp), off, buf, ilen);
+	/* Corrupt read: silently flip a byte the checksum must catch. */
+	fb = __db_sim_io_flip_byte(ilen);
 	if (fb >= 0)
 		((unsigned char *)buf)[fb] ^= 0x40;
+}
+
+/*
+ * __db_sim_io_presnapshot_hook --
+ *	Called from the write path BEFORE overwriting, with the bytes
+ *	CURRENTLY on disk at this (file,offset).  Records them in the
+ *	stale-read ring so a later seeded stale read can return this
+ *	now-prior version.  A no-op unless stale injection is armed.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, void *, size_t));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_io_presnapshot_hook(fhp, off, buf, len)
+	DB_FH *fhp;
+	u_int64_t off;
+	void *buf;
+	size_t len;
+{
+	if (!__db_sim_active() || buf == NULL || len == 0)
+		return;
+	__db_sim_io_stale_record(db_sim_fkey(fhp), off, buf,
+	    (int)(len > 0x7fffffff ? 0x7fffffff : len));
+}
+
+/*
+ * __db_sim_io_latency_hook --
+ *	Consume the seeded per-I/O latency knob (a tiny capped sleep when
+ *	armed; a no-op otherwise).
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_io_latency_hook __P((void));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_io_latency_hook()
+{
+	if (!__db_sim_active())
+		return;
+	__db_sim_io_sleep_latency();
 }

--- a/test/sim/sim_scenario.h
+++ b/test/sim/sim_scenario.h
@@ -1,0 +1,107 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_scenario.h --
+ *	Shared helpers for the DST crash/recover scenarios so each
+ *	test_sim_*.c is just its workload + invariant, not env boilerplate.
+ *
+ *	The crash discipline (see .agents/concurrent-btree-corruption.md and
+ *	DESIGN.md): a child forks, runs a seeded workload, arms the
+ *	write-back durable-frontier model, and at the crash boundary calls
+ *	__db_sim_wb_crash() to drop every byte written-but-not-fsync'd (a
+ *	real power loss) before an abrupt _exit.  The parent ALWAYS runs
+ *	DB_RECOVER before verify.
+ */
+
+#ifndef _DB_SIM_SCENARIO_H_
+#define _DB_SIM_SCENARIO_H_
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+#include "sim_inject.h"
+
+/* Wipe and recreate a scratch env dir (known path we own). */
+static int
+sim_fresh_home(home)
+	const char *home;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    home, home);
+	return (system(cmd));
+}
+
+/*
+ * sim_run_crash_child --
+ *	Fork; the child calls populate(seed) (which arms the write-back
+ *	model, does the workload, and at its crash boundary calls
+ *	__db_sim_wb_crash() then _exit(42)); the parent waits.  Returns 0
+ *	iff the child reached the crash point (exit 42).
+ */
+typedef int (*sim_populate_fn) __P((uint64_t));
+
+static int
+sim_run_crash_child(seed, populate)
+	uint64_t seed;
+	sim_populate_fn populate;
+{
+	pid_t pid;
+	int status;
+
+	if ((pid = fork()) < 0) {
+		perror("fork");
+		return (-1);
+	}
+	if (pid == 0)
+		exit(populate(seed) == 0 ? 0 : 1);   /* only on setup error */
+	if (waitpid(pid, &status, 0) < 0) {
+		perror("waitpid");
+		return (-1);
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+		return (0);
+	fprintf(stderr, "child did not reach the crash point (status %d)\n",
+	    status);
+	return (-1);
+}
+
+/* Open an env for recovery (always DB_RECOVER before verify). */
+static int
+sim_env_recover(home, envp)
+	const char *home;
+	DB_ENV **envp;
+{
+	DB_ENV *env;
+	int ret;
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, home, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER, 0664))
+	    != 0) {
+		fprintf(stderr, "recover open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*envp = env;
+	return (0);
+}
+
+/* Crash the write-back model then _exit like a power loss. */
+#define SIM_CRASH_EXIT() do {						\
+	__db_sim_wb_crash();						\
+	fflush(NULL);							\
+	_exit(42);							\
+} while (0)
+
+#endif /* !_DB_SIM_SCENARIO_H_ */

--- a/test/sim/test_sim_abort_atomic.c
+++ b/test/sim/test_sim_abort_atomic.c
@@ -1,0 +1,171 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_abort_atomic.c --
+ *	Transaction atomicity-under-crash scenario.  A seeded mix of
+ *	committed and explicitly-aborted txns runs, then the process
+ *	crashes.  After recovery: every COMMITTED txn's record is present,
+ *	every ABORTED txn left NO trace, and the tree verifies clean.  This
+ *	is the all-or-nothing invariant: an abort must be as complete as a
+ *	crash-rollback, and a crash must not resurrect an aborted txn.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_abort_atomic && ./test_sim_abort_atomic [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_abort"
+#define DBFILE  "abort.db"
+#define NTXN    96
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "ab-%08d", i);
+	(void)snprintf(vbuf, 32, "av-%016llx", (unsigned long long)tok);
+}
+
+/* Deterministic commit/abort decision for txn i (seeded APP coin). */
+static int
+should_commit(void)
+{
+	return ((int)__db_sim_rng_range(DB_SIM_RNG_APP, 2));
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NTXN; i++) {
+		int commit = should_commit();   /* draws the APP coin */
+		mkrec(i, kbuf, vbuf);            /* draws the APP value */
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0) {
+			(void)txn->abort(txn);
+			return (ret);
+		}
+		if (commit)
+			ret = txn->commit(txn, DB_TXN_SYNC);
+		else
+			ret = txn->abort(txn);
+		if (ret != 0)
+			return (ret);
+	}
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xAB07;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, resurrected = 0, ncommit = 0, nabort = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	/* Replay the SAME seed draws in the SAME order to reconstruct each
+	 * txn's commit/abort decision and value. */
+	__db_sim_activate(seed);
+	for (i = 0; i < NTXN; i++) {
+		int commit = should_commit();
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (commit) {
+			ncommit++;
+			if (ret != 0)
+				missing++;
+		} else {
+			nabort++;
+			if (ret == 0)
+				resurrected++;
+		}
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_abort_atomic: verify FAILED: %s\n",
+		    db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing || resurrected) {
+		fprintf(stderr, "test_sim_abort_atomic: FAIL -- %d committed "
+		    "missing, %d aborted resurrected (seed 0x%llx)\n",
+		    missing, resurrected, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_abort_atomic: PASS -- %d committed present, %d "
+	    "aborted left no trace, tree clean (seed 0x%llx)\n",
+	    ncommit, nabort, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_ckp_crash.c
+++ b/test/sim/test_sim_ckp_crash.c
@@ -1,0 +1,168 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_ckp_crash.c --
+ *	Checkpoint / page-flush durability scenario.  A non-transactional
+ *	btree (data reaches disk ONLY via a buffer-pool flush, not a
+ *	redoable log) is populated, flushed to disk with db->sync (the
+ *	checkpoint analogue: __memp_pgwrite lands every dirty page), and the
+ *	process crashes abruptly.  After reopening, every synced record MUST
+ *	be present -- the flush claimed they were durable.
+ *
+ *	This is the scenario the LOSTUPDATE planted bug (DB_DST_INJECT_BUG=3)
+ *	targets: __memp_pgwrite skips the page write but reports success, so
+ *	the flush believes the page is durable when it never reached disk.
+ *	With no log to redo it, the record is simply gone after the crash --
+ *	and this test's "every synced record survives" invariant fires.
+ *
+ *	A crash here is an abrupt _exit after the flush with NO clean close
+ *	(no second flush of anything the bug dropped), modelling kill -9.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_ckp_crash && ./test_sim_ckp_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_ckp"
+#define DBFILE  "ckp.db"
+#define NREC    200
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "ck-%08d", i);
+	(void)snprintf(vbuf, 32, "cv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    create ? DB_CREATE : 0, 0664)) != 0) {
+		fprintf(stderr, "ckp db open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+/* Populate a NON-txn btree, flush every dirty page to disk, then crash
+ * abruptly (no clean close).  A correct flush made every record durable
+ * in the data file. */
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	/* No txn/log subsystem: durability is ONLY via the page flush.
+	 * DB_PRIVATE: a process-local cache that dies with the crash, so
+	 * the parent must read pages from the DATA FILE, not a surviving
+	 * shared mpool region -- that is what makes a skipped page write
+	 * (LOSTUPDATE) observable. */
+	if ((ret = env->open(env, HOME,
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NREC; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, NULL, &key, &data, 0)) != 0)
+			return (ret);
+	}
+
+	/* The checkpoint analogue: flush every dirty page to the data file.
+	 * A correct __memp_pgwrite lands them all. */
+	if ((ret = db->sync(db, 0)) != 0)
+		return (ret);
+
+	/* CRASH abruptly -- no clean close (which would flush again). */
+	fflush(NULL);
+	_exit(42);
+	/* NOTREACHED */
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC4E;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, mismatch = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Reopen the (non-txn) env and DB; the flushed data must be there.
+	 * No recovery: there is no log -- the data file is the truth. */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = env->open(env, HOME,
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0664)) != 0) {
+		fprintf(stderr, "reopen env failed: %s\n", db_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NREC; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	if (missing || mismatch) {
+		fprintf(stderr, "test_sim_ckp_crash: FAIL -- %d missing, %d "
+		    "mismatched synced records after crash (seed 0x%llx)\n",
+		    missing, mismatch, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_ckp_crash: PASS -- all %d flushed records durable "
+	    "across the crash (seed 0x%llx)\n", NREC,
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_crash_recover.c
+++ b/test/sim/test_sim_crash_recover.c
@@ -3,26 +3,35 @@
  *
  * test_sim_crash_recover.c --
  *	THE capstone pilot: a transactional btree workload commits N
- *	durable txns, a child process "crashes" mid-uncommitted-txn (an
- *	abrupt _exit with a dirty env), then the parent runs recovery and
- *	verifies EVERY committed txn survived, the uncommitted one did not,
- *	and the DB verifies clean.
+ *	durable txns, then a "crash" drops every byte the write-back model
+ *	says was written but never fsync'd (a real power loss), the parent
+ *	runs recovery, and asserts EVERY committed txn survived, the
+ *	uncommitted one did not, and the DB verifies clean.
+ *
+ *	The write-back durable-frontier model is what makes this HONEST:
+ *	the sim writes to a real file, so bytes reach the file on pwrite
+ *	regardless of fsync -- a naive crash test therefore cannot catch a
+ *	writer that ACKs a commit it never fsync'd.  Here the child, at the
+ *	crash boundary, calls __db_sim_wb_crash(), which truncates the real
+ *	log file back to its durable frontier (last fsync).  So a commit
+ *	whose log was written but not synced is genuinely lost -- exactly
+ *	how a disk loses it on power loss.
  *
  *	Determinism: the workload keys/values are drawn from the seeded APP
  *	stream, so a given seed produces the exact same committed set --
- *	the same seed replays the same run.  The crash point is fixed
- *	(after N synced commits, inside txn N+1), which the deterministic
- *	fault schedule will later parameterize (v2).
+ *	the same seed replays the same run.
  *
  *	CRITICAL (see .agents/concurrent-btree-corruption.md): a crashed
  *	txn env verified WITHOUT recovery falsely looks corrupt.  This
  *	pilot ALWAYS runs DB_RECOVER before db->verify.
  *
- *	Planted-bug hook (DB_DST_INJECT_BUG=1, NODURABLE): the last "acked"
- *	txn commits with DB_TXN_NOSYNC (acked but not fsync'd).  A correct
- *	engine loses it across the crash (it was never durable); the buggy
- *	build ASSERTS it survived, so the DST invariant fires -- proving the
- *	capstone catches an ack-before-durable bug.
+ *	PLANTED BUG (DB_DST_INJECT_BUG=1, NODURABLE): __log_flush_int skips
+ *	the log fsync but still acks the commit.  The write-back durable
+ *	frontier then never advances past the last DB_TXN_SYNC commit's
+ *	log, so __db_sim_wb_crash() truncates that record away and the
+ *	"committed" txn is LOST after recovery -- the capstone invariant
+ *	fires.  This is the FoundationDB-grade "DST finds a real durability
+ *	bug, here is the seed" proof.
  *
  *	Build/run (from build_unix, after configure --enable-dst):
  *	    make test_sim_crash_recover && ./test_sim_crash_recover [seed]
@@ -72,10 +81,11 @@ run_child(seed)
 	int i, ret;
 
 	/* Re-seed identically in the child so its APP-stream draws match the
-	 * parent's expectation (fork copies the seed but we re-activate to
-	 * be explicit and independent of copy semantics). */
+	 * parent's expectation.  Arm the write-back model so the log's
+	 * durable frontier is tracked and un-fsync'd bytes get dropped at
+	 * the crash boundary below. */
 	__db_sim_activate(seed);
-	__db_sim_wb_enable(1);       /* honest disk: writes durable only on fsync */
+	__db_sim_wb_enable(1);
 
 	if ((ret = db_env_create(&env, 0)) != 0)
 		return (ret);
@@ -103,8 +113,10 @@ run_child(seed)
 			return (ret);
 	}
 
-#if DB_DST_BUG(1) == 0
-	/* Normal path: start an UNCOMMITTED txn, then crash inside it. */
+	/* An UNCOMMITTED txn, then crash inside it: its data must NOT
+	 * survive.  (With the NODURABLE planted bug, the DB_TXN_SYNC commits
+	 * above were never fsync'd, so the write-back crash below drops their
+	 * log too -- that is the bug the capstone catches.) */
 	mkrec(NCOMMIT, kbuf, vbuf);
 	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
 		return (ret);
@@ -113,30 +125,18 @@ run_child(seed)
 	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
 	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
 	(void)db->put(db, txn, &key, &data, 0);
-	/* Deliberately DO NOT commit txn.  Crash now. */
-#else
-	/*
-	 * NODURABLE bug: "ack" a commit WITHOUT fsync (DB_TXN_NOSYNC) and
-	 * treat it as durable.  A correct engine loses this across a crash;
-	 * the harness invariant (below) asserts it survived, so the planted
-	 * bug makes the capstone FAIL -- exactly the DST catch we want.
-	 */
-	mkrec(NCOMMIT, kbuf, vbuf);
-	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
-		return (ret);
-	memset(&key, 0, sizeof(key));
-	memset(&data, 0, sizeof(data));
-	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
-	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
-	(void)db->put(db, txn, &key, &data, 0);
-	(void)txn->commit(txn, DB_TXN_NOSYNC);   /* acked, NOT durable */
-#endif
+	/* Deliberately DO NOT commit txn. */
 
 	/*
-	 * CRASH: abrupt exit, no clean close, no checkpoint.  _exit skips
-	 * atexit handlers and libdb cleanup, leaving the env dirty exactly
-	 * as a kill -9 would.  Flush stdio so any child diagnostics escape.
+	 * CRASH (power loss): drop every byte written but not fsync'd.  The
+	 * write-back model truncates each tracked real file (the log) back
+	 * to its durable frontier.  A correct engine fsync'd each
+	 * DB_TXN_SYNC commit, so its durable frontier already covers all
+	 * NCOMMIT commits and only the uncommitted tail is dropped.  Then an
+	 * abrupt _exit (no clean close, no checkpoint) leaves the env dirty
+	 * exactly as kill -9 would.
 	 */
+	__db_sim_wb_crash();
 	fflush(NULL);
 	_exit(42);
 	/* NOTREACHED */
@@ -145,9 +145,9 @@ run_child(seed)
 
 /* Recover, reopen, and verify the committed set.  Returns 0 on success. */
 static int
-verify_after_recovery(seed, saw_nosync_key)
+verify_after_recovery(seed, saw_uncommitted, missing_out)
 	uint64_t seed;
-	int *saw_nosync_key;
+	int *saw_uncommitted, *missing_out;
 {
 	DB_ENV *env;
 	DB *db;
@@ -155,7 +155,8 @@ verify_after_recovery(seed, saw_nosync_key)
 	char kbuf[32], vbuf[32];
 	int i, ret, missing = 0, mismatch = 0;
 
-	*saw_nosync_key = 0;
+	*saw_uncommitted = 0;
+	*missing_out = 0;
 
 	/* ALWAYS recover before touching the tree (else a WAL-consistent
 	 * crashed tree falsely looks corrupt). */
@@ -194,14 +195,13 @@ verify_after_recovery(seed, saw_nosync_key)
 			mismatch++;
 		}
 	}
-	/* The (NOSYNC-acked or uncommitted) key NCOMMIT must be ABSENT after
-	 * a correct recovery. */
+	/* The uncommitted key NCOMMIT must be ABSENT after recovery. */
 	mkrec(NCOMMIT, kbuf, vbuf);
 	memset(&key, 0, sizeof(key));
 	memset(&data, 0, sizeof(data));
 	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
 	if (db->get(db, NULL, &key, &data, 0) == 0)
-		*saw_nosync_key = 1;
+		*saw_uncommitted = 1;
 	__db_sim_deactivate();
 
 	(void)db->close(db, 0);
@@ -217,6 +217,7 @@ verify_after_recovery(seed, saw_nosync_key)
 	}
 	(void)env->close(env, 0);
 
+	*missing_out = missing;
 	if (missing != 0 || mismatch != 0) {
 		fprintf(stderr, "%d missing, %d mismatched committed txns\n",
 		    missing, mismatch);
@@ -232,16 +233,16 @@ main(argc, argv)
 {
 	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xDB5EEDull;
 	pid_t pid;
-	int status, ret, saw_nosync;
+	int status, ret, saw_uncommitted, missing;
 	char cmd[256];
 
-	/* Fresh env dir each run (trash-friendly: a plain rm of a known
-	 * scratch dir we created). */
+	/* Fresh env dir each run. */
 	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
 	    HOME, HOME);
 	(void)system(cmd);
 
-	/* Child does the durable work then crashes. */
+	/* Child does the durable work then crashes (dropping un-fsync'd
+	 * bytes via the write-back model). */
 	if ((pid = fork()) < 0) {
 		perror("fork");
 		return (EXIT_FAILURE);
@@ -259,26 +260,36 @@ main(argc, argv)
 		return (EXIT_FAILURE);
 	}
 
-	ret = verify_after_recovery(seed, &saw_nosync);
+	ret = verify_after_recovery(seed, &saw_uncommitted, &missing);
 
 #if DB_DST_BUG(1)
 	/*
-	 * NODURABLE invariant: the NOSYNC-acked commit must NOT survive.
-	 * If it did (or recovery/verify otherwise passed), the ack-before-
-	 * durable bug went UNDETECTED -- fail loudly so the sweep records
-	 * DST caught it (a nonzero exit is the "caught" signal here since
-	 * the bug is in what we ACCEPT, not what crashes).
+	 * NODURABLE invariant: with the fsync-skip bug, at least one
+	 * DB_TXN_SYNC-committed txn must be LOST after the crash (its log
+	 * was never made durable).  If everything survived, the bug went
+	 * UNDETECTED -- fail so the sweep records a coverage hole.  When the
+	 * bug IS caught (a committed txn missing => verify_after_recovery
+	 * returned nonzero), exit 0: DST caught the planted bug for this
+	 * seed, which is the success condition for the injected build.
 	 */
-	if (ret == 0 && saw_nosync) {
-		fprintf(stderr, "test_sim_crash_recover: DST CAUGHT NODURABLE "
-		    "-- a NOSYNC-acked commit survived a crash (seed 0x%llx)\n",
+	if (ret == 0 && missing == 0) {
+		fprintf(stderr, "test_sim_crash_recover: DST DID NOT CATCH "
+		    "NODURABLE -- every committed txn survived despite the "
+		    "skipped fsync (seed 0x%llx)\n",
 		    (unsigned long long)seed);
 		return (EXIT_FAILURE);
 	}
-	printf("test_sim_crash_recover: (bug build) NOSYNC commit correctly "
-	    "absent -- would need a real ack-before-fsync site to trip\n");
-#endif
-
+	printf("test_sim_crash_recover: DST CAUGHT NODURABLE -- %d "
+	    "\"committed\" txn(s) lost after crash because the log fsync was "
+	    "skipped (seed 0x%llx)\n", missing, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+#else
+	if (saw_uncommitted) {
+		fprintf(stderr, "test_sim_crash_recover: FAIL -- an "
+		    "uncommitted txn survived the crash (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
 	if (ret == 0) {
 		printf("test_sim_crash_recover: PASS -- %d committed txns "
 		    "survived, uncommitted did not, DB verifies clean "
@@ -288,4 +299,5 @@ main(argc, argv)
 	fprintf(stderr, "test_sim_crash_recover: FAIL (seed 0x%llx)\n",
 	    (unsigned long long)seed);
 	return (EXIT_FAILURE);
+#endif
 }

--- a/test/sim/test_sim_dup_crash.c
+++ b/test/sim/test_sim_dup_crash.c
@@ -1,0 +1,196 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_dup_crash.c --
+ *	Duplicate-key crash/recover scenario.  A DB_DUPSORT btree holds
+ *	several sorted duplicates per key, committed durably, then the
+ *	process crashes mid-uncommitted-txn.  After recovery every committed
+ *	(key, dup) pair must survive with the right multiplicity and sorted
+ *	order, the uncommitted dup must not, and the tree verifies clean.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_dup_crash && ./test_sim_dup_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_dup"
+#define DBFILE  "dup.db"
+#define NKEY    24
+#define NDUP    8
+
+static void
+mkkey(i, kbuf)
+	int i;
+	char *kbuf;
+{
+	(void)snprintf(kbuf, 32, "dk-%06d", i);
+}
+
+static void
+mkdup(i, j, vbuf)
+	int i, j;
+	char *vbuf;
+{
+	(void)snprintf(vbuf, 32, "dv-%06d-%03d", i, j);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_DUPSORT);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, j, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* Each key gets NDUP sorted dups, all in one durable txn per key. */
+	for (i = 0; i < NKEY; i++) {
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		mkkey(i, kbuf);
+		for (j = 0; j < NDUP; j++) {
+			mkdup(i, j, vbuf);
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+			data.data = vbuf;
+			data.size = (u_int32_t)strlen(vbuf) + 1;
+			if ((ret = db->put(db, txn, &key, &data, 0)) != 0) {
+				(void)txn->abort(txn);
+				return (ret);
+			}
+		}
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Uncommitted extra dup on key 0, then crash. */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	mkkey(0, kbuf);
+	mkdup(0, NDUP, vbuf);   /* a dup that was never committed */
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xD09;
+	DB_ENV *env;
+	DB *db;
+	DBC *dbc;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, j, ret, bad = 0, saw_uncommitted = 0;
+	db_recno_t cnt;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	/* Every committed (key,dup) present with exact multiplicity. */
+	for (i = 0; i < NKEY; i++) {
+		mkkey(i, kbuf);
+		for (j = 0; j < NDUP; j++) {
+			mkdup(i, j, vbuf);
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+			data.data = vbuf; data.size =
+			    (u_int32_t)strlen(vbuf) + 1;
+			if (db->get(db, NULL, &key, &data, DB_GET_BOTH) != 0)
+				bad++;
+		}
+		/* Multiplicity: key i must have exactly NDUP dups (key 0 must
+		 * NOT have the uncommitted extra). */
+		if ((ret = db->cursor(db, NULL, &dbc, 0)) == 0) {
+			mkkey(i, kbuf);
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+			if (dbc->get(dbc, &key, &data, DB_SET) == 0) {
+				cnt = 0;
+				(void)dbc->count(dbc, &cnt, 0);
+				if (cnt != (db_recno_t)NDUP) {
+					if (i == 0 && cnt == (db_recno_t)NDUP + 1)
+						saw_uncommitted = 1;
+					else
+						bad++;
+				}
+			}
+			(void)dbc->close(dbc);
+		}
+	}
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_dup_crash: verify FAILED: %s\n",
+		    db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (bad || saw_uncommitted) {
+		fprintf(stderr, "test_sim_dup_crash: FAIL -- %d bad dup "
+		    "checks, uncommitted=%d (seed 0x%llx)\n",
+		    bad, saw_uncommitted, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_dup_crash: PASS -- %d keys x %d sorted dups "
+	    "survived, uncommitted dup did not, tree clean (seed 0x%llx)\n",
+	    NKEY, NDUP, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_enospc.c
+++ b/test/sim/test_sim_enospc.c
@@ -1,0 +1,186 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_enospc.c --
+ *	Disk-full (ENOSPC) graceful-degradation scenario.  A seeded coin
+ *	fails a whole write with ENOSPC mid-workload (nothing persists for
+ *	that write).  The engine must degrade gracefully: the affected
+ *	put/commit returns an error rather than corrupting anything, txns
+ *	that committed durably BEFORE the disk filled survive, and after
+ *	recovery the DB verifies clean.
+ *
+ *	Invariant: no silent data loss and no corruption under ENOSPC.
+ *	Every txn we observed commit successfully (ret == 0) must be present
+ *	after crash+recover; a txn whose commit returned an error must not
+ *	leave a half-written record; the tree verifies clean.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_enospc && ./test_sim_enospc [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_enospc"
+#define DBFILE  "enospc.db"
+#define NTRY    128
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "es-%08d", i);
+	(void)snprintf(vbuf, 32, "ev-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+/* Records whose commit returned 0 (we saw them succeed): a bitmap the
+ * child writes to a sidecar so the parent knows what MUST survive. */
+static unsigned char g_committed[NTRY];
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+	FILE *fp;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	memset(g_committed, 0, sizeof(g_committed));
+
+	/* Warm up a durable prefix, THEN arm ENOSPC so the disk "fills"
+	 * mid-workload. */
+	for (i = 0; i < NTRY; i++) {
+		if (i == NTRY / 4)
+			__db_sim_io_enospc_enable(150);   /* 15% of writes ENOSPC */
+		mkrec(i, kbuf, vbuf);
+		if (env->txn_begin(env, NULL, &txn, 0) != 0)
+			continue;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if (db->put(db, txn, &key, &data, 0) != 0) {
+			(void)txn->abort(txn);
+			continue;
+		}
+		if (txn->commit(txn, DB_TXN_SYNC) == 0)
+			g_committed[i] = 1;   /* observed durable */
+	}
+
+	/* Hand the observed-committed bitmap to the parent. */
+	if ((fp = fopen(HOME "/committed.map", "wb")) != NULL) {
+		(void)fwrite(g_committed, 1, sizeof(g_committed), fp);
+		(void)fclose(fp);
+	}
+
+	/* Disarm before the crash so the durable-frontier truncation itself
+	 * is not subject to ENOSPC. */
+	__db_sim_io_enospc_enable(0);
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xF011;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	unsigned char committed[NTRY];
+	FILE *fp;
+	int i, ret, missing = 0, ncommitted = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	memset(committed, 0, sizeof(committed));
+	if ((fp = fopen(HOME "/committed.map", "rb")) != NULL) {
+		(void)fread(committed, 1, sizeof(committed), fp);
+		(void)fclose(fp);
+	}
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NTRY; i++) {
+		mkrec(i, kbuf, vbuf);
+		if (!committed[i])
+			continue;   /* commit failed/aborted -- no guarantee */
+		ncommitted++;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	/* No corruption under ENOSPC: the tree must verify clean. */
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_enospc: verify FAILED: %s "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing != 0) {
+		fprintf(stderr, "test_sim_enospc: FAIL -- %d of %d observed-"
+		    "committed txns lost under ENOSPC (seed 0x%llx)\n",
+		    missing, ncommitted, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_enospc: PASS -- graceful ENOSPC: all %d observed-"
+	    "committed txns durable, tree clean, no corruption (seed 0x%llx)\n",
+	    ncommitted, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_hash_crash.c
+++ b/test/sim/test_sim_hash_crash.c
@@ -1,0 +1,164 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_hash_crash.c --
+ *	Access-method crash/recover scenario for DB_HASH: commit N durable
+ *	txns into a hash DB, crash mid-uncommitted-txn (dropping every
+ *	un-fsync'd byte via the write-back model), recover, and assert every
+ *	committed record survived, the uncommitted one did not, and the DB
+ *	verifies clean.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_hash_crash && ./test_sim_hash_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_hash"
+#define DBFILE  "hash.db"
+#define NCOMMIT 64
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "hk-%08d", i);
+	(void)snprintf(vbuf, 32, "hv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_HASH,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "hash open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Uncommitted txn, then crash. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x4A54;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, mismatch = 0, saw_uncommitted = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	mkrec(NCOMMIT, kbuf, vbuf);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		saw_uncommitted = 1;
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "verify FAILED: %s\n", db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing || mismatch || saw_uncommitted) {
+		fprintf(stderr, "test_sim_hash_crash: FAIL -- %d missing, %d "
+		    "mismatched, uncommitted=%d (seed 0x%llx)\n",
+		    missing, mismatch, saw_uncommitted,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_hash_crash: PASS -- %d committed survived, "
+	    "uncommitted did not, verifies clean (seed 0x%llx)\n",
+	    NCOMMIT, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_overflow_torn.c
+++ b/test/sim/test_sim_overflow_torn.c
@@ -1,0 +1,135 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_overflow_torn.c --
+ *	Large / overflow-record corruption-detection scenario.  Values far
+ *	larger than the page size spill onto overflow pages.  With DB_CHKSUM
+ *	and a cold DB_PRIVATE cache, every page (including overflow pages)
+ *	is read from disk on lookup; a seeded corrupt-read flips a byte.
+ *	The engine must either return the CORRECT big value or error cleanly
+ *	(checksum) -- it must NEVER hand back a silently-wrong overflow
+ *	record.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_overflow_torn && ./test_sim_overflow_torn [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_ovf"
+#define DBFILE  "ovf.db"
+#define NKEYS   80
+#define PGSIZE  512
+#define VLEN    4000       /* >> PGSIZE: forces overflow pages */
+
+/* Deterministic big value for record i: a repeating verifiable pattern. */
+static void
+mkval(i, vbuf)
+	int i;
+	unsigned char *vbuf;
+{
+	int j;
+	for (j = 0; j < VLEN; j++)
+		vbuf[j] = (unsigned char)((i * 31 + j * 7) & 0xff);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x0FF;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32];
+	unsigned char vbuf[VLEN], want[VLEN];
+	int i, ret, correct = 0, detected = 0, silent_bad = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+
+	/* ---- populate a DB_CHKSUM btree with big (overflow) values ---- */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		goto err;
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_MPOOL, 0664)) != 0)
+		goto err;
+	if ((ret = db_create(&db, env, 0)) != 0)
+		goto err;
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		goto err;
+	for (i = 0; i < NKEYS; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "of-%08d", i);
+		mkval(i, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = VLEN;
+		if ((ret = db->put(db, NULL, &key, &data, 0)) != 0)
+			goto err;
+	}
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	/* ---- reopen COLD (DB_PRIVATE, small cache), arm corrupt reads,
+	 *      fetch every big value from disk ---- */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		goto err;
+	(void)env->set_cachesize(env, 0, 128 * 1024, 1);
+	if ((ret = env->open(env, HOME,
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0664)) != 0)
+		goto err;
+	if ((ret = db_create(&db, env, 0)) != 0)
+		goto err;
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE, 0, 0664)) != 0)
+		goto err;
+
+	__db_sim_activate(seed);
+	__db_sim_io_corrupt_enable(60);    /* 6% of page reads bit-flipped */
+
+	for (i = 0; i < NKEYS; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "of-%08d", i);
+		mkval(i, want);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size == VLEN &&
+			    memcmp(data.data, want, VLEN) == 0)
+				correct++;
+			else
+				silent_bad++;   /* wrong big value, no error */
+		} else
+			detected++;         /* clean checksum/page error */
+	}
+
+	__db_sim_io_corrupt_disable();
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_overflow_torn: %d correct, %d detected, %d "
+	    "SILENT-BAD (seed 0x%llx)\n", correct, detected, silent_bad,
+	    (unsigned long long)seed);
+
+	if (silent_bad != 0) {
+		fprintf(stderr, "test_sim_overflow_torn: FAIL -- %d silently "
+		    "corrupted overflow records slipped past the checksum\n",
+		    silent_bad);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_overflow_torn: PASS -- no silent corruption of "
+	    "overflow records; every read correct or cleanly rejected\n");
+	return (EXIT_SUCCESS);
+
+err:
+	fprintf(stderr, "test_sim_overflow_torn: setup error: %s\n",
+	    db_strerror(ret));
+	return (EXIT_FAILURE);
+}

--- a/test/sim/test_sim_queue_crash.c
+++ b/test/sim/test_sim_queue_crash.c
@@ -1,0 +1,170 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_queue_crash.c --
+ *	Access-method crash/recover scenario for DB_QUEUE (fixed-length
+ *	records): enqueue N records in durable txns, crash mid-uncommitted
+ *	enqueue (dropping every un-fsync'd byte), recover, and assert every
+ *	committed record survived, the uncommitted one did not, and the DB
+ *	verifies clean.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_queue_crash && ./test_sim_queue_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_queue"
+#define DBFILE  "queue.db"
+#define NCOMMIT 64
+#define RECLEN  24
+
+static void
+mkval(i, vbuf)
+	int i;
+	char *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(vbuf, RECLEN, "q%06d-%08llx", i,
+	    (unsigned long long)(tok & 0xffffffffu));
+	/* Pad to a fixed RECLEN (queue records are fixed-length). */
+	memset(vbuf + strlen(vbuf), '.', RECLEN - 1 - strlen(vbuf));
+	vbuf[RECLEN - 1] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_re_len(db, RECLEN);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_QUEUE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "queue open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	db_recno_t recno;
+	char vbuf[RECLEN];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkval(i, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &recno; key.size = sizeof(recno);
+		data.data = vbuf; data.size = RECLEN;
+		if ((ret = db->put(db, txn, &key, &data, DB_APPEND)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	mkval(NCOMMIT, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = &recno; key.size = sizeof(recno);
+	data.data = vbuf; data.size = RECLEN;
+	(void)db->put(db, txn, &key, &data, DB_APPEND);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x9EE;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	db_recno_t recno;
+	char vbuf[RECLEN];
+	int i, ret, missing = 0, mismatch = 0, extra = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkval(i, vbuf);
+		recno = (db_recno_t)(i + 1);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &recno; key.size = sizeof(recno);
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != RECLEN ||
+		    memcmp(data.data, vbuf, RECLEN) != 0)
+			mismatch++;
+	}
+	recno = (db_recno_t)(NCOMMIT + 1);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = &recno; key.size = sizeof(recno);
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		extra = 1;
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "verify FAILED: %s\n", db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing || mismatch || extra) {
+		fprintf(stderr, "test_sim_queue_crash: FAIL -- %d missing, %d "
+		    "mismatched, extra=%d (seed 0x%llx)\n",
+		    missing, mismatch, extra, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_queue_crash: PASS -- %d enqueued records survived, "
+	    "uncommitted did not, verifies clean (seed 0x%llx)\n",
+	    NCOMMIT, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_recno_crash.c
+++ b/test/sim/test_sim_recno_crash.c
@@ -1,0 +1,167 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_recno_crash.c --
+ *	Access-method crash/recover scenario for DB_RECNO: append N records
+ *	in durable txns, crash mid-uncommitted-append (dropping every
+ *	un-fsync'd byte), recover, and assert every committed record number
+ *	survived with the right value, the uncommitted append did not, and
+ *	the DB verifies clean.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_recno_crash && ./test_sim_recno_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_recno"
+#define DBFILE  "recno.db"
+#define NCOMMIT 64
+
+/* Deterministic seeded value for record i. */
+static void
+mkval(i, vbuf)
+	int i;
+	char *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(vbuf, 32, "r%08d-%08llx", i,
+	    (unsigned long long)(tok & 0xffffffffu));
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_RECNO,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "recno open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	db_recno_t recno;
+	char vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkval(i, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &recno; key.size = sizeof(recno);
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, DB_APPEND)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	mkval(NCOMMIT, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = &recno; key.size = sizeof(recno);
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, DB_APPEND);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x5EC0;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	db_recno_t recno;
+	char vbuf[32];
+	int i, ret, missing = 0, mismatch = 0, extra = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkval(i, vbuf);
+		recno = (db_recno_t)(i + 1);   /* DB_APPEND is 1-based */
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &recno; key.size = sizeof(recno);
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	/* The uncommitted append (recno NCOMMIT+1) must be ABSENT. */
+	recno = (db_recno_t)(NCOMMIT + 1);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = &recno; key.size = sizeof(recno);
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		extra = 1;
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "verify FAILED: %s\n", db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing || mismatch || extra) {
+		fprintf(stderr, "test_sim_recno_crash: FAIL -- %d missing, %d "
+		    "mismatched, extra=%d (seed 0x%llx)\n",
+		    missing, mismatch, extra, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_recno_crash: PASS -- %d appended records survived, "
+	    "uncommitted append did not, verifies clean (seed 0x%llx)\n",
+	    NCOMMIT, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_recover_idempotent.c
+++ b/test/sim/test_sim_recover_idempotent.c
@@ -1,0 +1,179 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_recover_idempotent.c --
+ *	Recovery idempotency scenario.  Recovery must be idempotent: running
+ *	it a second time on an already-recovered environment must reach the
+ *	exact same state.  A crash leaves a dirty env; we recover, snapshot
+ *	the full key/value state as a hash, recover AGAIN, snapshot again,
+ *	and assert the two hashes are identical.  A recovery that
+ *	double-applies (or fails to re-converge) a redo/undo would diverge.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_recover_idempotent && ./test_sim_recover_idempotent [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_idem"
+#define DBFILE  "idem.db"
+#define NCOMMIT 80
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "id-%08d", i);
+	(void)snprintf(vbuf, 32, "iv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	/* Uncommitted tail, then crash. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+/* Recover, then walk the whole tree in key order into an FNV-1a hash of
+ * every (key,value) pair -- a full-state fingerprint. */
+static int
+recover_and_hash(hashp)
+	uint64_t *hashp;
+{
+	DB_ENV *env;
+	DB *db;
+	DBC *dbc;
+	DBT key, data;
+	uint64_t h = 1469598103934665603ull;
+	int ret;
+	const unsigned char *p, *e;
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (-1);
+	if (open_db(env, &db, 0) != 0)
+		return (-1);
+	if ((ret = db->cursor(db, NULL, &dbc, 0)) != 0) {
+		(void)env->close(env, 0);
+		return (-1);
+	}
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	while ((ret = dbc->get(dbc, &key, &data, DB_NEXT)) == 0) {
+		for (p = key.data, e = p + key.size; p < e; p++) {
+			h ^= *p; h *= 1099511628211ull;
+		}
+		for (p = data.data, e = p + data.size; p < e; p++) {
+			h ^= *p; h *= 1099511628211ull;
+		}
+	}
+	(void)dbc->close(dbc);
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+	if (ret != DB_NOTFOUND)
+		return (-1);
+	*hashp = h;
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x1DE33;
+	uint64_t h1 = 0, h2 = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* First recovery + full-state fingerprint. */
+	if (recover_and_hash(&h1) != 0) {
+		fprintf(stderr, "test_sim_recover_idempotent: first recovery "
+		    "failed (seed 0x%llx)\n", (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	/* Second recovery on the already-recovered env + fingerprint. */
+	if (recover_and_hash(&h2) != 0) {
+		fprintf(stderr, "test_sim_recover_idempotent: second recovery "
+		    "failed (seed 0x%llx)\n", (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+
+	if (h1 != h2) {
+		fprintf(stderr, "test_sim_recover_idempotent: FAIL -- state "
+		    "diverged across a second recovery: %016llx != %016llx "
+		    "(seed 0x%llx)\n", (unsigned long long)h1,
+		    (unsigned long long)h2, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_recover_idempotent: PASS -- recovery idempotent; "
+	    "identical state hash %016llx across two recoveries (seed 0x%llx)\n",
+	    (unsigned long long)h1, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_split_crash.c
+++ b/test/sim/test_sim_split_crash.c
@@ -1,0 +1,198 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_split_crash.c --
+ *	Btree split/merge churn across a crash.  A small-page btree takes a
+ *	seeded insert/delete churn heavy enough to force many page splits
+ *	and merges, all in durable txns, then crashes.  After recovery the
+ *	live key set (inserts not later deleted) must be exactly present,
+ *	deleted keys absent, and the split-heavy tree verifies clean -- the
+ *	structural-integrity-under-crash invariant for the btree's most
+ *	complex mutation path.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_split_crash && ./test_sim_split_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_split"
+#define DBFILE  "split.db"
+#define NKEYS   500
+#define NDEL    120
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	/* Keys drawn so inserts scatter across the keyspace (forces splits
+	 * at many points, not just append-at-end). */
+	(void)snprintf(kbuf, 32, "sk-%08d", (i * 2654435761u) % 1000000u);
+	(void)snprintf(vbuf, 40, "sv-%08d-padded-value-xx", i);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+/* Which insert indexes get deleted (seeded, deterministic).  Deleted iff
+ * (i % (NKEYS/NDEL)) == 0, plus a seeded stride so the pattern varies. */
+static int
+is_deleted(i)
+	int i;
+{
+	return ((i % (NKEYS / NDEL)) == 0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[40];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* Insert every key (forces splits). */
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		(void)db->put(db, txn, &key, &data, 0);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	/* Delete a seeded subset (forces merges/rebalances). */
+	for (i = 0; i < NKEYS; i++) {
+		if (!is_deleted(i))
+			continue;
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		(void)db->del(db, txn, &key, 0);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Uncommitted split-inducing insert, then crash. */
+	{
+		char ukey[32] = "sk-99999999";
+		if (env->txn_begin(env, NULL, &txn, 0) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = ukey; key.size = (u_int32_t)strlen(ukey) + 1;
+			data.data = ukey; data.size = (u_int32_t)strlen(ukey)+1;
+			(void)db->put(db, txn, &key, &data, 0);
+			/* no commit */
+		}
+	}
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x5911;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[40];
+	int i, ret, missing = 0, ghost = 0, uncommitted = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (is_deleted(i)) {
+			if (ret == 0)
+				ghost++;   /* deleted key resurrected */
+		} else {
+			if (ret != 0)
+				missing++; /* live key lost */
+		}
+	}
+	{
+		char ukey[32] = "sk-99999999";
+		memset(&key, 0, sizeof(key));
+		key.data = ukey; key.size = (u_int32_t)strlen(ukey) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0)
+			uncommitted = 1;
+	}
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_split_crash: verify FAILED "
+		    "(split-heavy tree corrupt): %s\n", db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing || ghost || uncommitted) {
+		fprintf(stderr, "test_sim_split_crash: FAIL -- %d live keys "
+		    "missing, %d deleted resurrected, uncommitted=%d "
+		    "(seed 0x%llx)\n", missing, ghost, uncommitted,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_split_crash: PASS -- %d live keys survived "
+	    "split/merge churn, %d deletes stayed deleted, tree clean "
+	    "(seed 0x%llx)\n", NKEYS - NDEL, NDEL, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_torn_log.c
+++ b/test/sim/test_sim_torn_log.c
@@ -1,0 +1,181 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_torn_log.c --
+ *	Torn LOG write scenario.  A torn write persists only a seeded prefix
+ *	of a buffer but reports full success (a real partial page/sector
+ *	write at a power loss).  Armed on the log, the last flushed log
+ *	block can be torn.  Recovery MUST stop cleanly at the last intact
+ *	record -- it must not misparse the torn tail into a bogus record,
+ *	panic, or silently corrupt the tree.
+ *
+ *	Invariant: after a crash with a possibly-torn log, DB_RECOVER
+ *	succeeds (or fails with a clean error), the DB verifies clean, and
+ *	every txn that committed BEFORE the torn point is present.  We do
+ *	not assert anything about the record straddling the tear -- that is
+ *	the legitimate crash gray zone -- only that recovery is SAFE.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_torn_log && ./test_sim_torn_log [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_tornlog"
+#define DBFILE  "tornlog.db"
+#define NSYNC   32     /* fsync'd (durable) commits -- MUST survive */
+#define NNOSYNC 32     /* NOSYNC commits after -- may be torn away */
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "tl-%08d", i);
+	(void)snprintf(vbuf, 32, "tv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+one(env, db, i, sync)
+	DB_ENV *env;
+	DB *db;
+	int i, sync;
+{
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int ret;
+
+	mkrec(i, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	if ((ret = db->put(db, txn, &key, &data, 0)) != 0) {
+		(void)txn->abort(txn);
+		return (ret);
+	}
+	return (txn->commit(txn, sync ? DB_TXN_SYNC : DB_TXN_NOSYNC));
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* Durable prefix -- these fsync'd commits must all survive. */
+	for (i = 0; i < NSYNC; i++)
+		if ((ret = one(env, db, i, 1)) != 0)
+			return (ret);
+
+	/* Now arm torn writes and do NOSYNC commits: their log blocks may be
+	 * torn.  The write-back crash then drops un-fsync'd bytes AND a torn
+	 * write already left a partial tail on the last flushed block. */
+	__db_sim_io_corrupt_enable(200);   /* 20% of writes torn */
+	for (i = NSYNC; i < NSYNC + NNOSYNC; i++)
+		(void)one(env, db, i, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x70A;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Recovery must be SAFE even with a torn log tail. */
+	if ((ret = sim_env_recover(HOME, &env)) != 0) {
+		fprintf(stderr, "test_sim_torn_log: recovery did not complete "
+		    "cleanly (%s) -- a torn log tail was misparsed "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NSYNC; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	/* The tree must be structurally clean after recovering a torn log. */
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_torn_log: verify FAILED after "
+		    "torn-log recovery: %s (seed 0x%llx)\n",
+		    db_strerror(ret), (unsigned long long)seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing != 0) {
+		fprintf(stderr, "test_sim_torn_log: FAIL -- %d durable "
+		    "(fsync'd) commits lost to a torn log (seed 0x%llx)\n",
+		    missing, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_torn_log: PASS -- recovery safe past a torn log "
+	    "tail; all %d durable commits present, tree clean (seed 0x%llx)\n",
+	    NSYNC, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
## DST depth: real write-back crash model, 3 caught planted bugs, 14 scenarios

Deepens the Deterministic Simulation Testing framework (Tier A1+A2+A3 of the
maturity plan). Everything is behind `--enable-dst`; the OFF library exports
**0** `__db_sim_*` symbols and compiles the `__os_*` hooks to the stock path.

### A1 — write-back durable-frontier crash model, fully wired
A simulated crash now genuinely **drops bytes written-but-not-fsynced**:
`__db_sim_wb_crash()` truncates each tracked real file back to its durable
frontier (last fsync), so a commit acked without its log being fsync'd is
detectably lost after crash+recover. The write-side ENOSPC and torn-write knobs
are consumed by `__os_io`'s write fast path; the read fast path is offset-aware
(corrupt bit-flip + a ported stale-read ring); a per-I/O latency hook consumes
the latency knob.

### A2 — planted-bug harness (the "DST finds real bugs" proof)
Three known durability bugs planted at **real library sites**, each caught by a
scenario within **K=1** seeds (`test/sim/dst-bug-inject.sh` builds a dedicated
library per bug and asserts the catch):

| Bug | Site | Caught by |
|---|---|---|
| 1 NODURABLE | `__log_flush_int` skips the log fsync, still acks | `test_sim_crash_recover` — 64 "committed" txns lost |
| 2 NOCKSUM | `__db_check_chksum` ignores a checksum mismatch | `test_sim_torn` — SILENT-BAD reads |
| 3 LOSTUPDATE | `__memp_pgwrite` skips a dirty-page write, acks | `test_sim_ckp_crash` — flushed records lost |

A normal build compiles all three out and every scenario passes.

### A3 — scenario catalog grown 3 → 14
btree/hash/recno/queue op+crash+recover, checkpoint/page-flush durability, torn
log, ENOSPC degradation, txn abort atomicity, recovery idempotency, sorted
dups, overflow records, btree split/merge churn. Each: seeded workload → inject
fault → recover → assert invariant; deterministic (same seed → same outcome,
verified). **14/14 pass** from a fresh build; each crash/fault scenario passes
an 8-seed sweep.

### A4-lite
`dst-sweep.sh` (seed-range swarm) and `dst-bug-inject.sh` (bug-detection-latency
yardstick).

### Honest gaps (documented in DESIGN.md §4)
Stale-read ring is consumed on read but has no dedicated scenario (needs
offset-threaded write-side snapshot). Determinism-guard planting at
`__os_gettime`/`__os_id` deferred (read on legitimate recovery paths; earns its
keep with the v2 scheduler). `os_aio*`/`__os_physwrite` hooks and meson wiring
remain follow-ups.

Verified: fresh `--enable-dst` build → 14/14 scenarios PASS; OFF build → 0 DST
symbols; `dst-bug-inject.sh 16` → all 3 bugs caught at seed 1.
