### PR TITLE
test: add compint/compress/recno PBT properties + compaction/partition coverage (26.9->28.8%)

### DIFF
--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -93,7 +93,7 @@ the job log.
 
 ---
 
-## Measured baseline (2026-07-27, updated 2026-07-28)
+## Measured baseline (2026-07-27, updated 2026-07-28, extended 2026-07-29)
 
 `CC=gcc`, `--coverage`, src/-only. Two subsets have been measured:
 
@@ -111,19 +111,23 @@ core, leaving every other access method and all of db verification at 0%:
 matrix run via `run_method` — which runs each test **and then `verify_dir` +
 `salvage_dir`** on the databases it leaves behind, so one form lights up the
 hash / queue / recno / heap access methods *and* the db-verification and
-salvage paths:
+salvage paths — plus a compaction test (`btree/test111`) and two
+partition runs (`run_range_partition` / `run_partition_callback` over
+`test001`) that light up `bt_compact.c` and `partition.c`:
 
 | Metric    | Coverage                    | vs. original |
 |-----------|-----------------------------|-------------|
-| **Lines** | **26.9%** (19543 / 72694)   | **+8.3 pp** |
-| **Branches** | **17.8%** (13934 / 78249) | **+5.5 pp** |
-| Functions | 33.3% (925 / 2781)          | +7.7 pp     |
+| **Lines** | **28.8%** (20970 / 72757)   | **+10.2 pp** |
+| **Branches** | **19.0%** (14921 / 78331) | **+6.7 pp** |
+| Functions | 34.9% (971 / 2782)          | +9.3 pp     |
 
 The access-method matrix is:
-`btree/test001`, `hash/test001,006,010,025,077`, `queue/test001,007,025`,
-`recno/test001,006,024,025`, `heap/test001,013,024` (all reuse existing Tcl
-tests — no new Tcl written; the win is just running tests the CI subset had
-not). The formerly-0% files it moved:
+`btree/test001`, `btree/test111` (compaction),
+`hash/test001,006,010,025,077`, `queue/test001,007,025`,
+`recno/test001,006,024,025`, `heap/test001,013,024`, plus
+`run_range_partition test001 btree` and `run_partition_callback test001 btree`
+(all reuse existing Tcl tests — no new Tcl written; the win is just running
+tests the CI subset had not). The formerly-0% files it moved:
 
 | file | before | after (line% / br%) |
 |------|:------:|:------:|
@@ -133,6 +137,8 @@ not). The formerly-0% files it moved:
 | `qam/qam.c`          | 0% | 52.5 / 26.0 |
 | `qam/qam_verify.c`   | 0% | 44.7 / 26.3 |
 | `btree/bt_recno.c`   | 0% | 41.4 / 21.7 |
+| `btree/bt_compact.c` | 0% | 30.1 / 17.4 |
+| `db/partition.c`     | 0% | 53.7 / 45.0 |
 | `heap/heap.c`        | 0% | 31.4 / 19.2 |
 | `heap/heap_verify.c` | 0% | 48.0 / 37.9 |
 | `db/db_vrfy.c`       | 0% | 48.0 / 34.3 |
@@ -153,11 +159,9 @@ why they lag the single-process access-method tests:
 | line% | br% | lines | branches | file | subsystem |
 |------:|----:|------:|---------:|------|-----------|
 | 0.0 | 0.0 | 1769 | 1565 | `log/log_verify_int.c` | log verification |
-| 0.0 | 0.0 | 1397 | 1702 | `btree/bt_compact.c` | btree compaction |
 | 0.0 | 0.0 | 1064 | 1619 | `rep/rep_record.c` | replication |
 | 0.0 | 0.0 | 1017 | 644 | `log/log_verify_util.c` | log verification |
 | 0.0 | 0.0 | 923 | 942 | `rep/rep_util.c` | replication |
-| 0.0 | 0.0 | 883 | 620 | `db/partition.c` | partitioning |
 | 0.0 | 0.0 | 864 | 540 | `repmgr/repmgr_sel.c` | replication manager |
 | 0.0 | 0.0 | 836 | 2069 | `hash/hash_rec.c` | hash recovery records |
 | 0.0 | 0.0 | 704 | 556 | `repmgr/repmgr_net.c` | replication manager |
@@ -167,11 +171,18 @@ why they lag the single-process access-method tests:
 | 0.0 | 0.0 | 457 | 674 | `lock/lock_deadlock.c` | deadlock detection |
 | 0.0 | 0.0 | 431 | 470 | `sequence/sequence.c` | sequences |
 | 0.0 | 0.0 | 394 | 398 | `xa/xa.c` | XA transactions |
+| 5.4 | 2.0 | 445 | 306 | `qam/qam_files.c` | queue extent files |
+| 30.1 | 17.4 | 1397 | 1702 | `btree/bt_compact.c` | btree compaction (was 0%) |
 
 Next-highest-leverage additions (future work): a **replication smoke test**
 (needs the multi-process rep harness — `rep0NN` / `repmgr0NN` exist but each
-spins up multiple envs; scope as a separate job), **`bt_compact.c`** (a
-`test111`-family compaction run), **`partition.c`** (a partition-callback DB
-test), and **`log_verify_*`** (`db_log_verify` over a real log). The PBT tier
-(`test/pbt/pbt_hash_func.c`) now also covers `src/hash/hash_func.c` pure
-logic.
+spins up multiple envs; scope as a separate job), **`log_verify_*`**
+(`db_log_verify` over a real log), **`hash/hash_rec.c`** (hash recovery
+records — needs a crash/recovery run over a hash DB), and **`sequence.c`** /
+**`xa.c`** (each has a small dedicated Tcl test that the subset omits).
+`btree/bt_compact.c` and `db/partition.c` moved off 0% in this subset via
+`btree/test111` and the partition runners; the PBT tier
+(`test/pbt/pbt_hash_func.c`, `pbt_compint.c`, `pbt_compress.c`,
+`pbt_recno.c`) covers pure logic in `hash_func.c`, `db_compint.c`,
+`bt_compress.c`, and `bt_recno.c` respectively (verified via hegel-c, run
+separately from this Tcl subset).

--- a/test/coverage/baseline.txt
+++ b/test/coverage/baseline.txt
@@ -2,5 +2,5 @@
 # src/-only, gcov/lcov, representative test subset (see test/coverage/README.md).
 # The Coverage workflow warns (advisory) if branch coverage drops >0.5% below this.
 # Update after landing new tests that raise coverage (ratchet upward, never down).
-line=26.9
-branch=17.8
+line=28.8
+branch=19.0

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -43,16 +43,24 @@ bld="$root/build_unix"
 #                    src/qam/qam_verify.c, src/heap/heap_verify.c) *and*
 #                    salvage. Before this, only test001:btree ran, leaving
 #                    hash/queue/heap/recno + all verify code at 0%.
+#   proc@test@method -> `run_range_partition`/`run_partition_callback`
+#                    (or any run_* proc) with (test method) -- runs an
+#                    existing Tcl test under range partitioning / partition
+#                    callbacks, lighting up src/db/partition.c.
 #
 # The access-method matrix is deliberately curated (a few high-value tests per
 # method: basic put/get, cursors, dups, delete/renumber, partial) rather than
 # the whole suite, to keep the run bounded while lighting up the red files.
+# btree/test111 adds compaction coverage (src/btree/bt_compact.c); the
+# run_range_partition/run_partition_callback entries add src/db/partition.c.
 : "${COV_TESTS:=lock001: txn001: ssi001: ssi002: recd001:btree \
-  btree/test001 \
+  btree/test001 btree/test111 \
   hash/test001 hash/test006 hash/test010 hash/test025 hash/test077 \
   queue/test001 queue/test007 queue/test025 \
   recno/test001 recno/test006 recno/test024 recno/test025 \
-  heap/test001 heap/test013 heap/test024}"
+  heap/test001 heap/test013 heap/test024 \
+  run_range_partition@test001@btree \
+  run_partition_callback@test001@btree}"
 : "${COV_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 : "${TCLSH:=tclsh}"
 # TCL lib dir: nix store on this box, /usr/lib/tcl8.6 on ubuntu CI.
@@ -119,6 +127,12 @@ runtcl="$bld/.cov-run.tcl"
   echo 'source ../test/tcl/test.tcl'
   for pair in $COV_TESTS; do
     case "$pair" in
+    *@*)  # proc@test@method form -> `run_proc test method` (partition runners)
+      p="${pair%%@*}"; rest="${pair#*@}"; t="${rest%%@*}"; m="${rest#*@}"
+      printf 'source ../test/tcl/%s.tcl\n' "$t"
+      printf 'if {[catch {%s %s %s 0 1} res]} { puts "FAIL %s/%s/%s: $res"; exit 1 }\n' "$p" "$t" "$m" "$p" "$t" "$m"
+      printf 'puts "PASS %s/%s/%s"\n' "$p" "$t" "$m"
+      ;;
     */*)  # method/test form -> run_method (test + verify_dir + salvage_dir)
       m="${pair%%/*}"; t="${pair#*/}"
       printf 'source ../test/tcl/%s.tcl\n' "$t"

--- a/test/pbt/README.md
+++ b/test/pbt/README.md
@@ -21,6 +21,10 @@ reachable) and then prints `SKIP` and exits 0, so CI stays green without the
 | `pbt_defcmp.c`      | key-comparator total order | `__bam_defcmp()` (`src/btree/bt_compare.c`) |
 | `pbt_put_get.c`     | put/get round-trip (end-to-end) | in-memory B-tree via `db_create` + `DB->open`/`put`/`get` |
 | `pbt_hash_model.c`  | DB_HASH vs. model map (stateful) | in-memory `DB_HASH` via `db_create` + `DB->open`/`put`/`del`/`get` |
+| `pbt_hash_func.c`   | key-hash determinism / length / FNV | `__ham_func2/3/4/5` (`src/hash/hash_func.c`) |
+| `pbt_compint.c`     | varint codec round-trip / order-preserving | `__db_compress_int` / `__db_decompress_int` / `__db_*_count_int` / `__db_decompress_int32` (`src/common/db_compint.c`) |
+| `pbt_compress.c`    | prefix-compression codec round-trip | `__bam_defcompress` / `__bam_defdecompress` (`src/btree/bt_compress.c`) |
+| `pbt_recno.c`       | recno append/get + DB_RENUMBER contiguity | in-memory `DB_RECNO` (`src/btree/bt_recno.c`) |
 
 ## Property catalog
 
@@ -37,6 +41,10 @@ The `M_*_SWAP` macros swap between big- and little-endian in place. Byte
 reversal is an involution.
 - **swap16/32/64_involution** — `swap(swap(x)) == x` for all inputs.
 - **swap32_reverses_bytes** — one swap equals a manual 4-byte reversal.
+- **copyswap32/16_unaligned** — `P_32_COPYSWAP` / `P_16_COPYSWAP` reverse
+  bytes into an *unaligned* destination (the form used for on-page fields).
+- **swap64_unaligned** — `P_64_SWAP` on an unaligned 8-byte location both
+  reverses (one call) and restores (two calls), at a random byte offset.
 
 ### `pbt_defcmp` — `__bam_defcmp()` total order
 Source contract: returns `< 0 / = 0 / > 0` for `a < / = / > b`, comparing byte
@@ -63,6 +71,41 @@ and a simple in-test array-map model, asserting they agree after every
 operation (and at the end over the whole key pool). Keys are drawn from a
 small fixed pool so overwrites, deletes of present/absent keys, and re-inserts
 occur frequently.
+
+### `pbt_compint` — integer-compression (varint) codec
+`src/common/db_compint.c` is the self-describing varint codec (1–9 bytes,
+high-bit length prefix) used for on-disk lengths/offsets in the compressed
+btree. Built only when `HAVE_COMPRESSION` is defined (the default). The
+source header comment gives the exact format table and states it "depends on
+big-endian order".
+- **roundtrip** — `decompress(compress(i)) == i` over the full `u_int64_t`
+  range (drawn as signed bits reinterpreted, so 9-byte encodings are hit).
+- **count_agrees** — `__db_compress_count_int(i)` equals the bytes
+  `__db_compress_int` writes, `__db_decompress_count_int(buf)`, and the length
+  `__db_decompress_int` reports.
+- **order_preserving** — the encoding sorts like the integers: `a<=b` iff the
+  encoded bytes compare `<=` (common-prefix compare, longer encoding wins
+  ties). This is what lets the codec store sortable keys.
+- **int32_matches** — for `i <= UINT32_MAX`, `__db_decompress_int32` agrees
+  with `__db_decompress_int` on both value and byte count.
+
+### `pbt_compress` — btree prefix-compression codec
+`__bam_defcompress` writes a compressed encoding of a `(key, data)` pair
+expressed relative to the preceding `(prevKey, prevData)`; `__bam_defdecompress`
+reverses it. (`src/btree/bt_compress.c`, `HAVE_COMPRESSION`.)
+- **compress_roundtrip** — `decompress(compress(prev, cur)) == cur`
+  byte-for-byte, for arbitrary preceding and current key/data byte strings
+  (sizes chosen to hit both long-shared-prefix and no-prefix paths). This is
+  the invariant the whole compressed on-disk format rests on.
+
+### `pbt_recno` — recno access method (end-to-end)
+Opens a real in-memory `DB_RECNO` and drives it through the public API.
+- **put_get_roundtrip** — a value appended with `DB_APPEND` reads back
+  byte-for-byte at its assigned record number.
+- **renumber_contiguous** — with `DB_RENUMBER`, after any generated sequence
+  of appends and in-range deletes, a cursor walk (`DB_NEXT`) yields record
+  numbers `1, 2, 3, …` with no gaps, and exactly `N − deletes` records
+  survive (the recno renumber contract in `bt_recno.c __ramc_del`).
 
 ## Building and running
 

--- a/test/pbt/meson.build
+++ b/test/pbt/meson.build
@@ -27,11 +27,14 @@ pbt_common = files('pbt_common.h')
 
 pbt_props = [
   'log_compare',   # LSN total-order: log_compare() (public db.h)
-  'byteswap',      # M_*_SWAP involution (src/dbinc/db_swap.h)
+  'byteswap',      # M_*_SWAP + P_*_COPYSWAP involution (src/dbinc/db_swap.h)
   'defcmp',        # __bam_defcmp total-order over byte strings
   'put_get',       # in-memory B-tree put/get round-trip (end-to-end)
   'hash_model',    # DB_HASH vs in-test model map (stateful)
   'hash_func',     # __ham_func2/3/4/5 determinism + length-honoring + FNV oracle
+  'compint',       # varint codec round-trip/order-preserving (src/common/db_compint.c)
+  'compress',      # __bam_defcompress/decompress round-trip (src/btree/bt_compress.c)
+  'recno',         # recno append/get + DB_RENUMBER contiguity (src/btree/bt_recno.c)
 ]
 
 # Try to locate hegel-c.  cmake + pkg-config are both attempted; either

--- a/test/pbt/pbt_byteswap.c
+++ b/test/pbt/pbt_byteswap.c
@@ -10,6 +10,13 @@
  * swapping twice must yield the original value for any input.  A single
  * swap of a 32-bit value must also equal the manual byte reversal.
  *
+ * We also cover the P_*_COPYSWAP / P_64_SWAP forms that operate on
+ * potentially *unaligned* byte buffers (used for on-page fields that are
+ * not naturally aligned): P_32_COPYSWAP/P_16_COPYSWAP copy-and-reverse
+ * into a separate destination, and P_64_SWAP reverses an 8-byte location
+ * in place.  These are the forms bt_conv.c / db_conv.c actually use, and
+ * they read/write byte-at-a-time so unaligned offsets must work.
+ *
  * These are header macros (no libdb symbol), but they are real BDB
  * on-disk-format code exercised on every cross-endian database.
  */
@@ -75,11 +82,85 @@ prop_swap32_reverses_bytes(hegel_test_case *tc, void *u)
 	    a[2] == b[1] && a[3] == b[0]);
 }
 
+/*
+ * P5: P_32_COPYSWAP into an UNALIGNED destination reverses the 4 bytes.
+ * We place both source and destination at a random offset inside a byte
+ * buffer so alignment is not assumed, and check the reversal explicitly.
+ */
+static void
+prop_copyswap32_unaligned(hegel_test_case *tc, void *u)
+{
+	u_int8_t buf[16];
+	u_int8_t *src, *dst;
+	int soff, doff, i;
+	(void)u;
+
+	soff = (int)hegel_draw_int(tc, hegel_integers(0, 3));
+	doff = (int)hegel_draw_int(tc, hegel_integers(8, 11));
+	src = buf + soff;
+	dst = buf + doff;
+	for (i = 0; i < 4; i++)
+		src[i] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
+
+	P_32_COPYSWAP(src, dst);
+	hegel_assume(dst[0] == src[3] && dst[1] == src[2] &&
+	    dst[2] == src[1] && dst[3] == src[0]);
+}
+
+/* P6: P_16_COPYSWAP into an unaligned destination reverses the 2 bytes. */
+static void
+prop_copyswap16_unaligned(hegel_test_case *tc, void *u)
+{
+	u_int8_t buf[16];
+	u_int8_t *src, *dst;
+	int soff, doff;
+	(void)u;
+
+	soff = (int)hegel_draw_int(tc, hegel_integers(0, 5));
+	doff = (int)hegel_draw_int(tc, hegel_integers(8, 13));
+	src = buf + soff;
+	dst = buf + doff;
+	src[0] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
+	src[1] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
+
+	P_16_COPYSWAP(src, dst);
+	hegel_assume(dst[0] == src[1] && dst[1] == src[0]);
+}
+
+/*
+ * P7: P_64_SWAP on an unaligned 8-byte location is an involution and
+ * equals the manual 8-byte reversal.  Runs at a random offset so the
+ * byte-at-a-time swap is exercised without alignment.
+ */
+static void
+prop_swap64_unaligned(hegel_test_case *tc, void *u)
+{
+	u_int8_t buf[16], orig[8];
+	u_int8_t *p;
+	int off, i;
+	(void)u;
+
+	off = (int)hegel_draw_int(tc, hegel_integers(0, 8));
+	p = buf + off;
+	for (i = 0; i < 8; i++)
+		p[i] = orig[i] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
+
+	P_64_SWAP(p);
+	for (i = 0; i < 8; i++)
+		hegel_assume(p[i] == orig[7 - i]);	/* one swap reverses */
+	P_64_SWAP(p);
+	for (i = 0; i < 8; i++)
+		hegel_assume(p[i] == orig[i]);		/* two swaps restore */
+}
+
 static const pbt_entry_t tests[] = {
 	{ "swap16_involution",     prop_swap16_involution,     500 },
 	{ "swap32_involution",     prop_swap32_involution,     500 },
 	{ "swap64_involution",     prop_swap64_involution,     500 },
 	{ "swap32_reverses_bytes", prop_swap32_reverses_bytes, 500 },
+	{ "copyswap32_unaligned",  prop_copyswap32_unaligned,  500 },
+	{ "copyswap16_unaligned",  prop_copyswap16_unaligned,  500 },
+	{ "swap64_unaligned",      prop_swap64_unaligned,      500 },
 	{ NULL, NULL, 0 }
 };
 
@@ -90,6 +171,9 @@ static const pbt_entry_t tests[] = {
 	{ "swap32_involution",     NULL, 0 },
 	{ "swap64_involution",     NULL, 0 },
 	{ "swap32_reverses_bytes", NULL, 0 },
+	{ "copyswap32_unaligned",  NULL, 0 },
+	{ "copyswap16_unaligned",  NULL, 0 },
+	{ "swap64_unaligned",      NULL, 0 },
 	{ NULL, NULL, 0 }
 };
 

--- a/test/pbt/pbt_compint.c
+++ b/test/pbt/pbt_compint.c
@@ -1,0 +1,190 @@
+/*-
+ * test/pbt/pbt_compint.c
+ *	Property-based tests for the integer-compression (varint) codec in
+ *	src/common/db_compint.c: __db_compress_int / __db_decompress_int /
+ *	__db_compress_count_int / __db_decompress_count_int /
+ *	__db_decompress_int32.
+ *
+ * This codec is the on-disk length/offset encoding used by the btree
+ * prefix-compression path (src/btree/bt_compress.c) -- it is only built
+ * when HAVE_COMPRESSION is defined (the default: dist/configure.ac
+ * db_cv_build_compression=yes -> AC_DEFINE(HAVE_COMPRESSION)).  The
+ * source's own header comment gives the format table:
+ *
+ *   First byte  | Next  | Maximum value
+ *   [0 xxxxxxx] | 0     | 2^7 - 1
+ *   [10 xxxxxx] | 1     | 2^14 + 2^7 - 1
+ *   ...
+ *   [11111 011] | 8     | 2^64 + ... + 2^7 - 1
+ *
+ * and states: "this compression algorithm depends on big-endian order".
+ * The high bits of the first byte are a self-describing length prefix, so
+ * the encoding is *order-preserving*: this is what lets the codec store
+ * lengths/offsets that must sort correctly.
+ *
+ * Contracts exercised (all grounded in the source, not restated from it):
+ *   roundtrip        -- __db_decompress_int(__db_compress_int(i)) == i for
+ *                       every u_int64_t i (the codec is a bijection).
+ *   count_agrees     -- __db_compress_count_int(i) equals the byte count
+ *                       __db_compress_int actually writes, AND equals
+ *                       __db_decompress_count_int over the produced bytes,
+ *                       AND equals the length __db_decompress_int reports.
+ *   order_preserving -- a <= b  ==>  memcmp(enc(a), enc(b)) has the same
+ *                       sign (comparing over the shorter length then by
+ *                       length): the encoded bytes sort like the integers.
+ *   int32_matches    -- for i <= UINT32_MAX, __db_decompress_int32 yields
+ *                       the same value (and length) as __db_decompress_int.
+ *
+ * These are all exported from libdb (PUBLIC: prototypes in db_compint.c;
+ * verified reachable via nm on the built library).  We declare them
+ * locally to avoid dragging in db_int.h.
+ */
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+/* Exported by libdb (PUBLIC: prototypes in src/common/db_compint.c). */
+extern u_int32_t __db_compress_count_int(u_int64_t);
+extern int __db_compress_int(u_int8_t *, u_int64_t);
+extern u_int32_t __db_decompress_count_int(const u_int8_t *);
+extern int __db_decompress_int(const u_int8_t *, u_int64_t *);
+extern int __db_decompress_int32(const u_int8_t *, u_int32_t *);
+
+#if defined(PBT_HAVE_HEGEL)
+
+#include <string.h>
+
+/* Max encoded size is 9 bytes (the [11111 011] 9-byte form). */
+#define CMP_MAXLEN 9
+
+/*
+ * Draw a u_int64_t.  hegel_integers works over int64_t, so we draw a
+ * signed value and reinterpret its bits -- this reaches the full unsigned
+ * range including values above INT64_MAX (the 9-byte encodings).
+ */
+static u_int64_t
+draw_u64(hegel_test_case *tc)
+{
+	return ((u_int64_t)hegel_draw_int(tc, hegel_integers(INT64_MIN, INT64_MAX)));
+}
+
+/* P1: encode then decode is the identity over the full 64-bit range. */
+static void
+prop_roundtrip(hegel_test_case *tc, void *u)
+{
+	u_int8_t buf[CMP_MAXLEN];
+	u_int64_t v, out;
+	int n;
+	(void)u;
+
+	v = draw_u64(tc);
+	n = __db_compress_int(buf, v);
+	hegel_assume(n >= 1 && n <= CMP_MAXLEN);
+	(void)__db_decompress_int(buf, &out);
+	hegel_assume(out == v);
+}
+
+/*
+ * P2: the three "how many bytes" views agree with the encoder:
+ *   count_int(v) == bytes written == decompress_count_int(buf)
+ *                == length reported by decompress_int.
+ */
+static void
+prop_count_agrees(hegel_test_case *tc, void *u)
+{
+	u_int8_t buf[CMP_MAXLEN];
+	u_int64_t v, out;
+	u_int32_t predicted, back;
+	int written, read_len;
+	(void)u;
+
+	v = draw_u64(tc);
+	predicted = __db_compress_count_int(v);
+	written = __db_compress_int(buf, v);
+	back = __db_decompress_count_int(buf);
+	read_len = __db_decompress_int(buf, &out);
+
+	hegel_assume((u_int32_t)written == predicted);
+	hegel_assume(back == predicted);
+	hegel_assume((u_int32_t)read_len == predicted);
+}
+
+/*
+ * P3: the encoding is order-preserving under unsigned byte comparison.
+ * We encode two values, then compare the encodings the way a sorted store
+ * would -- lexicographically over the common prefix, ties broken by the
+ * longer encoding being greater (a longer varint always encodes a larger
+ * value).  The sign of that comparison must match the sign of (a - b).
+ */
+static void
+prop_order_preserving(hegel_test_case *tc, void *u)
+{
+	u_int8_t ba[CMP_MAXLEN], bb[CMP_MAXLEN];
+	u_int64_t a, b;
+	int la, lb, mn, cmp;
+	(void)u;
+
+	a = draw_u64(tc);
+	b = draw_u64(tc);
+	la = __db_compress_int(ba, a);
+	lb = __db_compress_int(bb, b);
+
+	mn = la < lb ? la : lb;
+	cmp = memcmp(ba, bb, (size_t)mn);
+	if (cmp == 0)
+		cmp = (la > lb) - (la < lb);	/* longer enc => larger value */
+
+	if (a < b)
+		hegel_assume(cmp < 0);
+	else if (a > b)
+		hegel_assume(cmp > 0);
+	else
+		hegel_assume(cmp == 0);
+}
+
+/*
+ * P4: for values that fit in 32 bits, the 32-bit decoder agrees with the
+ * 64-bit decoder on both the value and the number of bytes consumed.
+ */
+static void
+prop_int32_matches(hegel_test_case *tc, void *u)
+{
+	u_int8_t buf[CMP_MAXLEN];
+	u_int64_t v, out64;
+	u_int32_t out32;
+	int n32, n64;
+	(void)u;
+
+	v = (u_int64_t)(u_int32_t)hegel_draw_int(tc,
+	    hegel_integers(0, 0xFFFFFFFFLL));
+	(void)__db_compress_int(buf, v);
+	n32 = __db_decompress_int32(buf, &out32);
+	n64 = __db_decompress_int(buf, &out64);
+
+	hegel_assume((u_int64_t)out32 == out64);
+	hegel_assume(out32 == (u_int32_t)v);
+	hegel_assume(n32 == n64);
+}
+
+static const pbt_entry_t tests[] = {
+	{ "roundtrip",        prop_roundtrip,        800 },
+	{ "count_agrees",     prop_count_agrees,     800 },
+	{ "order_preserving", prop_order_preserving, 800 },
+	{ "int32_matches",    prop_int32_matches,    500 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "roundtrip",        NULL, 0 },
+	{ "count_agrees",     NULL, 0 },
+	{ "order_preserving", NULL, 0 },
+	{ "int32_matches",    NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("compint", tests)

--- a/test/pbt/pbt_compress.c
+++ b/test/pbt/pbt_compress.c
@@ -1,0 +1,131 @@
+/*-
+ * test/pbt/pbt_compress.c
+ *	Property-based test for the btree default prefix-compression codec:
+ *	__bam_defcompress / __bam_defdecompress (src/btree/bt_compress.c),
+ *	built only when HAVE_COMPRESSION is defined (the default).
+ *
+ * Contract from the source:
+ *   __bam_defcompress(dbp, prevKey, prevData, key, data, dest)
+ *	writes into `dest` a compressed encoding of (key, data) expressed
+ *	relative to the preceding (prevKey, prevData): it stores the length
+ *	of the common prefix key shares with prevKey, then the differing
+ *	suffix, then the data.  dbp is COMPQUIET'd, so NULL is safe.
+ *   __bam_defdecompress(dbp, prevKey, prevData, compressed, destKey, destData)
+ *	reverses it: it reconstructs (key, data) from the same preceding
+ *	(prevKey, prevData) and the compressed bytes.
+ *
+ * Property (round-trip identity): for any preceding pair (prevKey,
+ * prevData) and any current pair (key, data),
+ *	decompress(compress(prev, cur)) == cur
+ * byte-for-byte.  This is the invariant the whole compressed-btree
+ * on-disk format rests on -- if it failed, a compressed database could
+ * not be read back.  It is falsifiable against any prefix-length or
+ * memcpy bug in either half of the codec.
+ *
+ * Both routines are exported from libdb (PUBLIC: prototypes in
+ * bt_compress.c; verified reachable via nm).  We declare them locally.
+ */
+
+#include <string.h>
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+/* Exported by libdb (PUBLIC: prototypes in src/btree/bt_compress.c). */
+extern int __bam_defcompress(DB *, const DBT *, const DBT *,
+    const DBT *, const DBT *, DBT *);
+extern int __bam_defdecompress(DB *, const DBT *, const DBT *, DBT *,
+    DBT *, DBT *);
+
+#if defined(PBT_HAVE_HEGEL)
+
+/* Set a DBT to reference `n` bytes at `p`. */
+static void
+set_dbt(DBT *d, void *p, size_t n)
+{
+	memset(d, 0, sizeof(*d));
+	d->data = p;
+	d->size = (u_int32_t)n;
+}
+
+/* Set a DBT to reference an output buffer of capacity `cap` at `p`. */
+static void
+set_out(DBT *d, void *p, size_t cap)
+{
+	memset(d, 0, sizeof(*d));
+	d->data = p;
+	d->ulen = (u_int32_t)cap;
+}
+
+/*
+ * P1: decompress(compress(prev, cur)) reproduces cur exactly.
+ *
+ * We generate a preceding key/data and a current key/data, all as
+ * arbitrary byte strings (keys non-empty since a btree key is; data may
+ * be empty).  Broad sizes deliberately include the case where `key`
+ * shares a long prefix with `prevKey` (the interesting compression path)
+ * and the case where they diverge at byte 0 (no prefix).
+ */
+static void
+prop_compress_roundtrip(hegel_test_case *tc, void *u)
+{
+	uint8_t *pk, *pd, *k, *dta;
+	size_t pklen = 0, pdlen = 0, klen = 0, dlen = 0;
+	uint8_t enc[2048];
+	uint8_t outk[1024], outd[1024];
+	DBT prevKey, prevData, key, data, dest, dkey, ddata;
+	int ret;
+	(void)u;
+
+	pk = hegel_draw_bytes(tc, hegel_binary(1, 200), &pklen);
+	pd = hegel_draw_bytes(tc, hegel_binary(0, 200), &pdlen);
+	k  = hegel_draw_bytes(tc, hegel_binary(1, 200), &klen);
+	dta = hegel_draw_bytes(tc, hegel_binary(0, 200), &dlen);
+	hegel_assume(pk != NULL && k != NULL);
+
+	set_dbt(&prevKey, pk, pklen);
+	set_dbt(&prevData, pd, pdlen);
+	set_dbt(&key, k, klen);
+	set_dbt(&data, dta, dlen);
+	set_out(&dest, enc, sizeof(enc));
+
+	ret = __bam_defcompress(NULL, &prevKey, &prevData, &key, &data, &dest);
+	/* enc[] is generously sized; a full buffer is not the property here. */
+	hegel_assume(ret == 0);
+
+	/* dest.size now holds the encoded length; feed it back to decompress. */
+	set_out(&dkey, outk, sizeof(outk));
+	set_out(&ddata, outd, sizeof(outd));
+	ret = __bam_defdecompress(NULL, &prevKey, &prevData, &dest,
+	    &dkey, &ddata);
+	hegel_assume(ret == 0);
+
+	/* Round-trip identity for both key and data. */
+	hegel_assume(dkey.size == key.size);
+	hegel_assume(key.size == 0 || memcmp(dkey.data, key.data, key.size) == 0);
+	hegel_assume(ddata.size == data.size);
+	hegel_assume(data.size == 0 ||
+	    memcmp(ddata.data, data.data, data.size) == 0);
+
+	free(pk);
+	free(pd);
+	free(k);
+	free(dta);
+}
+
+static const pbt_entry_t tests[] = {
+	{ "compress_roundtrip", prop_compress_roundtrip, 600 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "compress_roundtrip", NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("compress", tests)

--- a/test/pbt/pbt_recno.c
+++ b/test/pbt/pbt_recno.c
@@ -1,0 +1,189 @@
+/*-
+ * test/pbt/pbt_recno.c
+ *	End-to-end property tests for the recno (record-number) access
+ *	method, src/btree/bt_recno.c, over a real in-memory DB_RECNO.
+ *
+ * Two contracts, both grounded in bt_recno.c and the recno design:
+ *
+ *   put_get_roundtrip -- appending a data item (DB_APPEND) assigns it the
+ *	next record number, and getting that record number returns exactly
+ *	the data stored (round-trip identity through the recno stack:
+ *	__ram_append -> __ram_add -> __bam_iitem, and DB->get by record
+ *	number).
+ *
+ *   renumber_contiguous -- with DB_RENUMBER set, deleting a record
+ *	physically removes it and shifts every higher record down by one
+ *	(bt_recno.c __ramc_del: "In renumbering recnos, ... adjust the
+ *	counts, adjust the cursors"; __ram_ca(CA_DELETE)).  So after any
+ *	sequence of N appends and D in-range deletes, the surviving records
+ *	are numbered exactly 1..(N-D) with no gaps.  We verify this by
+ *	walking the whole database with a cursor and DB_NEXT: the record
+ *	numbers must come out 1, 2, 3, ... contiguously.
+ *
+ * All symbols used are public (db.h) and linked; this exercises the recno
+ * access method the way the Tcl recno tests do, but with generated
+ * insert/delete sequences and an explicit contiguity oracle.
+ */
+
+#include <string.h>
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+#if defined(PBT_HAVE_HEGEL)
+
+/* Open a fresh in-memory DB_RECNO.  If renumber, set DB_RENUMBER first. */
+static DB *
+open_inmem_recno(int renumber)
+{
+	DB *dbp = NULL;
+
+	if (db_create(&dbp, NULL, 0) != 0)
+		return (NULL);
+	if (renumber && dbp->set_flags(dbp, DB_RENUMBER) != 0) {
+		(void)dbp->close(dbp, 0);
+		return (NULL);
+	}
+	if (dbp->open(dbp, NULL, NULL, NULL, DB_RECNO, DB_CREATE, 0600) != 0) {
+		(void)dbp->close(dbp, 0);
+		return (NULL);
+	}
+	return (dbp);
+}
+
+/* Append one data item; return the assigned record number (0 on failure). */
+static db_recno_t
+recno_append(DB *dbp, const void *buf, size_t len)
+{
+	DBT key, data;
+	db_recno_t rec = 0;
+
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = &rec;
+	key.ulen = sizeof(rec);
+	key.flags = DB_DBT_USERMEM;	/* DB_APPEND writes the recno here */
+	data.data = (void *)buf;
+	data.size = (u_int32_t)len;
+	if (dbp->put(dbp, NULL, &key, &data, DB_APPEND) != 0)
+		return (0);
+	return (rec);
+}
+
+/*
+ * P1: append/get round-trip -- a value appended at the returned record
+ * number reads back byte-for-byte.
+ */
+static void
+prop_put_get_roundtrip(hegel_test_case *tc, void *u)
+{
+	DB *dbp;
+	DBT key, out;
+	uint8_t *vbuf;
+	size_t vlen = 0;
+	db_recno_t rec;
+	int ret;
+	(void)u;
+
+	/* Recno data is non-empty (a zero-length record is not stored). */
+	vbuf = hegel_draw_bytes(tc, hegel_binary(1, 300), &vlen);
+	hegel_assume(vbuf != NULL);
+
+	dbp = open_inmem_recno(0);
+	hegel_assume(dbp != NULL);
+
+	rec = recno_append(dbp, vbuf, vlen);
+	hegel_assume(rec != 0);
+
+	memset(&key, 0, sizeof(key));
+	memset(&out, 0, sizeof(out));
+	key.data = &rec;
+	key.size = sizeof(rec);
+	ret = dbp->get(dbp, NULL, &key, &out, 0);
+	hegel_assume(ret == 0);
+	hegel_assume(out.size == (u_int32_t)vlen);
+	hegel_assume(memcmp(out.data, vbuf, vlen) == 0);
+
+	(void)dbp->close(dbp, 0);
+	free(vbuf);
+}
+
+/*
+ * P2: renumber contiguity -- after N appends and a set of deletes, the
+ * live records are numbered exactly 1..M with no gaps.  We drive it with
+ * a generated number of appends and a generated list of delete positions,
+ * then verify by cursor walk.
+ */
+static void
+prop_renumber_contiguous(hegel_test_case *tc, void *u)
+{
+	DB *dbp;
+	DBC *dbc;
+	DBT key, data;
+	db_recno_t rec, walk, expected;
+	int n, ndel, i, live, ret;
+	uint8_t payload[4] = { 0xDE, 0xAD, 0xBE, 0xEF };
+	(void)u;
+
+	dbp = open_inmem_recno(1 /* DB_RENUMBER */);
+	hegel_assume(dbp != NULL);
+
+	/* Append n records (1..n). */
+	n = (int)hegel_draw_int(tc, hegel_integers(1, 30));
+	for (i = 0; i < n; i++)
+		hegel_assume(recno_append(dbp, payload, sizeof(payload)) != 0);
+	live = n;
+
+	/* Delete ndel records, each at a currently-valid position. */
+	ndel = (int)hegel_draw_int(tc, hegel_integers(0, n));
+	for (i = 0; i < ndel && live > 0; i++) {
+		rec = (db_recno_t)hegel_draw_int(tc, hegel_integers(1, live));
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &rec;
+		key.size = sizeof(rec);
+		ret = dbp->del(dbp, NULL, &key, 0);
+		hegel_assume(ret == 0);
+		live--;
+	}
+
+	/* Walk every live record; recnos must be 1, 2, 3, ... contiguously. */
+	hegel_assume(dbp->cursor(dbp, NULL, &dbc, 0) == 0);
+	expected = 1;
+	for (;;) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		ret = dbc->get(dbc, &key, &data, DB_NEXT);
+		if (ret == DB_NOTFOUND)
+			break;
+		hegel_assume(ret == 0);
+		hegel_assume(key.size == sizeof(walk));
+		memcpy(&walk, key.data, sizeof(walk));
+		hegel_assume(walk == expected);	/* no gaps, in order */
+		expected++;
+	}
+	/* Exactly `live` records survived, numbered 1..live. */
+	hegel_assume((int)(expected - 1) == live);
+
+	(void)dbc->close(dbc);
+	(void)dbp->close(dbp, 0);
+}
+
+static const pbt_entry_t tests[] = {
+	{ "put_get_roundtrip",   prop_put_get_roundtrip,   200 },
+	{ "renumber_contiguous", prop_renumber_contiguous, 200 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "put_get_roundtrip",   NULL, 0 },
+	{ "renumber_contiguous", NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("recno", tests)


### PR DESCRIPTION
## Summary

Two logically-separate additions to the test tiers, both grounded in the
actual code under test and both re-measured against a real coverage baseline
(no coverage theater):

1. **4 new Hegel property targets (10 properties)** aimed at under-covered
   *pure logic*, all verified to link against libdb **and run green** (hegel-c
   built locally, hegel-core server installed; each property passed 200–800
   generated examples).
2. **Wider coverage subset** — three existing Tcl tests the CI subset had not
   been running (compaction + range/callback partitioning), each verified to
   PASS before adding. No new Tcl written.

## Coverage delta (src/-only, `CC=gcc --coverage`, same subset methodology)

| Metric    | before | after | Δ |
|-----------|:------:|:-----:|:--:|
| Lines     | 26.9% (19583/72757) | **28.8%** (20970/72757) | **+1.9 pp** |
| Branches  | 17.8% (13982/78331) | **19.0%** (14921/78331) | **+1.2 pp** |
| Functions | 33.3% (926/2782)    | **34.9%** (971/2782)    | +1.6 pp |

Subsystems that moved off 0%:

| file | before | after (line% / br%) |
|------|:------:|:------:|
| `btree/bt_compact.c` (compaction, was #2 gap) | 0% | 30.1 / 17.4 |
| `db/partition.c` (partitioning, was #6 gap)   | 0% | 53.7 / 45.0 |

`baseline.txt` ratcheted to `line=28.8 branch=19.0`.

## New PBT properties (all verified-link + ran-green)

**`pbt_compint.c`** — `src/common/db_compint.c` varint codec (HAVE_COMPRESSION):
- `roundtrip` — `decompress(compress(i)) == i` over the full `u_int64_t` range
- `count_agrees` — `compress_count_int` == bytes written == `decompress_count_int` == reported length
- `order_preserving` — the encoding sorts like the integers (the key property)
- `int32_matches` — 32-bit decoder agrees with 64-bit for values ≤ UINT32_MAX

**`pbt_compress.c`** — `src/btree/bt_compress.c` `__bam_defcompress`/`__bam_defdecompress`:
- `compress_roundtrip` — `decompress(compress(prev, cur)) == cur` byte-for-byte (the invariant the compressed on-disk btree format rests on)

**`pbt_recno.c`** — end-to-end in-memory `DB_RECNO` (`src/btree/bt_recno.c`):
- `put_get_roundtrip` — `DB_APPEND` value reads back at its assigned record number
- `renumber_contiguous` — with `DB_RENUMBER`, after generated insert/delete sequences a cursor walk yields record numbers `1..N` with no gaps

**`pbt_byteswap.c`** (extended) — the unaligned on-page conversion forms:
- `copyswap32_unaligned` / `copyswap16_unaligned` — `P_32/16_COPYSWAP` into an unaligned destination
- `swap64_unaligned` — `P_64_SWAP` reverses (1×) and restores (2×) at a random offset

All 9 PBT files build+link+SKIP cleanly in **stub mode** via the meson wiring
(the CI-default path, hegel-c absent), so CI stays green without the hegel
server.

## What I deliberately skipped

- **mt19937 RNG determinism** — the seed path is time-based and the generator
  functions are `static` (only `__db_generate_iv` is exported, and it needs a
  full mutex-bearing `ENV`); not reachable as a pure-function property.
- **queue variable-length round-trip** — queue requires a fixed `re_len` and
  pads records, so it is not a clean variable-length round-trip; recno covers
  the record-number access-method surface instead.

## Remaining gaps (unchanged, need bigger harnesses)

Replication / repmgr (multi-process), `log_verify_*` (crafted corrupt logs),
`hash/hash_rec.c` (crash/recovery over a hash DB), `sequence.c` / `xa.c`
(small dedicated Tcl tests the subset omits).

## Validation

- Baseline + re-measured coverage both run via `test/coverage/run_coverage.sh`
  in the nix dev shell (`CC=gcc`); all 24 Tcl runs PASS in the extended subset.
- Every new `pbt_*.c` stub-compiled + linked against libdb (proving the
  symbols resolve), then compiled in real mode and run under the hegel server:
  compint 4/4, compress 1/1, recno 2/2, byteswap 7/7 OK.
- No coverage artifacts (`.gcda`/`.gcno`/`TESTDIR`) committed (`build_unix/**`
  is gitignored).
