### PR TITLE
test(coverage): broaden AM/verify subset + hash_func PBT (18.6→26.9% line, 12.3→17.8% branch)

### DIFF
--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -29,7 +29,7 @@ Knobs (all optional env vars):
 
 | Var          | Default                                   | Meaning                          |
 |--------------|-------------------------------------------|----------------------------------|
-| `COV_TESTS`  | `lock001: txn001: test001:btree ssi001: ssi002: recd001:btree` | `test:arg` pairs to run |
+| `COV_TESTS`  | core `test:arg` pairs + a `method/test` access-method matrix (see script) | tests to run |
 | `COV_JOBS`   | `nproc`                                   | build parallelism                |
 | `TCL_LIB`    | autodetected (nix store or `/usr/lib/tcl8.6`) | Tcl lib dir for `--with-tcl` |
 | `COV_TIMEOUT`| `2400`                                    | seconds ceiling for the test run |
@@ -93,50 +93,85 @@ the job log.
 
 ---
 
-## Measured baseline (2026-07-27)
+## Measured baseline (2026-07-27, updated 2026-07-28)
 
-`CC=gcc`, `--coverage`, src/-only, subset
-`lock001 txn001 test001:btree ssi001 ssi002 recd001:btree`
-(278 source files, ~72.7k lines, ~78.2k branches):
+`CC=gcc`, `--coverage`, src/-only. Two subsets have been measured:
+
+**Original core subset** (`lock001 txn001 test001:btree ssi001 ssi002
+recd001:btree`) exercised only the transaction/lock/**btree**/SSI/recovery
+core, leaving every other access method and all of db verification at 0%:
 
 | Metric    | Coverage                    |
 |-----------|-----------------------------|
-| **Lines** | **18.6%** (13534 / 72681)   |
-| **Branches** | **12.3%** (9631 / 78233) |
+| Lines     | 18.6% (13534 / 72681)       |
+| Branches  | 12.3% (9631 / 78233)        |
 | Functions | 25.6% (712 / 2781)          |
 
-This subset exercises the transaction/lock/btree/SSI/recovery core. The full
-Tcl suite (`run_std`) and the PBT/DST tiers would raise these substantially —
-the nightly job can widen `COV_TESTS` toward that. The point is the *floor is
-now measured* and every future test can be aimed at a specific red file below.
+**Current subset** (default in `run_coverage.sh`) adds a curated access-method
+matrix run via `run_method` — which runs each test **and then `verify_dir` +
+`salvage_dir`** on the databases it leaves behind, so one form lights up the
+hash / queue / recno / heap access methods *and* the db-verification and
+salvage paths:
 
-## Top 15 least-covered source files (aim tests here next)
+| Metric    | Coverage                    | vs. original |
+|-----------|-----------------------------|-------------|
+| **Lines** | **26.9%** (19543 / 72694)   | **+8.3 pp** |
+| **Branches** | **17.8%** (13934 / 78249) | **+5.5 pp** |
+| Functions | 33.3% (925 / 2781)          | +7.7 pp     |
 
-Entirely-untested subsystems in this subset — the biggest actionable gaps
-(the recovery-critical and access-method files near the top are the highest
-leverage for DST scenarios):
+The access-method matrix is:
+`btree/test001`, `hash/test001,006,010,025,077`, `queue/test001,007,025`,
+`recno/test001,006,024,025`, `heap/test001,013,024` (all reuse existing Tcl
+tests — no new Tcl written; the win is just running tests the CI subset had
+not). The formerly-0% files it moved:
+
+| file | before | after (line% / br%) |
+|------|:------:|:------:|
+| `hash/hash.c`        | 0% | 53.4 / 36.5 |
+| `hash/hash_page.c`   | 0% | 42.5 / 27.5 |
+| `hash/hash_verify.c` | 0% | 62.1 / 45.9 |
+| `qam/qam.c`          | 0% | 52.5 / 26.0 |
+| `qam/qam_verify.c`   | 0% | 44.7 / 26.3 |
+| `btree/bt_recno.c`   | 0% | 41.4 / 21.7 |
+| `heap/heap.c`        | 0% | 31.4 / 19.2 |
+| `heap/heap_verify.c` | 0% | 48.0 / 37.9 |
+| `db/db_vrfy.c`       | 0% | 48.0 / 34.3 |
+| `btree/bt_verify.c`  | 0% | 49.5 / 37.3 |
+
+The full Tcl suite (`run_std`) and the PBT/DST tiers would raise these
+further — the nightly job (`coverage.yml.workflow`) / the `ci-extended`
+full-tcl job can widen the matrix toward that. The point is the *floor is
+measured* and each future test is aimed at a specific red file below.
+
+## Top least-covered source files (aim tests here next)
+
+The remaining big untested surfaces are now dominated by **replication /
+repmgr** and **log/db verification** — subsystems that need multi-process
+harnesses (rep/repmgr) or crafted corrupt inputs (`log_verify_*`), which is
+why they lag the single-process access-method tests:
 
 | line% | br% | lines | branches | file | subsystem |
 |------:|----:|------:|---------:|------|-----------|
 | 0.0 | 0.0 | 1769 | 1565 | `log/log_verify_int.c` | log verification |
 | 0.0 | 0.0 | 1397 | 1702 | `btree/bt_compact.c` | btree compaction |
-| 0.0 | 0.0 | 1385 | 1590 | `hash/hash_page.c` | hash access method |
-| 0.0 | 0.0 | 1307 | 1838 | `heap/heap.c` | heap access method |
-| 0.0 | 0.0 | 1089 | 933 | `hash/hash.c` | hash access method |
 | 0.0 | 0.0 | 1064 | 1619 | `rep/rep_record.c` | replication |
 | 0.0 | 0.0 | 1017 | 644 | `log/log_verify_util.c` | log verification |
 | 0.0 | 0.0 | 923 | 942 | `rep/rep_util.c` | replication |
 | 0.0 | 0.0 | 883 | 620 | `db/partition.c` | partitioning |
 | 0.0 | 0.0 | 864 | 540 | `repmgr/repmgr_sel.c` | replication manager |
-| 0.0 | 0.0 | 842 | 1129 | `qam/qam.c` | queue access method |
 | 0.0 | 0.0 | 836 | 2069 | `hash/hash_rec.c` | hash recovery records |
 | 0.0 | 0.0 | 704 | 556 | `repmgr/repmgr_net.c` | replication manager |
 | 0.0 | 0.0 | 701 | 556 | `repmgr/repmgr_msg.c` | replication manager |
 | 0.0 | 0.0 | 556 | 656 | `rep/rep_elect.c` | replication elections |
+| 0.0 | 0.0 | 541 | 460 | `rep/rep_automsg.c` | replication |
+| 0.0 | 0.0 | 457 | 674 | `lock/lock_deadlock.c` | deadlock detection |
+| 0.0 | 0.0 | 431 | 470 | `sequence/sequence.c` | sequences |
+| 0.0 | 0.0 | 394 | 398 | `xa/xa.c` | XA transactions |
 
-Grouped by subsystem, the biggest untested surfaces are **replication /
-repmgr** (`rep_*`, `repmgr_*`), the **hash** and **heap** and **queue** access
-methods (only btree is exercised by `test001:btree`), **log/db verification**
-(`log_verify_*`, `db_vrfy.c`, `bt_verify.c`), **btree compaction**, and
-**partitioning**. Adding a hash/queue/heap variant of the access-method tests
-and a replication smoke test to `COV_TESTS` would move the needle most.
+Next-highest-leverage additions (future work): a **replication smoke test**
+(needs the multi-process rep harness — `rep0NN` / `repmgr0NN` exist but each
+spins up multiple envs; scope as a separate job), **`bt_compact.c`** (a
+`test111`-family compaction run), **`partition.c`** (a partition-callback DB
+test), and **`log_verify_*`** (`db_log_verify` over a real log). The PBT tier
+(`test/pbt/pbt_hash_func.c`) now also covers `src/hash/hash_func.c` pure
+logic.

--- a/test/coverage/baseline.txt
+++ b/test/coverage/baseline.txt
@@ -2,5 +2,5 @@
 # src/-only, gcov/lcov, representative test subset (see test/coverage/README.md).
 # The Coverage workflow warns (advisory) if branch coverage drops >0.5% below this.
 # Update after landing new tests that raise coverage (ratchet upward, never down).
-line=18.6
-branch=12.3
+line=26.9
+branch=17.8

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -28,10 +28,31 @@ root="$(cd "$here/../.." && pwd)"
 bld="$root/build_unix"
 
 # --- config ------------------------------------------------------------------
-# Bounded, representative subset: lock/txn/basic-access + SSI + one access
-# method + a recovery test. Runs in a few minutes, exercises the core engine.
-# Format: "test arg" pairs (arg blank for tests that take none).
-: "${COV_TESTS:=lock001: txn001: test001:btree ssi001: ssi002: recd001:btree}"
+# Bounded, representative subset. Runs in a few minutes, exercises the core
+# engine AND every access method plus the verify/salvage paths.
+#
+# Two entry forms, space-separated:
+#   test:arg      -> `eval test arg` (arg blank for tests taking none).
+#                    Used for the lock/txn/SSI/recovery core.
+#   method/test   -> `run_method method test`, which runs the access-method
+#                    test AND then verify_dir + salvage_dir on the databases
+#                    it leaves behind -- so this one form covers the hash/
+#                    queue/recno/heap access methods (src/hash, src/qam,
+#                    src/btree/bt_recno.c, src/heap) *and* db verification
+#                    (src/db/db_vrfy.c, src/hash/hash_verify.c,
+#                    src/qam/qam_verify.c, src/heap/heap_verify.c) *and*
+#                    salvage. Before this, only test001:btree ran, leaving
+#                    hash/queue/heap/recno + all verify code at 0%.
+#
+# The access-method matrix is deliberately curated (a few high-value tests per
+# method: basic put/get, cursors, dups, delete/renumber, partial) rather than
+# the whole suite, to keep the run bounded while lighting up the red files.
+: "${COV_TESTS:=lock001: txn001: ssi001: ssi002: recd001:btree \
+  btree/test001 \
+  hash/test001 hash/test006 hash/test010 hash/test025 hash/test077 \
+  queue/test001 queue/test007 queue/test025 \
+  recno/test001 recno/test006 recno/test024 recno/test025 \
+  heap/test001 heap/test013 heap/test024}"
 : "${COV_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 : "${TCLSH:=tclsh}"
 # TCL lib dir: nix store on this box, /usr/lib/tcl8.6 on ubuntu CI.
@@ -97,10 +118,20 @@ runtcl="$bld/.cov-run.tcl"
 {
   echo 'source ../test/tcl/test.tcl'
   for pair in $COV_TESTS; do
-    t="${pair%%:*}"; a="${pair#*:}"
-    printf 'source ../test/tcl/%s.tcl\n' "$t"
-    printf 'if {[catch {eval %s %s} res]} { puts "FAIL %s: $res"; exit 1 }\n' "$t" "$a" "$t"
-    printf 'puts "PASS %s"\n' "$t"
+    case "$pair" in
+    */*)  # method/test form -> run_method (test + verify_dir + salvage_dir)
+      m="${pair%%/*}"; t="${pair#*/}"
+      printf 'source ../test/tcl/%s.tcl\n' "$t"
+      printf 'if {[catch {run_method %s %s 0 1} res]} { puts "FAIL %s/%s: $res"; exit 1 }\n' "$m" "$t" "$m" "$t"
+      printf 'puts "PASS %s/%s"\n' "$m" "$t"
+      ;;
+    *)    # test:arg form -> eval test arg
+      t="${pair%%:*}"; a="${pair#*:}"
+      printf 'source ../test/tcl/%s.tcl\n' "$t"
+      printf 'if {[catch {eval %s %s} res]} { puts "FAIL %s: $res"; exit 1 }\n' "$t" "$a" "$t"
+      printf 'puts "PASS %s"\n' "$t"
+      ;;
+    esac
   done
 } > "$runtcl"
 # tclsh8.6 preferred if present (nix); fall back to tclsh.

--- a/test/pbt/meson.build
+++ b/test/pbt/meson.build
@@ -31,6 +31,7 @@ pbt_props = [
   'defcmp',        # __bam_defcmp total-order over byte strings
   'put_get',       # in-memory B-tree put/get round-trip (end-to-end)
   'hash_model',    # DB_HASH vs in-test model map (stateful)
+  'hash_func',     # __ham_func2/3/4/5 determinism + length-honoring + FNV oracle
 ]
 
 # Try to locate hegel-c.  cmake + pkg-config are both attempted; either

--- a/test/pbt/pbt_hash_func.c
+++ b/test/pbt/pbt_hash_func.c
@@ -1,0 +1,143 @@
+/*-
+ * test/pbt/pbt_hash_func.c
+ *	Property-based tests for the hash access method's key-hashing
+ *	functions (src/hash/hash_func.c): __ham_func2 (Phong Vo linear
+ *	congruential), __ham_func3 (sdbm), __ham_func4 (Chris Torek),
+ *	__ham_func5 (Fowler/Noll/Vo).  __ham_func5 is the default hash
+ *	(see __ham_init_htab / DB->set_h_hash); the others are selectable.
+ *
+ * Contract from the source: each is
+ *	u_int32_t f(DB *dbp, const void *key, u_int32_t len);
+ * a pure function of (key bytes, len).  dbp is COMPQUIET'd (unused), so
+ * NULL is safe.  It reads exactly `len` bytes of `key` and returns a
+ * 32-bit hash.  The contract a hash function must honor for the access
+ * method to be correct:
+ *
+ *   determinism    -- equal (key,len) inputs yield equal outputs.  A
+ *                     non-deterministic hash would send the same key to
+ *                     different buckets on different lookups.
+ *   length-honoring -- the result depends only on the first `len` bytes;
+ *                     trailing bytes past `len` never change it.  All
+ *                     four functions iterate exactly `key..key+len`.
+ *   func5 == FNV    -- __ham_func5 is exactly the 32-bit FNV-1 recurrence
+ *                     h = (h * 16777619) ^ byte, h0 = 0 (an independent
+ *                     re-derivation of the loop body).
+ *
+ * These are exported from libdb (verified via nm on the built .so); the
+ * prototypes live in an internal header, so we declare them locally to
+ * avoid dragging in the full db_int.h include tree.
+ */
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+/* Exported by libdb; prototypes from src/hash/hash_func.c. */
+extern u_int32_t __ham_func2(DB *, const void *, u_int32_t);
+extern u_int32_t __ham_func3(DB *, const void *, u_int32_t);
+extern u_int32_t __ham_func4(DB *, const void *, u_int32_t);
+extern u_int32_t __ham_func5(DB *, const void *, u_int32_t);
+
+#if defined(PBT_HAVE_HEGEL)
+
+#include <string.h>
+
+typedef u_int32_t (*hashfn)(DB *, const void *, u_int32_t);
+static const hashfn FUNCS[] = {
+	__ham_func2, __ham_func3, __ham_func4, __ham_func5
+};
+#define NFUNCS ((int)(sizeof(FUNCS) / sizeof(FUNCS[0])))
+
+/* Draw a byte buffer (0..128 bytes) into caller-owned storage. */
+static uint8_t *
+draw_key(hegel_test_case *tc, size_t *lenp)
+{
+	return (hegel_draw_bytes(tc, hegel_binary(0, 128), lenp));
+}
+
+/* P1: determinism -- same bytes + len hash identically, for every func. */
+static void
+prop_determinism(hegel_test_case *tc, void *u)
+{
+	uint8_t *k;
+	size_t len = 0;
+	int i;
+	(void)u;
+
+	k = draw_key(tc, &len);
+	for (i = 0; i < NFUNCS; i++)
+		hegel_assume(FUNCS[i](NULL, k, (u_int32_t)len) ==
+		    FUNCS[i](NULL, k, (u_int32_t)len));
+	free(k);
+}
+
+/*
+ * P2: length-honoring -- the hash of the first `len` bytes is unaffected
+ * by whatever follows.  We hash `k` at length `len`, then append a random
+ * suffix and hash the SAME prefix length again; results must match.
+ */
+static void
+prop_length_honoring(hegel_test_case *tc, void *u)
+{
+	uint8_t *prefix, *suffix, *joined;
+	size_t plen = 0, slen = 0;
+	int i;
+	(void)u;
+
+	prefix = draw_key(tc, &plen);
+	suffix = draw_key(tc, &slen);
+
+	joined = malloc(plen + slen + 1);	/* +1 so malloc(0) is fine */
+	hegel_assume(joined != NULL);
+	if (plen != 0)
+		memcpy(joined, prefix, plen);
+	if (slen != 0)
+		memcpy(joined + plen, suffix, slen);
+
+	for (i = 0; i < NFUNCS; i++)
+		hegel_assume(
+		    FUNCS[i](NULL, prefix, (u_int32_t)plen) ==
+		    FUNCS[i](NULL, joined, (u_int32_t)plen));
+
+	free(prefix);
+	free(suffix);
+	free(joined);
+}
+
+/* P3: __ham_func5 is exactly the 32-bit FNV-1 recurrence (oracle). */
+static void
+prop_func5_is_fnv(hegel_test_case *tc, void *u)
+{
+	uint8_t *k;
+	size_t len = 0, i;
+	u_int32_t h;
+	(void)u;
+
+	k = draw_key(tc, &len);
+	for (h = 0, i = 0; i < len; i++) {
+		h *= 16777619U;
+		h ^= k[i];
+	}
+	hegel_assume(__ham_func5(NULL, k, (u_int32_t)len) == h);
+	free(k);
+}
+
+static const pbt_entry_t tests[] = {
+	{ "determinism",      prop_determinism,      400 },
+	{ "length_honoring",  prop_length_honoring,  500 },
+	{ "func5_is_fnv",     prop_func5_is_fnv,      500 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "determinism",      NULL, 0 },
+	{ "length_honoring",  NULL, 0 },
+	{ "func5_is_fnv",     NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("hash_func", tests)


### PR DESCRIPTION
## Summary

Raise **measured** libdb coverage by aiming genuine tests at the thinnest spots (Tier B3). Two changes, biggest-win-first:

1. **Broaden the coverage subset** (`test/coverage/run_coverage.sh`). The CI subset ran only `test001:btree`, leaving every non-btree access method and *all* of db verification at **0%**. Added a curated access-method matrix run via `run_method`, which runs each test **and then `verify_dir` + `salvage_dir`** on the DBs it leaves behind — so one entry form covers the hash/queue/recno/heap access methods *and* the db-verification + salvage paths. **All tests already existed**; the win is running tests the subset had not (no new Tcl written). A new `method/test` entry form dispatches to `run_method` alongside the existing `test:arg` form.

2. **New PBT** `test/pbt/pbt_hash_func.c` for `src/hash/hash_func.c` (`__ham_func2/3/4/5`), three properties grounded in the source contract: **determinism**, **length-honoring** (result depends only on the first `len` bytes), and **func5_is_fnv** (`__ham_func5` is exactly the 32-bit FNV-1 recurrence). Compiles + links against libdb in stub mode and runs green under `meson test --suite pbt`; the properties were also verified against the real libdb symbols.

## Measured delta (CC=gcc, --coverage, src/-only)

| Metric | Before | After | Δ |
|--------|:------:|:-----:|:--:|
| **Lines** | 18.6% (13534/72681) | **26.9%** (19543/72694) | **+8.3 pp** |
| **Branches** | 12.3% (9631/78233) | **17.8%** (13934/78249) | **+5.5 pp** |
| Functions | 25.6% (712/2781) | 33.3% (925/2781) | +7.7 pp |

Formerly-0% files now covered (line% / branch%): `hash.c` 53/37, `hash_page.c` 43/28, `hash_verify.c` 62/46, `qam.c` 53/26, `qam_verify.c` 45/26, `bt_recno.c` 41/22, `heap.c` 31/19, `heap_verify.c` 48/38, `db_vrfy.c` 48/34, `bt_verify.c` 50/37.

Ratcheted `baseline.txt` up (18.6/12.3 → 26.9/17.8) and refreshed the README baseline + gap list.

## Remaining biggest gaps (future work)

Now dominated by subsystems that need heavier harnesses, not single-process AM tests:
- **replication / repmgr** (`rep_record.c`, `rep_util.c`, `repmgr_*`, `rep_elect.c`) — need multi-process rep harnesses (`rep0NN`/`repmgr0NN` each spin up multiple envs; scope as a separate slow job).
- **log verification** (`log_verify_int.c`, `log_verify_util.c`) — need crafted corrupt logs / `db_log_verify` over a real log.
- **btree compaction** (`bt_compact.c`), **partitioning** (`partition.c`) — a `test111`-family compaction run and a partition-callback DB test would move these.

## Validation

- `run_coverage.sh` run end-to-end in the nix dev shell before/after; all 21 subset tests PASS.
- `meson test --suite pbt`: 6/6 OK (incl. new `pbt_hash_func`).
- No build artifacts committed (`build_unix/` gitignored).

Does NOT touch AWS, build_windows/, ci.yml, .github/ocr/, dist/cocci/, test/sim/, test/faultinject/, test/fuzz/.