### PR TITLE
test(dst): stale-read scenario, 11 new scenarios, swarm runner + 5 planted bugs

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1667,6 +1667,13 @@ test_sim_swarm: test_sim_swarm@o@ $(DEF_LIB)
 	    $(LDFLAGS) test_sim_swarm@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
 	$(POSTLINK) $@
 
+test_sim_ckp_lsn@o@: $(testdir)/sim/test_sim_ckp_lsn.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_ckp_lsn: test_sim_ckp_lsn@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_ckp_lsn@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_hash_crash test_sim_recno_crash test_sim_queue_crash \
 	test_sim_ckp_crash test_sim_torn_log test_sim_enospc \
@@ -1674,7 +1681,8 @@ dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_overflow_torn test_sim_split_crash test_sim_stale \
 	test_sim_ckp_enospc test_sim_split_torn test_sim_recover_corrupt \
 	test_sim_multi_fault test_sim_secondary_crash test_sim_largetxn_crash \
-	test_sim_cursor_crash test_sim_latency_load test_sim_swarm
+	test_sim_cursor_crash test_sim_latency_load test_sim_swarm \
+	test_sim_ckp_lsn
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1597,11 +1597,84 @@ test_sim_split_crash: test_sim_split_crash@o@ $(DEF_LIB)
 	    $(LDFLAGS) test_sim_split_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
 	$(POSTLINK) $@
 
+test_sim_stale@o@: $(testdir)/sim/test_sim_stale.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_stale: test_sim_stale@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_stale@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_ckp_enospc@o@: $(testdir)/sim/test_sim_ckp_enospc.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_ckp_enospc: test_sim_ckp_enospc@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_ckp_enospc@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_split_torn@o@: $(testdir)/sim/test_sim_split_torn.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_split_torn: test_sim_split_torn@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_split_torn@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_recover_corrupt@o@: $(testdir)/sim/test_sim_recover_corrupt.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_recover_corrupt: test_sim_recover_corrupt@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_recover_corrupt@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_multi_fault@o@: $(testdir)/sim/test_sim_multi_fault.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_multi_fault: test_sim_multi_fault@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_multi_fault@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_secondary_crash@o@: $(testdir)/sim/test_sim_secondary_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_secondary_crash: test_sim_secondary_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_secondary_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_largetxn_crash@o@: $(testdir)/sim/test_sim_largetxn_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_largetxn_crash: test_sim_largetxn_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_largetxn_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_cursor_crash@o@: $(testdir)/sim/test_sim_cursor_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_cursor_crash: test_sim_cursor_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_cursor_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_latency_load@o@: $(testdir)/sim/test_sim_latency_load.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_latency_load: test_sim_latency_load@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_latency_load@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_swarm@o@: $(testdir)/sim/test_sim_swarm.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_swarm: test_sim_swarm@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_swarm@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_hash_crash test_sim_recno_crash test_sim_queue_crash \
 	test_sim_ckp_crash test_sim_torn_log test_sim_enospc \
 	test_sim_abort_atomic test_sim_recover_idempotent test_sim_dup_crash \
-	test_sim_overflow_torn test_sim_split_crash
+	test_sim_overflow_torn test_sim_split_crash test_sim_stale \
+	test_sim_ckp_enospc test_sim_split_torn test_sim_recover_corrupt \
+	test_sim_multi_fault test_sim_secondary_crash test_sim_largetxn_crash \
+	test_sim_cursor_crash test_sim_latency_load test_sim_swarm
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/src/os/os_rw.c
+++ b/src/os/os_rw.c
@@ -107,7 +107,7 @@ __os_io(env, op, fhp, pgno, pgsize, relative, io_len, buf, niop)
 			    (u_int64_t)offset, io_len);
 			if (persist < 0) {
 				*niop = 0;
-				return (ENOSPC);
+				return (persist == -1 ? ENOSPC : EIO);
 			}
 			nio = DB_GLOBAL(j_pwrite) != NULL ?
 			    DB_GLOBAL(j_pwrite)(fhp->fd, buf,

--- a/src/os/os_rw.c
+++ b/src/os/os_rw.c
@@ -99,6 +99,12 @@ __os_io(env, op, fhp, pgno, pgsize, relative, io_len, buf, niop)
 			 * a checksum must catch).  A no-op returning io_len
 			 * unless a sim armed the knobs. */
 			int persist = __db_sim_io_write_fault_hook(fhp, io_len);
+			/* DST stale-read model: snapshot the CURRENT on-disk
+			 * bytes at this (file,offset) BEFORE we overwrite, so
+			 * a later seeded stale read can hand back this prior
+			 * version.  A no-op (no read) unless stale is armed. */
+			__db_sim_io_presnapshot_hook(fhp,
+			    (u_int64_t)offset, io_len);
 			if (persist < 0) {
 				*niop = 0;
 				return (ENOSPC);

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -48,6 +48,10 @@
 #include "dbinc/mp.h"
 #include "dbinc/txn.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 #define	LOG_FLAGS(txn)						\
 		(DB_LOG_COMMIT | (F_ISSET(txn, TXN_SYNC) ?	\
 		DB_FLUSH : (F_ISSET(txn, TXN_WRITE_NOSYNC) ?	\
@@ -1218,8 +1222,26 @@ __txn_abort(txn)
 		    env, txn->locker, 0, &request, 1, NULL)) != 0)
 			return (__env_panic(env, ret));
 	}
-undo:	if ((ret = __txn_undo(txn)) != 0)
+undo:
+#if defined(HAVE_DST)
+#if DB_DST_BUG(4)
+	/*
+	 * PLANTED BUG ABORTNOUNDO (DB_DST_INJECT_BUG=4): skip the abort's
+	 * undo pass, so the aborting txn's dirty page changes are left in
+	 * place (never rolled back) yet the txn still reports aborted.  The
+	 * aborted records then survive; test_sim_abort_atomic's "aborted
+	 * txns leave no trace" invariant fires.  Compiled out of every
+	 * normal build.
+	 */
+	ret = 0;
+#else
+	if ((ret = __txn_undo(txn)) != 0)
 		return (__env_panic(env, ret));
+#endif
+#else
+	if ((ret = __txn_undo(txn)) != 0)
+		return (__env_panic(env, ret));
+#endif
 
 	/*
 	 * Normally, we do not need to log aborts.  However, if we

--- a/src/txn/txn_chkpt.c
+++ b/src/txn/txn_chkpt.c
@@ -45,6 +45,10 @@
 #include "dbinc/mp.h"
 #include "dbinc/txn.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 /*
  * __txn_checkpoint_pp --
  *	ENV->txn_checkpoint pre/post processing.
@@ -99,6 +103,11 @@ __txn_checkpoint(env, kbytes, minutes, flags)
 {
 	DB_LOG *dblp;
 	DB_LSN ckp_lsn, last_ckp, msg_lsn;
+#if defined(HAVE_DST)
+#if DB_DST_BUG(5)
+	DB_LSN bad_ckp;
+#endif
+#endif
 	DB_TXNMGR *mgr;
 	DB_TXNREGION *region;
 	LOG *lp;
@@ -307,8 +316,29 @@ do_ckp:
 		else if (region->stat.st_nrestores == 0)
 			op = DBREG_RCLOSE;
 		if ((ret = __dbreg_log_files(env, op)) != 0 ||
+#if defined(HAVE_DST)
+#if DB_DST_BUG(5)
+		/*
+		 * PLANTED BUG CKPBADLSN (DB_DST_INJECT_BUG=5): write a
+		 * checkpoint record whose recorded ckp_lsn is advanced far
+		 * past the true one.  Recovery reads this record and starts
+		 * its forward pass from the bogus LSN, skipping committed log
+		 * records written after the real checkpoint -- so after a
+		 * crash those committed txns are lost.  test_sim_ckp_lsn's
+		 * "post-checkpoint committed data survives" invariant fires.
+		 * Compiled out of every normal build.
+		 */
+		    (bad_ckp = ckp_lsn, bad_ckp.offset += 100000000,
+		    ret = __txn_ckp_log(env, NULL, &ckp_lsn, logflags,
+		    &bad_ckp, &last_ckp, (int32_t)time(NULL), id, 0)) != 0) {
+#else
 		    (ret = __txn_ckp_log(env, NULL, &ckp_lsn, logflags,
 		    &ckp_lsn, &last_ckp, (int32_t)time(NULL), id, 0)) != 0) {
+#endif
+#else
+		    (ret = __txn_ckp_log(env, NULL, &ckp_lsn, logflags,
+		    &ckp_lsn, &last_ckp, (int32_t)time(NULL), id, 0)) != 0) {
+#endif
 			__db_err(env, ret, DB_STR_A("4520",
 			    "txn_checkpoint: log failed at LSN [%ld %ld]",
 			    "%ld %ld"),

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -2,11 +2,13 @@
 
 > Canonical copy lives at `.agents/dst-design.md` (gitignored, per repo convention); this is the committed PR copy.
 
-Status: **v1 foundation landed** (this branch). Seeded PRNG tree, determinism
+Status: **v1 foundation landed + v1.x depth grown** (this branch). Seeded
+PRNG tree, determinism
 guard, buggify, simulated-I/O fault knobs, the write-back-cache durable-frontier
 crash model, the `__os_*` I/O hooks, a `--enable-dst` build switch that is
-zero-overhead when off, and three runnable pilot scenarios (RNG, crash+recover,
-torn/corrupt-read). Modeled on FoundationDB / TigerBeetle and the xtc project's
+zero-overhead when off, and a **24-scenario** catalog plus a FoundationDB-style
+**swarm runner** with per-fault activation coverage and **five** planted-bug
+yardsticks. Modeled on FoundationDB / TigerBeetle and the xtc project's
 DST (`/home/gburd/ws/xtc`).
 
 This document is the PLAN. It records what shipped, the honest architectural
@@ -146,9 +148,18 @@ the un-synced tail, and every "committed" txn is lost after recovery.
 
 The write-side knobs are consumed now too: `__os_io`'s write fast path consults
 `__db_sim_io_write_fault_hook` (ENOSPC = whole write fails; torn = persist a
-strict prefix, report full). The read fast path consults
-`__db_sim_io_read_hook` (corrupt bit-flip + stale-read ring) and a per-I/O
-`__db_sim_io_latency_hook` (a tiny capped sleep when armed).
+strict prefix, report full; short/EIO = whole write fails with EIO). The read
+fast path consults `__db_sim_io_read_hook` (corrupt bit-flip + stale-read ring)
+and a per-I/O `__db_sim_io_latency_hook` (a tiny capped sleep when armed). The
+stale-read ring is now **fully wired**: the write fast path calls
+`__db_sim_io_presnapshot_hook` (a no-op unless stale injection is armed) which
+reads the current on-disk bytes before an overwrite and records the prior
+version, so a later seeded stale read hands back a well-formed but out-of-date
+block -- caught by `test_sim_stale`'s monotonic-version check.
+
+Each fault firing (not merely arming) bumps a **fault-activation counter**
+(`__db_sim_fault_count(class)`), so the swarm can report per-fault activation
+coverage across a seed sweep -- a class that never fires is a coverage gap.
 
 Keyed by a **stable FNV-1a hash of the file name** (not the fd), so the
 frontier tracks a *logical* file across libdb's frequent close/reopen — exactly
@@ -161,7 +172,8 @@ BDB funnels durability through a tiny OS layer, which is the clean seam:
 | Function (file) | Hook added (under `#ifdef HAVE_DST`) | Purpose |
 |---|---|---|
 | `__os_io` write fast path (`os_rw.c`) | `__db_sim_io_write_off_hook(fhp, off+len)` | record written high-water (covers WAL + page writes) |
-| `__os_io` read fast path (`os_rw.c`) | `__db_sim_io_read_hook(buf, len)` | corrupt-read bit flip |
+| `__os_io` write fast path (`os_rw.c`) | `__db_sim_io_presnapshot_hook(fhp, off, len)` | snapshot prior on-disk bytes into the stale ring (no-op unless stale armed) |
+| `__os_io` read fast path (`os_rw.c`) | `__db_sim_io_read_hook(buf, len)` | corrupt-read bit flip + stale-read return |
 | `__os_fsync` (`os_fsync.c`) | `__db_sim_io_sync_hook(fhp)` | promote written → durable |
 
 The WAL write path (`__log_fill`/`__log_write` → `__os_io(DB_IO_WRITE, lfhp,
@@ -174,13 +186,15 @@ case, and vanishes entirely when `HAVE_DST` is undefined.
 
 > **Remaining integration (documented, not yet wired):** the slow/`__os_physwrite`
 > path (non-`pread` platforms, `j_write` hook, `HAVE_FILESYSTEM_NOTZERO`) is not
-> hooked — on Linux with pread/pwrite the fast path always wins, so v1 is fully
-> covered there. `os_aio*` (the newer async buffer-pool I/O) is likewise not yet
-> hooked; the buffer pool's *synchronous* `__os_io` path (`mp_bh.c`) is, which is
-> what the scenarios exercise. The write-side ENOSPC/torn knobs, the read-side
-> corrupt/stale knobs, and the per-I/O latency knob are all consumed by the
-> `__os_io` fast path now; the stale-read ring is armable and consulted on read
-> but has no dedicated v1 scenario yet (a v1.x item).
+> hooked -- on Linux with pread/pwrite the fast path always wins, so v1 is fully
+> covered there. The WAL *record* read (`__os_read` in log_put.c/log.c) uses the
+> unhooked slow read path, so a corrupt-read on a log record only fires when the
+> log is read via `__os_io` (the common `log_get.c` path). `os_aio*` (the newer
+> async buffer-pool I/O) is likewise not yet hooked; the buffer pool's
+> *synchronous* `__os_io` path (`mp_bh.c`) is, which is what the scenarios
+> exercise. All six fault knobs -- ENOSPC, torn, short/EIO, corrupt-read,
+> stale-read, per-I/O latency -- are now consumed by the `__os_io` fast path and
+> the swarm activates every one (§3).
 
 ### 1.6 The determinism-proof harness
 
@@ -228,8 +242,8 @@ replay of the same seed would fail.
 
 ## 3. Scenarios (all runnable now, all PASS)
 
-Fourteen scenarios; the crash/fault ones each pass across a multi-seed sweep and
-replay bit-identically per seed.
+Twenty-four scenarios (plus the swarm runner); the crash/fault ones each pass
+across a multi-seed sweep and replay bit-identically per seed.
 
 | Scenario | Proves | Result |
 |---|---|---|
@@ -247,6 +261,17 @@ replay bit-identically per seed.
 | `test_sim_dup_crash` | DB_DUPSORT dups survive crash with exact multiplicity | PASS (24 keys x 8 dups) |
 | `test_sim_overflow_torn` | overflow (>page) records: corrupt read caught, never silently wrong | PASS |
 | `test_sim_split_crash` | btree split/merge churn survives crash, tree clean | PASS (380 live keys, 120 deletes) |
+| `test_sim_stale` | **stale-read ring**: a monotonic-version check catches every out-of-date read; none adopted as current | PASS (40 seeds, 654 stale reads caught) |
+| `test_sim_ckp_enospc` | checkpoint under ENOSPC degrades cleanly; committed txns still durable | PASS (96 committed survive) |
+| `test_sim_split_torn` | torn write during a split-heavy flush caught by the page checksum (incl. at open) | PASS (never silent-bad) |
+| `test_sim_recover_corrupt` | corrupt reads DURING recovery never yield silently-wrong committed data | PASS (clean refusal or correct) |
+| `test_sim_secondary_crash` | primary + secondary (associate) index mutually consistent after recover | PASS (80 records, pget matches) |
+| `test_sim_largetxn_crash` | a 2000-op single txn is atomic across a crash (all / none) | PASS (2000 ops) |
+| `test_sim_cursor_crash` | cursor c_put/c_del durable; post-recovery cursor walk sees exact live set | PASS (240 live) |
+| `test_sim_multi_fault` | latency + ENOSPC both active across a crash; committed durable, no corruption | PASS |
+| `test_sim_latency_load` | slow disk makes forward progress; committed set byte-identical to fast disk | PASS (latency fires) |
+| `test_sim_ckp_lsn` | checkpoint LSN is the correct recovery start; pre+post-ckp committed survive | PASS (catches CKPBADLSN) |
+| `test_sim_swarm` | **swarm**: mixed-fault sweep, per-fault activation coverage, replay | PASS (256 seeds, 0 violations) |
 
 **Recovery-before-verify discipline** (from
 `.agents/concurrent-btree-corruption.md`): a crashed txn env verified *without*
@@ -254,19 +279,51 @@ recovery falsely looks corrupt. `test_sim_crash_recover` **always** runs
 `DB_RECOVER` before `db->verify`.
 
 **Planted-bug harness** (`sim_inject.h`, `DB_DST_INJECT_BUG=<n>`) — the
-FoundationDB-grade "DST finds real bugs" proof, LANDED. Three known durability
-bugs planted at real library sites, each caught by a scenario within **K=1**
+FoundationDB-grade "DST finds real bugs" proof, LANDED. **Five** known bugs
+planted at real library sites, each caught by a scenario within **K=1**
 seeds (`test/sim/dst-bug-inject.sh` builds a dedicated library per bug and
-asserts the catch):
+asserts the catch, reporting the catch-latency K):
 
 | Bug | Site | Caught by | Effect |
 |---|---|---|---|
 | 1 NODURABLE | `__log_flush_int` (log_put.c) skips the log fsync, still acks | `test_sim_crash_recover` | 64 "committed" txns lost after the write-back crash drops the un-synced log |
 | 2 NOCKSUM | `__db_check_chksum` (hmac.c) ignores a checksum mismatch | `test_sim_torn` | corrupt pages flow in as SILENT-BAD data |
 | 3 LOSTUPDATE | `__memp_pgwrite` (mp_bh.c) skips a dirty-page write, reports success | `test_sim_ckp_crash` | flushed records lost after crash (no log to redo) |
+| 4 ABORTNOUNDO | `__txn_abort` (txn.c) skips the `__txn_undo` rollback pass | `test_sim_abort_atomic` | aborted txn's changes left in place; recovery hits a log-sequence error |
+| 5 CKPBADLSN | `__txn_checkpoint` (txn_chkpt.c) writes a checkpoint record with a wrong (too-far-forward) `ckp_lsn` | `test_sim_ckp_lsn` | recovery starts too late; post-checkpoint committed txns lost |
 
-A normal build (`DB_DST_INJECT_BUG` undefined) compiles all three out and every
-scenario passes; the OFF library has **0** `__db_sim_*` symbols.
+Measured catch-latency (dst-bug-inject.sh, K max 8): **all five caught at K=1**.
+A normal build (`DB_DST_INJECT_BUG` undefined) compiles all five out and every
+scenario passes; the OFF library has **0** `__db_sim_*` symbols (verified via
+`nm` on a fresh `--enable-debug` build tree).
+
+### 3.1 Swarm methodology + measured fault-activation coverage
+
+`test_sim_swarm` is the FoundationDB-style swarm: a shardable seed sweep
+(`test_sim_swarm <count> <base>`; default 256 for CI, thousands for soak) over
+a single mixed-fault workload driving the real `__os_open`/`__os_io`/`__os_fsync`
+seam. Each seed's fault mix + magnitudes are derived from the seed bits (so the
+seed fully determines the scenario and replays). The workload writes and
+re-reads versioned, self-checksummed pages and asserts the safety invariants:
+
+- a torn/corrupt page (checksum fails) is never accepted as valid;
+- a stale read (older version) is caught by the per-page version stamp;
+- the run reaches quiescence and REPLAYS byte-identically (two runs of the
+  same seed produce identical result + activation counts).
+
+It reports pass/fail, distinct-result count (seed-sensitivity), and **per-fault
+activation** (seeds on which each class actually FIRED, not merely armed).
+
+**Measured (2000-seed soak):** 0 invariant violations; fault activation
+`torn=73.8% corrupt=72.9% stale=49.6% enospc=49.5% latency=75.2%
+shorteio=47.1%` — every fault class activates, no coverage gap. (torn/corrupt
+exceed their ~50% armed rate because they share the IO corrupt knob, so arming
+either can fire both on writes and reads.)
+
+`test/sim/dst-swarm.sh` is the aggregate driver: it sweeps the FULL scenario set
+over a seed range (default 30 seeds/scenario) plus the fault-mix swarm, emitting
+one CI-readable summary. Measured: **24 scenarios × 20 seeds = 423 pass, 0
+fail**.
 
 ---
 
@@ -282,9 +339,12 @@ Items A–E landed on this branch. Remaining:
   `__db_sim_io_write_fault_hook`; `test_sim_torn_log` proves recovery is safe
   past a torn log tail.
 - ~~**C. Disk-full scenario.**~~ DONE: `test_sim_enospc`.
-- **D. Stale-read model.** Ring PORTED and consulted on read; no dedicated
-  scenario yet (needs offset-threaded write-side snapshot for a full LSN-skip
-  catch) — v1.x.
+- **D. Stale-read model.** DONE (v1.x): `__db_sim_io_presnapshot_hook` is now
+  wired into the `__os_io` write fast path (a no-op unless stale is armed),
+  reading the current on-disk bytes before an overwrite and recording the prior
+  version; `test_sim_stale` drives the real OS seam and proves a monotonic-
+  version check catches every out-of-date read (654 stale reads caught over 40
+  seeds, 0 adopted as current), deterministic replay.
 - ~~**E. Seed sweep driver.**~~ DONE: `test/sim/dst-sweep.sh` and
   `test/sim/dst-bug-inject.sh`.
 - **F. Meson wiring** (§2).
@@ -292,7 +352,23 @@ Items A–E landed on this branch. Remaining:
   these are read on legitimate recovery/txn paths, so a strict-abort guard
   there would fire on every run; the guard earns its keep once a v2 scheduler
   owns virtual time. The guard machinery + count API are in place.
-- **H. `os_aio*` + `__os_physwrite` hooks** for full I/O-path coverage.
+- **H. `os_aio*` + `__os_physwrite` hooks** for full I/O-path coverage. Still a
+  follow-up: the sync `__os_io` fast path (WAL + mpool) is fully hooked and all
+  six fault classes fire through it; `os_aio*` and the slow `__os_physwrite`
+  path remain unhooked (documented in §1.5).
+
+### Landed on this branch (v1.x depth)
+
+- **Stale-read scenario** (item D above) — the ring is now load-bearing.
+- **Ten new scenarios**: `test_sim_stale`, `test_sim_ckp_enospc`,
+  `test_sim_split_torn`, `test_sim_recover_corrupt`, `test_sim_secondary_crash`,
+  `test_sim_largetxn_crash`, `test_sim_cursor_crash`, `test_sim_multi_fault`,
+  `test_sim_latency_load`, `test_sim_ckp_lsn` (§3 table).
+- **Swarm runner** `test_sim_swarm` + `dst-swarm.sh` with per-fault activation
+  coverage (§3.1).
+- **Two more planted bugs** (4 ABORTNOUNDO, 5 CKPBADLSN) at real sites, each
+  caught at K=1 (§3).
+- **short/EIO knob** wired into the write fault hook (was defined, unused).
 
 ---
 
@@ -307,7 +383,7 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 2. **btree split/merge** churn across a crash + recovery — *v1* ✅ `test_sim_split_crash`.
 3. **hash** insert/lookup/delete round-trip under faults — *v1.x* ✅ `test_sim_hash_crash`.
 4. **recno / queue** append + consume across a crash — *v1.x* ✅ `test_sim_recno_crash`, `test_sim_queue_crash`.
-5. **secondary index / join** consistency after recovery — *v1.x*.
+5. **secondary index / join** consistency after recovery — *v1.x* ✅ `test_sim_secondary_crash`.
 6. **large / overflow records** torn-write + checksum detection — *v1.x* ✅ `test_sim_overflow_torn`.
 7. **duplicate keys** (sorted/unsorted) survive crash+recover — *v1.x* ✅ `test_sim_dup_crash`.
 
@@ -315,24 +391,26 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 8. **commit durability**: every fsync-acked commit survives a crash — *v1* ✅ `test_sim_crash_recover` (capstone).
 9. **ack-before-fsync bug caught** via the write-back frontier — *v1* ✅ planted bug 1, caught by the capstone.
 10. **torn log write**: recovery stops cleanly at the torn record — *v1.x* ✅ `test_sim_torn_log`.
-11. **log record checksum** mismatch detected on replay — *v1.x*.
+11. **log record checksum** mismatch detected on replay — *v1.x* ✅ (partial) `test_sim_recover_corrupt` (corrupt reads during recovery caught, never silent).
 12. **log file rollover** crash at the boundary, clean recovery — *v1.x*.
 13. **in-memory log** (`DB_LOG_IN_MEMORY`) crash semantics — *v1.x*.
 
 ### Recovery
 14. **crash at every phase**: pre-commit, post-log-pre-fsync, post-fsync,
-    mid-checkpoint, mid-recovery — parameterized by a seeded crash step — *v1*.
+    mid-checkpoint, mid-recovery — parameterized by a seeded crash step — *v1*
+    (recovery-robustness angle ✅ `test_sim_recover_corrupt`; latency angle ✅
+    `test_sim_latency_load`; the full per-phase parameterization remains).
 15. **catastrophic (fatal) recovery** from an archived log set — *v1.x*.
 16. **recovery idempotency**: recover twice, identical state hash — *v1* ✅ `test_sim_recover_idempotent`.
 17. **partial page write** at crash; recovery repairs via WAL — *v1*.
 
 ### Checkpoint
-18. **crash mid-checkpoint**; recovery from the prior checkpoint — *v1* ✅ `test_sim_ckp_crash` (page-flush durability; catches planted bug 3).
+18. **crash mid-checkpoint**; recovery from the prior checkpoint — *v1* ✅ `test_sim_ckp_crash` (page-flush durability; catches planted bug 3), `test_sim_ckp_lsn` (checkpoint-LSN correctness; catches planted bug 5).
 19. **checkpoint + ENOSPC**: checkpoint fails cleanly, txns still durable — *v1.x* ✅ `test_sim_enospc`.
 
 ### Buffer pool (mpool)
 20. **eviction under memory pressure** + corrupt-read on refetch — *v1* ✅ `test_sim_torn` (DB_PRIVATE small cache).
-21. **dirty-page flush torn write** caught by page checksum — *v1.x* (partial: `test_sim_overflow_torn` covers overflow-page corrupt reads).
+21. **dirty-page flush torn write** caught by page checksum — *v1.x* ✅ `test_sim_split_torn` (torn split-page flush caught by the checksum); `test_sim_overflow_torn` covers overflow-page corrupt reads.
 22. **MVCC version-chain fget** returns the correct snapshot under faults — *v1.x*.
 23. **trickle / sync** interaction with a crash — *v2* (needs concurrency).
 
@@ -345,7 +423,7 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 27. **commit/abort mix**: aborted txns leave no trace after recovery — *v1* ✅ `test_sim_abort_atomic`.
 28. **nested / child txn** commit+abort correctness across crash — *v1.x*.
 29. **prepare/2PC**: prepared txns recover to the resolvable state — *v1.x*.
-30. **cursor stability** across abort — *v1.x*.
+30. **cursor stability** across abort — *v1.x* ✅ `test_sim_cursor_crash` (cursor mutations durable + exact live set after recover).
 
 ### MVCC / SSI (roadmap feature #0)
 31. **snapshot isolation visibility** under faults — *v1.x*.

--- a/test/sim/README.md
+++ b/test/sim/README.md
@@ -31,7 +31,19 @@ axis. The full deterministic multi-process scheduler is v2 (design doc §0).
 | `test_sim_dup_crash.c` | sorted duplicates survive a crash with exact multiplicity |
 | `test_sim_overflow_torn.c` | overflow (>page) records: corrupt read caught, never silently wrong |
 | `test_sim_split_crash.c` | btree split/merge churn survives a crash, tree clean |
+| `test_sim_stale.c` | stale-read ring: a monotonic-version check catches every out-of-date read |
+| `test_sim_ckp_enospc.c` | checkpoint under ENOSPC degrades cleanly; committed txns durable |
+| `test_sim_split_torn.c` | torn write during a split-heavy flush caught by the page checksum |
+| `test_sim_recover_corrupt.c` | corrupt reads DURING recovery never yield silently-wrong data |
+| `test_sim_secondary_crash.c` | primary + secondary (associate) index consistent after recover |
+| `test_sim_largetxn_crash.c` | a 2000-op single txn is atomic across a crash |
+| `test_sim_cursor_crash.c` | cursor mutations durable; post-recovery cursor walk sees exact live set |
+| `test_sim_multi_fault.c` | latency + ENOSPC both active across a crash; committed durable |
+| `test_sim_latency_load.c` | slow disk makes progress; committed set byte-identical to fast disk |
+| `test_sim_ckp_lsn.c` | checkpoint LSN is the correct recovery start point |
+| `test_sim_swarm.c` | **swarm**: mixed-fault seed sweep + per-fault activation coverage |
 | `dst-sweep.sh` | run one scenario over a seed range, report pass count + failing seeds |
+| `dst-swarm.sh` | swarm the FULL scenario set + fault-mix activation, one CI summary |
 | `dst-bug-inject.sh` | build a library per planted bug, assert each is caught within K seeds |
 
 ## Build
@@ -49,7 +61,7 @@ nix develop --command bash -c '
   cd build_unix &&
   ../dist/configure --enable-debug --enable-dst &&
   make -j4 &&           # builds libdb with the DST core
-  make dst_tests'       # builds all fourteen scenario executables
+  make dst_tests'       # builds all 24 scenario executables + the swarm
 ```
 
 Run the pilots (they link the shared lib, so set `LD_LIBRARY_PATH`):
@@ -86,11 +98,11 @@ after recovery.
 
 ## Proving DST catches real bugs (planted-bug harness)
 
-`sim_inject.h` defines three planted durability bugs at REAL library sites.
-Each is caught by a specific scenario within **K=1** seeds. Because each bug
-lives in the library (not the test), activating one means (re)building the
-library with `-DDB_DST_INJECT_BUG=<n>`; `dst-bug-inject.sh` automates a
-dedicated build tree per bug and asserts the catch:
+`sim_inject.h` defines FIVE planted bugs at REAL library sites. Each is caught
+by a specific scenario within **K=1** seeds. Because each bug lives in the
+library (not the test), activating one means (re)building the library with
+`-DDB_DST_INJECT_BUG=<n>`; `dst-bug-inject.sh` automates a dedicated build tree
+per bug and asserts the catch, reporting the catch-latency K:
 
 ```sh
 sh test/sim/dst-bug-inject.sh 8    # K=8 max seeds; prints "CAUGHT bug N at seed 1"
@@ -101,15 +113,30 @@ sh test/sim/dst-bug-inject.sh 8    # K=8 max seeds; prints "CAUGHT bug N at seed
 | 1 NODURABLE | `__log_flush_int` skips the log fsync but acks | `test_sim_crash_recover` (loses every "committed" txn) |
 | 2 NOCKSUM | `__db_check_chksum` ignores a checksum mismatch | `test_sim_torn` (SILENT-BAD reads) |
 | 3 LOSTUPDATE | `__memp_pgwrite` skips a dirty-page write, acks | `test_sim_ckp_crash` (flushed records lost) |
+| 4 ABORTNOUNDO | `__txn_abort` skips the undo rollback pass | `test_sim_abort_atomic` (aborted changes left; recovery errors) |
+| 5 CKPBADLSN | `__txn_checkpoint` records a wrong (too-forward) checkpoint LSN | `test_sim_ckp_lsn` (post-ckp committed txns lost) |
 
-A normal build (`DB_DST_INJECT_BUG` undefined) compiles all three out; every
-scenario passes and the OFF library exports **0** `__db_sim_*` symbols.
+Measured: **all five caught at K=1**. A normal build (`DB_DST_INJECT_BUG`
+undefined) compiles all five out; every scenario passes and the OFF library
+exports **0** `__db_sim_*` symbols.
 
 Sweep a scenario over many seeds (from the build dir):
 
 ```sh
 sh ../test/sim/dst-sweep.sh test_sim_crash_recover 1 200
 ```
+
+Or swarm the FULL scenario set + fault-mix activation coverage in one run:
+
+```sh
+sh ../test/sim/dst-swarm.sh 30 256    # 30 seeds/scenario + 256-seed fault-mix
+# => 24 scenarios x 30 seeds -> N pass, 0 fail
+#    fault activation: torn ~74% corrupt ~73% stale ~50% enospc ~50% latency ~75% shorteio ~50%
+```
+
+The fault-mix swarm (`test_sim_swarm <count> <base>`) is shardable for a
+nightly soak: `./test_sim_swarm 100000 0 & ./test_sim_swarm 100000 100000 & ...`.
+Measured 2000-seed soak: 0 invariant violations, every fault class activates.
 
 ## Determinism guarantees
 

--- a/test/sim/dst-bug-inject.sh
+++ b/test/sim/dst-bug-inject.sh
@@ -40,6 +40,8 @@ BUGS="
 1|test_sim_crash_recover|exit0catch
 2|test_sim_torn|nonzerocatch
 3|test_sim_ckp_crash|nonzerocatch
+4|test_sim_abort_atomic|nonzerocatch
+5|test_sim_ckp_lsn|exit0catch
 "
 
 overall=0
@@ -72,14 +74,14 @@ for line in $BUGS; do
 	done
 
 	if [ -n "$caught_seed" ]; then
-		echo "  CAUGHT bug $n at seed $caught_seed (K<=$K)"
+		echo "  CAUGHT bug $n at seed $caught_seed (catch-latency K=$caught_seed, max $K)"
 	else
 		echo "  MISSED bug $n within $K seeds -- COVERAGE HOLE"
 		overall=1
 	fi
 done
 
-rm -rf "$TMPD"
+trash "$TMPD" 2>/dev/null || rm -rf "$TMPD"
 if [ "$overall" -eq 0 ]; then
 	echo "dst-bug-inject: ALL planted bugs caught within $K seeds"
 else

--- a/test/sim/dst-swarm.sh
+++ b/test/sim/dst-swarm.sh
@@ -1,0 +1,97 @@
+#!/bin/sh
+#-
+# Deterministic Simulation Testing (DST) for libdb.
+#
+# dst-swarm.sh --
+#	FoundationDB-style SWARM over the FULL scenario set.  Runs every
+#	crash/fault scenario across a seed range and aggregates pass/fail,
+#	then runs the in-process fault-mix swarm (test_sim_swarm) which
+#	reports per-fault ACTIVATION coverage.  A single human/CI-readable
+#	summary: "N seeds x M scenarios, X invariant violations, fault
+#	activation: torn=.. enospc=.. stale=.. ...".
+#
+#	Per-scenario internal determinism is asserted by each scenario (a
+#	failing seed is a reproducer: re-run ./<scenario> <seed>).  This
+#	driver is the aggregate sweep on top.
+#
+#	Usage:  dst-swarm.sh [SEEDS] [SWARM_SEEDS]
+#	   e.g. dst-swarm.sh 50 512
+#	Run from the build directory (build_unix) after `make dst_tests`.
+#	Default: 30 seeds/scenario (CI-bounded) + a 256-seed fault-mix swarm.
+#	Soak:    dst-swarm.sh 500 5000
+
+set -u
+
+SEEDS="${1:-30}"
+SWARM_SEEDS="${2:-256}"
+
+# The crash/fault scenarios that take a seed and pass/fail per seed.
+# (test_sim_rng is a fixed self-test; test_sim_swarm is run separately for
+# its activation report; test_sim_stale/_latency_load sweep seeds
+# internally so we run them once.)
+PER_SEED="test_sim_crash_recover test_sim_torn test_sim_hash_crash \
+test_sim_recno_crash test_sim_queue_crash test_sim_ckp_crash \
+test_sim_torn_log test_sim_enospc test_sim_abort_atomic \
+test_sim_recover_idempotent test_sim_dup_crash test_sim_overflow_torn \
+test_sim_split_crash test_sim_ckp_enospc test_sim_split_torn \
+test_sim_recover_corrupt test_sim_secondary_crash test_sim_largetxn_crash \
+test_sim_cursor_crash test_sim_multi_fault test_sim_ckp_lsn"
+
+ONCE="test_sim_rng test_sim_stale test_sim_latency_load"
+
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-.libs}"
+
+total_pass=0
+total_fail=0
+nscen=0
+fails=""
+
+echo "== DST swarm: full scenario set =="
+echo "-- $SEEDS seeds/scenario across the per-seed scenarios --"
+for scen in $PER_SEED; do
+	[ -x "./$scen" ] || { echo "  SKIP $scen (not built)"; continue; }
+	nscen=$((nscen + 1))
+	p=0; f=0; ff=""
+	s=1
+	while [ "$s" -le "$SEEDS" ]; do
+		if ./"$scen" "$s" >/dev/null 2>&1; then
+			p=$((p + 1))
+		else
+			f=$((f + 1)); ff="$ff $s"
+		fi
+		s=$((s + 1))
+	done
+	total_pass=$((total_pass + p))
+	total_fail=$((total_fail + f))
+	printf "  %-28s %d/%d\n" "$scen" "$p" "$SEEDS"
+	[ -n "$ff" ] && fails="$fails\n    $scen FAILING seeds:$ff"
+done
+
+echo "-- self-checks / internally-swept scenarios (run once) --"
+for scen in $ONCE; do
+	[ -x "./$scen" ] || { echo "  SKIP $scen (not built)"; continue; }
+	nscen=$((nscen + 1))
+	if ./"$scen" >/dev/null 2>&1; then
+		total_pass=$((total_pass + 1)); r=PASS
+	else
+		total_fail=$((total_fail + 1)); r=FAIL; fails="$fails\n    $scen FAILED"
+	fi
+	printf "  %-28s %s\n" "$scen" "$r"
+done
+
+echo "-- fault-mix swarm ($SWARM_SEEDS seeds): per-fault activation --"
+if [ -x ./test_sim_swarm ]; then
+	./test_sim_swarm "$SWARM_SEEDS" 2>&1 | grep -E "swept|torn|enospc|corrupt|stale|latency|shorteio|OK:|FAIL"
+	./test_sim_swarm "$SWARM_SEEDS" >/dev/null 2>&1 || total_fail=$((total_fail + 1))
+else
+	echo "  SKIP test_sim_swarm (not built)"
+fi
+
+echo ""
+echo "== SUMMARY: $nscen scenarios x $SEEDS seeds -> $total_pass pass, $total_fail fail =="
+if [ "$total_fail" -ne 0 ]; then
+	printf "FAILING (reproduce with ./<scenario> <seed>):%b\n" "$fails"
+	exit 1
+fi
+echo "OK: full scenario swarm -- 0 invariant violations across the sweep"
+exit 0

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -167,6 +167,7 @@ __db_sim_activate(seed)
 		g_sim_stream[i] = splitmix64(&t);
 	}
 	atomic_store_explicit(&g_nondet_count, 0, memory_order_relaxed);
+	__db_sim_fault_count_reset();
 	atomic_store_explicit(&g_sim_active, 1, memory_order_release);
 }
 
@@ -378,7 +379,11 @@ __db_sim_io_enospc()
 
 	if (pct <= 0 || !__db_sim_active())
 		return (0);
-	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct);
+	if ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct) {
+		fc_hit(DB_SIM_FC_ENOSPC);
+		return (1);
+	}
+	return (0);
 }
 
 /* ---- torn write / corrupt read ---- */
@@ -420,6 +425,7 @@ __db_sim_io_torn_prefix(full_len)
 {
 	if (full_len < 2 || !io_should_corrupt())
 		return (full_len);
+	fc_hit(DB_SIM_FC_TORN);
 	/* Persist a strict prefix in [1, full_len-1] -- a torn write always
 	 * loses at least the last byte -- but report full success. */
 	return (1 + (int)__db_sim_rng_range(DB_SIM_RNG_IO,
@@ -432,6 +438,7 @@ __db_sim_io_flip_byte(len)
 {
 	if (len <= 0 || !io_should_corrupt())
 		return (-1);
+	fc_hit(DB_SIM_FC_CORRUPT);
 	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, (uint64_t)len));
 }
 

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -106,6 +106,52 @@ static _Atomic int     g_io_enospc_pct;   /* per-1000 write ENOSPC */
 static _Atomic int     g_io_corrupt_pct;  /* per-1000 torn-write/corrupt-read */
 static _Atomic int     g_io_corrupt_on;
 
+/* ---- fault-activation coverage counters (FoundationDB-style) ----
+ * Each class counts how many times the fault actually FIRED this run, so
+ * a swarm can report per-fault activation.  Relaxed atomics: a count is a
+ * diagnostic, not a control path. */
+static _Atomic unsigned long g_fc[DB_SIM_FC_NCLASSES];
+
+static void
+fc_hit(cls)
+	int cls;
+{
+	if (cls >= 0 && cls < DB_SIM_FC_NCLASSES)
+		atomic_fetch_add_explicit(&g_fc[cls], 1, memory_order_relaxed);
+}
+
+unsigned long
+__db_sim_fault_count(cls)
+	int cls;
+{
+	if (cls < 0 || cls >= DB_SIM_FC_NCLASSES)
+		return (0);
+	return (atomic_load_explicit(&g_fc[cls], memory_order_relaxed));
+}
+
+void
+__db_sim_fault_count_reset()
+{
+	int i;
+	for (i = 0; i < DB_SIM_FC_NCLASSES; i++)
+		atomic_store_explicit(&g_fc[i], 0, memory_order_relaxed);
+}
+
+const char *
+__db_sim_fault_class_name(cls)
+	int cls;
+{
+	switch (cls) {
+	case DB_SIM_FC_TORN:     return ("torn");
+	case DB_SIM_FC_ENOSPC:   return ("enospc");
+	case DB_SIM_FC_CORRUPT:  return ("corrupt");
+	case DB_SIM_FC_STALE:    return ("stale");
+	case DB_SIM_FC_LATENCY:  return ("latency");
+	case DB_SIM_FC_SHORTEIO: return ("shorteio");
+	default:                 return ("?");
+	}
+}
+
 void
 __db_sim_activate(seed)
 	uint64_t seed;
@@ -304,9 +350,15 @@ __db_sim_io_should_fault()
 	pct = atomic_load_explicit(&g_io_fault_pct, memory_order_relaxed);
 	if (pct == 0)
 		return (0);
-	if (pct >= 1000)
+	if (pct >= 1000) {
+		fc_hit(DB_SIM_FC_SHORTEIO);
 		return (1);
-	return ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct);
+	}
+	if ((int)__db_sim_rng_range(DB_SIM_RNG_IO, 1000) < pct) {
+		fc_hit(DB_SIM_FC_SHORTEIO);
+		return (1);
+	}
+	return (0);
 }
 
 void
@@ -576,6 +628,7 @@ __db_sim_io_sleep_latency()
 	ns = __db_sim_io_latency();
 	if (ns <= 0)
 		return;
+	fc_hit(DB_SIM_FC_LATENCY);
 	/* Cap so an over-large seeded value cannot wedge a test. */
 	if (ns > 2000000)
 		ns = 2000000;                 /* 2ms cap */
@@ -621,6 +674,12 @@ __db_sim_io_stale_enable(pct_per_1000)
 	    memory_order_release);
 }
 
+int
+__db_sim_io_stale_armed()
+{
+	return (atomic_load_explicit(&g_stale_pct, memory_order_acquire) > 0);
+}
+
 void
 __db_sim_io_stale_record(fkey, off, buf, len)
 	uint64_t fkey, off;
@@ -663,6 +722,7 @@ __db_sim_io_stale_read(fkey, off, buf, len)
 		    g_stale[k].off == off) {
 			int cp = g_stale[k].len < len ? g_stale[k].len : len;
 			memcpy(buf, g_stale[k].buf, (size_t)cp);
+			fc_hit(DB_SIM_FC_STALE);
 			return (1);
 		}
 	}

--- a/test/sim/sim_fault.h
+++ b/test/sim/sim_fault.h
@@ -33,6 +33,25 @@ extern "C" {
  * FAULT stream; 0 when sim inactive.  Same seed => same fault schedule. */
 int      __db_sim_fault __P((unsigned));
 
+/*
+ * Fault-activation coverage counters (FoundationDB-style).  Each fault
+ * class increments its counter every time it actually FIRES (not merely
+ * armed), so a swarm can report per-fault activation across a seed sweep
+ * -- a class that never fires is a coverage gap.  Reset at activate.
+ */
+enum db_sim_fault_class {
+	DB_SIM_FC_TORN     = 0,   /* torn write (short prefix persisted) */
+	DB_SIM_FC_ENOSPC   = 1,   /* whole write failed ENOSPC */
+	DB_SIM_FC_CORRUPT  = 2,   /* corrupt read (bit flip) */
+	DB_SIM_FC_STALE    = 3,   /* stale read (prior version returned) */
+	DB_SIM_FC_LATENCY  = 4,   /* per-I/O latency sleep taken */
+	DB_SIM_FC_SHORTEIO = 5,   /* short-transfer / EIO toggle fired */
+	DB_SIM_FC_NCLASSES
+};
+unsigned long __db_sim_fault_count __P((int));
+void          __db_sim_fault_count_reset __P((void));
+const char   *__db_sim_fault_class_name __P((int));
+
 /* Buggify: once-per-run cached coin per named site (BUGGIFY stream). */
 void     __db_sim_buggify_enable __P((unsigned));
 void     __db_sim_buggify_disable __P((void));
@@ -49,6 +68,7 @@ int      __db_sim_io_should_fault __P((void));
 /* Stale-read model: a seeded read returns a prior (superseded) version of
  * the block -- well-formed but out of date, to catch a missing LSN check. */
 void     __db_sim_io_stale_enable __P((unsigned));
+int      __db_sim_io_stale_armed __P((void));
 void     __db_sim_io_stale_record __P((uint64_t, uint64_t, const void *, int));
 int      __db_sim_io_stale_read __P((uint64_t, uint64_t, void *, int));
 

--- a/test/sim/sim_inject.h
+++ b/test/sim/sim_inject.h
@@ -45,6 +45,20 @@
  *	                   the update is lost.  test_sim_ckp_crash's
  *	                   "post-checkpoint committed data survives"
  *	                   invariant fires.
+ *	  4  ABORTNOUNDO -- src/txn/txn.c __txn_abort SKIPS the __txn_undo
+ *	                   rollback pass, so an aborting txn's dirty page
+ *	                   changes are left in place yet the txn reports
+ *	                   aborted.  The aborted records survive;
+ *	                   test_sim_abort_atomic's "aborted txns leave no
+ *	                   trace" invariant fires.
+ *	  5  CKPBADLSN  -- src/txn/txn_chkpt.c __txn_updateckp records a
+ *	                   checkpoint LSN advanced far past the true one, so
+ *	                   recovery starts too LATE and skips replaying
+ *	                   committed log records written after the real
+ *	                   checkpoint.  Post-checkpoint committed txns are
+ *	                   lost after a crash; test_sim_ckp_lsn's
+ *	                   "post-checkpoint committed data survives"
+ *	                   invariant fires.
  *
  *	When you add a safety invariant, add a bug id here, plant it at the
  *	real site, and add a case to scripts/dst-bug-inject.sh so DST must
@@ -68,5 +82,7 @@
 #define DB_DST_BUG_NODURABLE   1   /* log_put.c: skip log fsync, still ack */
 #define DB_DST_BUG_NOCKSUM     2   /* hmac.c: accept a checksum-mismatch page */
 #define DB_DST_BUG_LOSTUPDATE  3   /* mp_bh.c: skip a dirty-page write */
+#define DB_DST_BUG_ABORTNOUNDO 4   /* txn.c: skip an abort's undo pass */
+#define DB_DST_BUG_CKPBADLSN   5   /* txn_chkpt.c: record a wrong checkpoint LSN */
 
 #endif /* !_DB_SIM_INJECT_H_ */

--- a/test/sim/sim_os.h
+++ b/test/sim/sim_os.h
@@ -20,7 +20,7 @@ uint64_t db_sim_fkey __P((DB_FH *));
 void __db_sim_io_write_hook __P((DB_FH *, u_int32_t));
 void __db_sim_io_write_off_hook __P((DB_FH *, u_int64_t));
 int __db_sim_io_write_fault_hook __P((DB_FH *, u_int32_t));
-void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, void *, size_t));
+void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, u_int32_t));
 void __db_sim_io_sync_hook __P((DB_FH *));
 void __db_sim_io_read_hook __P((DB_FH *, u_int64_t, void *, size_t));
 void __db_sim_io_latency_hook __P((void));

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -180,26 +180,37 @@ __db_sim_io_read_hook(fhp, off, buf, len)
 
 /*
  * __db_sim_io_presnapshot_hook --
- *	Called from the write path BEFORE overwriting, with the bytes
- *	CURRENTLY on disk at this (file,offset).  Records them in the
- *	stale-read ring so a later seeded stale read can return this
- *	now-prior version.  A no-op unless stale injection is armed.
+ *	Called from the write fast path BEFORE overwriting (fhp, off, len).
+ *	When the stale-read model is armed it reads the bytes CURRENTLY on
+ *	disk at this (file,offset) and records them in the stale-read ring,
+ *	so a later seeded stale read can hand back this now-prior version.
+ *	A no-op (no pread, no cost) unless stale injection is armed -- so it
+ *	never perturbs a non-stale run.
  *
  * PUBLIC: #ifdef HAVE_DST
- * PUBLIC: void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, void *, size_t));
+ * PUBLIC: void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, u_int32_t));
  * PUBLIC: #endif
  */
 void
-__db_sim_io_presnapshot_hook(fhp, off, buf, len)
+__db_sim_io_presnapshot_hook(fhp, off, len)
 	DB_FH *fhp;
 	u_int64_t off;
-	void *buf;
-	size_t len;
+	u_int32_t len;
 {
-	if (!__db_sim_active() || buf == NULL || len == 0)
+	unsigned char snap[512];
+	size_t cp;
+	ssize_t nr;
+
+	/* Only pay for the read-before-write when stale injection is armed
+	 * (the ring is otherwise inert), and only for a real named file. */
+	if (!__db_sim_active() || !__db_sim_io_stale_armed() ||
+	    fhp == NULL || fhp->fd < 0 || len == 0)
 		return;
-	__db_sim_io_stale_record(db_sim_fkey(fhp), off, buf,
-	    (int)(len > 0x7fffffff ? 0x7fffffff : len));
+	cp = len < sizeof(snap) ? (size_t)len : sizeof(snap);
+	nr = pread(fhp->fd, snap, cp, (off_t)off);
+	if (nr <= 0)
+		return;                 /* nothing there yet: no prior version */
+	__db_sim_io_stale_record(db_sim_fkey(fhp), off, snap, (int)nr);
 }
 
 /*

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -125,6 +125,11 @@ __db_sim_io_write_fault_hook(fhp, len)
 		return ((int)len);
 	if (__db_sim_io_enospc())
 		return (-1);
+	/* Short-transfer / EIO: a seeded whole-write failure distinct from
+	 * ENOSPC (models a transient device error).  Returns -2 => the
+	 * caller reports EIO, nothing persists. */
+	if (__db_sim_io_should_fault())
+		return (-2);
 	return (__db_sim_io_torn_prefix((int)len));
 }
 

--- a/test/sim/test_sim_ckp_enospc.c
+++ b/test/sim/test_sim_ckp_enospc.c
@@ -1,0 +1,177 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_ckp_enospc.c --
+ *	Checkpoint under disk-full.  A transactional workload commits N
+ *	durable (DB_TXN_SYNC) txns; then ENOSPC is armed and a CHECKPOINT is
+ *	forced (env->txn_checkpoint, which flushes dirty pages to the data
+ *	files).  The checkpoint may fail because a page write hits ENOSPC --
+ *	but that MUST NOT lose a committed txn: the log already made them
+ *	durable, so recovery replays them regardless of whether the
+ *	checkpoint's page flush completed.  After the crash + recovery, every
+ *	committed txn survives and the tree verifies clean.
+ *
+ *	Invariant: a checkpoint that fails under ENOSPC degrades cleanly --
+ *	no committed data lost, no corruption.  This is DESIGN.md catalog #19
+ *	(checkpoint + ENOSPC), the txn-durability angle (as opposed to
+ *	test_sim_enospc's put/commit angle).
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_ckp_enospc && ./test_sim_ckp_enospc [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_ckp_enospc"
+#define DBFILE  "ckpes.db"
+#define NCOMMIT 96
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "ce-%08d", i);
+	(void)snprintf(vbuf, 32, "cv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* N durable commits -- the LOG makes them recoverable regardless of
+	 * whether a later checkpoint's page flush completes. */
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Arm ENOSPC, then force a checkpoint: its page flush may fail on a
+	 * full disk.  We IGNORE the checkpoint's return -- a failed
+	 * checkpoint must not lose committed data (the log has it). */
+	__db_sim_io_enospc_enable(200);   /* 20% of writes ENOSPC */
+	(void)env->txn_checkpoint(env, 0, 0, DB_FORCE);
+	__db_sim_io_enospc_enable(0);
+
+	/*
+	 * ENOSPC is transient: space is freed and a subsequent checkpoint
+	 * completes.  Run one CLEAN checkpoint so the data files reach a
+	 * consistent on-disk state (the failed checkpoint above left some
+	 * pages unflushed, but committed data is safe in the LOG regardless).
+	 * Then crash: recovery must still bring back every committed txn.
+	 */
+	(void)env->txn_checkpoint(env, 0, 0, DB_FORCE);
+
+	/* Crash: drop un-fsync'd bytes, then abrupt exit. */
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC4E5;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			missing++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_ckp_enospc: verify FAILED: %s "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing != 0) {
+		fprintf(stderr, "test_sim_ckp_enospc: FAIL -- %d of %d "
+		    "committed txns lost after a checkpoint hit ENOSPC "
+		    "(seed 0x%llx)\n", missing, NCOMMIT,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_ckp_enospc: PASS -- checkpoint under ENOSPC degraded "
+	    "cleanly: all %d committed txns durable, tree clean (seed 0x%llx)\n",
+	    NCOMMIT, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_ckp_lsn.c
+++ b/test/sim/test_sim_ckp_lsn.c
@@ -1,0 +1,218 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_ckp_lsn.c --
+ *	Checkpoint-LSN correctness across a crash.  A transactional workload
+ *	commits a PRE-checkpoint batch, forces a checkpoint (records the LSN
+ *	recovery will start from), commits a POST-checkpoint batch (durable
+ *	in the fsync'd log, but their data pages are NOT flushed), then
+ *	crashes.  Recovery must replay the log FROM THE CHECKPOINT forward
+ *	and bring back every post-checkpoint committed txn.
+ *
+ *	Invariant (DESIGN.md catalog #18, checkpoint-LSN angle): the
+ *	recorded checkpoint LSN is the correct recovery start point -- a
+ *	checkpoint that records the WRONG (too-recent) LSN makes recovery
+ *	skip committed records written after the real checkpoint, silently
+ *	losing them.  Every committed txn (pre AND post checkpoint) must be
+ *	present after recovery.
+ *
+ *	PLANTED BUG (DB_DST_INJECT_BUG=5, CKPBADLSN): __txn_updateckp records
+ *	a checkpoint LSN advanced far past the true one, so recovery starts
+ *	too late and the post-checkpoint committed txns are lost.  This
+ *	test's invariant then fires -- the FoundationDB-grade "DST finds a
+ *	real recovery bug, here is the seed" proof.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_ckp_lsn && ./test_sim_ckp_lsn [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_ckp_lsn"
+#define DBFILE  "ckplsn.db"
+#define NPRE    48            /* committed BEFORE the checkpoint */
+#define NPOST   48            /* committed AFTER the checkpoint */
+
+static void
+mkrec(post, i, kbuf, vbuf)
+	int post, i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "%s-%08d", post ? "po" : "pr", i);
+	(void)snprintf(vbuf, 32, "v-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+commit_batch(env, db, post, n)
+	DB_ENV *env;
+	DB *db;
+	int post, n;
+{
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	for (i = 0; i < n; i++) {
+		mkrec(post, i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	int ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* Pre-checkpoint commits. */
+	if ((ret = commit_batch(env, db, 0, NPRE)) != 0)
+		return (ret);
+
+	/* Checkpoint: records the LSN recovery will start from.  DB_FORCE
+	 * flushes dirty pages to disk too. */
+	if ((ret = env->txn_checkpoint(env, 0, 0, DB_FORCE)) != 0)
+		return (ret);
+
+	/* Post-checkpoint commits: durable in the fsync'd LOG, but their
+	 * data pages are NOT flushed (no further checkpoint).  Recovery must
+	 * replay them from the checkpoint LSN forward. */
+	if ((ret = commit_batch(env, db, 1, NPOST)) != 0)
+		return (ret);
+
+	/* Crash: drop un-fsync'd bytes (the log's synced prefix -- covering
+	 * every DB_TXN_SYNC commit -- survives; unflushed data pages are
+	 * rebuilt by recovery from the log). */
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC4914;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing_pre = 0, missing_post = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0) {
+#if DB_DST_BUG(5)
+		/* Recovery from a bogus (too-far-forward) checkpoint LSN may
+		 * fail outright -- that is also a detection of the bug. */
+		printf("test_sim_ckp_lsn: DST CAUGHT CKPBADLSN -- recovery "
+		    "from the wrong checkpoint LSN failed (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_SUCCESS);
+#else
+		return (EXIT_FAILURE);
+#endif
+	}
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NPRE; i++) {
+		mkrec(0, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing_pre++;
+	}
+	for (i = 0; i < NPOST; i++) {
+		mkrec(1, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing_post++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+#if DB_DST_BUG(5)
+	/*
+	 * CKPBADLSN invariant: with the wrong checkpoint LSN, recovery must
+	 * have LOST at least one post-checkpoint committed txn.  If all
+	 * survived, the bug went undetected -- fail so the sweep records the
+	 * hole.  When caught (a post-ckp txn missing), exit 0.
+	 */
+	if (missing_post == 0 && missing_pre == 0) {
+		fprintf(stderr, "test_sim_ckp_lsn: DID NOT CATCH CKPBADLSN -- "
+		    "all committed txns survived despite the wrong checkpoint "
+		    "LSN (seed 0x%llx)\n", (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_ckp_lsn: DST CAUGHT CKPBADLSN -- %d pre + %d post "
+	    "checkpoint committed txn(s) lost because recovery started from "
+	    "the wrong LSN (seed 0x%llx)\n", missing_pre, missing_post,
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+#else
+	if (missing_pre != 0 || missing_post != 0) {
+		fprintf(stderr, "test_sim_ckp_lsn: FAIL -- %d pre + %d post "
+		    "checkpoint committed txns lost after recovery "
+		    "(seed 0x%llx)\n", missing_pre, missing_post,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_ckp_lsn: PASS -- all %d pre + %d post checkpoint "
+	    "committed txns replayed from the correct checkpoint LSN "
+	    "(seed 0x%llx)\n", NPRE, NPOST, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+#endif
+}

--- a/test/sim/test_sim_cursor_crash.c
+++ b/test/sim/test_sim_cursor_crash.c
@@ -1,0 +1,210 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_cursor_crash.c --
+ *	Cursor-heavy workload across a crash.  All writes go through a
+ *	CURSOR (c_put), a seeded subset is removed via cursor delete (c_del
+ *	while iterating), all inside durable txns.  The process crashes;
+ *	recovery runs; then a fresh CURSOR walk (c_get DB_NEXT) must return
+ *	exactly the live set in key order -- every cursor-inserted, not
+ *	cursor-deleted record present, deleted ones absent -- and the tree
+ *	verifies clean.
+ *
+ *	Invariant (DESIGN.md catalog #30, cursor angle): cursor mutations
+ *	are durable and consistent across a crash, and a post-recovery
+ *	cursor scan sees exactly the committed live set (no phantom, no
+ *	lost, correct order).
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_cursor_crash && ./test_sim_cursor_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_cursor"
+#define DBFILE  "cursor.db"
+#define NKEYS   300
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "cu-%08d", i);
+	(void)snprintf(vbuf, 32, "cv-%016llx", (unsigned long long)tok);
+}
+
+/* Deleted iff every 5th key (seeded-stable, deterministic). */
+static int
+is_deleted(i)
+	int i;
+{
+	return ((i % 5) == 0);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBC *dbc;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* Insert all keys via a cursor, each in its own durable txn. */
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		if ((ret = db->cursor(db, txn, &dbc, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = dbc->put(dbc, &key, &data, DB_KEYFIRST)) != 0)
+			return (ret);
+		(void)dbc->close(dbc);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Cursor-delete a seeded subset: position via c_get(SET) then
+	 * c_del, in one durable txn (a cursor-heavy delete pass). */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	if ((ret = db->cursor(db, txn, &dbc, 0)) != 0)
+		return (ret);
+	for (i = 0; i < NKEYS; i++) {
+		if (!is_deleted(i))
+			continue;
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (dbc->get(dbc, &key, &data, DB_SET) == 0)
+			(void)dbc->del(dbc, 0);
+	}
+	(void)dbc->close(dbc);
+	if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+		return (ret);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC025;
+	DB_ENV *env;
+	DB *db;
+	DBC *dbc;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, ghost = 0, walked = 0, expect_live = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	/* Point-check each key. */
+	__db_sim_activate(seed);
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (is_deleted(i)) {
+			if (ret == 0)
+				ghost++;
+		} else {
+			expect_live++;
+			if (ret != 0)
+				missing++;
+			else if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				missing++;
+		}
+	}
+	__db_sim_deactivate();
+
+	/* Fresh cursor walk: count the live set the cursor sees in order. */
+	if ((ret = db->cursor(db, NULL, &dbc, 0)) == 0) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		while (dbc->get(dbc, &key, &data, DB_NEXT) == 0)
+			walked++;
+		(void)dbc->close(dbc);
+	}
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_cursor_crash: verify FAILED: %s\n",
+		    db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	printf("test_sim_cursor_crash: %d expected-live, cursor walked %d, "
+	    "%d missing, %d ghost (seed 0x%llx)\n",
+	    expect_live, walked, missing, ghost, (unsigned long long)seed);
+
+	if (missing != 0 || ghost != 0 || walked != expect_live) {
+		fprintf(stderr, "test_sim_cursor_crash: FAIL -- cursor "
+		    "mutations inconsistent after recovery (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_cursor_crash: PASS -- all cursor-written records "
+	    "survived, cursor-deletes stayed deleted, cursor walk exact, "
+	    "tree clean (seed 0x%llx)\n", (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_largetxn_crash.c
+++ b/test/sim/test_sim_largetxn_crash.c
@@ -1,0 +1,184 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_largetxn_crash.c --
+ *	Large-transaction (many ops in ONE txn) atomicity across a crash.
+ *	One BIG txn writes NOPS records and commits durably; a SECOND big
+ *	txn writes NOPS more records and is left UNCOMMITTED when the crash
+ *	hits.  After recovery: every record of the committed big txn is
+ *	present (all-or-nothing: the txn was atomic), and NOT ONE record of
+ *	the uncommitted big txn survives (a partial large-txn survivor would
+ *	be an atomicity violation).
+ *
+ *	Invariant (DESIGN.md catalog #8, large-txn angle): a large multi-op
+ *	transaction is atomic across a crash -- all of a committed one
+ *	survives, none of an uncommitted one does.  This stresses the log's
+ *	handling of a long single-txn record chain and the recovery
+ *	undo/redo over many ops in one commit boundary.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_largetxn_crash && ./test_sim_largetxn_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_largetxn"
+#define DBFILE  "largetxn.db"
+#define NOPS    2000          /* ops in ONE txn (large) */
+
+static void
+mkrec(committed, i, kbuf, vbuf)
+	int committed, i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "%s-%08d", committed ? "cm" : "un", i);
+	(void)snprintf(vbuf, 32, "v-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	/* Bigger cache + log so a 2000-op txn fits without a trickle sync. */
+	(void)env->set_cachesize(env, 0, 4 * 1024 * 1024, 1);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* ONE large committed txn: NOPS puts, then a single durable commit. */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	for (i = 0; i < NOPS; i++) {
+		mkrec(1, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+	}
+	if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+		return (ret);
+
+	/* ONE large UNCOMMITTED txn: NOPS puts, then crash mid-txn.  None
+	 * of these may survive. */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	for (i = 0; i < NOPS; i++) {
+		mkrec(0, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		(void)db->put(db, txn, &key, &data, 0);
+	}
+	/* deliberately DO NOT commit */
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x1A46E;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, ghost = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	/* Committed big txn: every record present (atomic all). */
+	for (i = 0; i < NOPS; i++) {
+		mkrec(1, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			missing++;
+	}
+	/* Uncommitted big txn: NOT ONE record survives (atomic none). */
+	for (i = 0; i < NOPS; i++) {
+		mkrec(0, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0)
+			ghost++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_largetxn_crash: verify FAILED: %s\n",
+		    db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	if (missing != 0 || ghost != 0) {
+		fprintf(stderr, "test_sim_largetxn_crash: FAIL -- %d of %d "
+		    "committed missing, %d uncommitted survived (large-txn "
+		    "atomicity broken, seed 0x%llx)\n", missing, NOPS, ghost,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_largetxn_crash: PASS -- large committed txn (%d ops) "
+	    "atomic-all survived, large uncommitted txn atomic-none, tree "
+	    "clean (seed 0x%llx)\n", NOPS, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_latency_load.c
+++ b/test/sim/test_sim_latency_load.c
@@ -1,0 +1,178 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_latency_load.c --
+ *	Workload under seeded I/O latency (a slow disk).  Every physical
+ *	I/O takes a seeded, capped delay (__db_sim_io_latency_hook).  A
+ *	transactional put/commit workload runs against this slow disk; the
+ *	engine's timeout / progress logic must still make forward progress
+ *	and produce correct results -- no lost commit, no hang, no spurious
+ *	deadlock-victim from the latency alone.
+ *
+ *	This is DESIGN.md catalog #14's latency angle on the single-process
+ *	axis: v1 latency is a real (tiny) sleep on each I/O, so it does not
+ *	REORDER concurrent I/O (that is the v2 async-scheduler payoff), but
+ *	it does exercise the code paths that time or bound I/O and proves
+ *	the workload's correctness is latency-independent (the same seed's
+ *	committed set is identical with and without latency armed).
+ *
+ *	Invariant: under a slow disk, (a) every committed txn is durable and
+ *	correct, and (b) the committed set is BYTE-IDENTICAL to a run of the
+ *	same seed with latency OFF -- latency changes timing, never the data
+ *	(a determinism-under-latency check).  And latency actually fired.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_latency_load && ./test_sim_latency_load [seed]
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+#define HOME    "TESTDIR_sim_latency"
+#define DBFILE  "latency.db"
+#define NCOMMIT 64
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "la-%08d", i);
+	(void)snprintf(vbuf, 32, "lv-%016llx", (unsigned long long)tok);
+}
+
+/* Run the workload once; latency_on selects whether the slow-disk knob is
+ * armed.  Fold every committed value into a hash so two runs' committed
+ * sets can be compared byte-for-byte.  Returns 0 on success. */
+static int
+run_once(seed, latency_on, out_hash, out_committed)
+	uint64_t seed;
+	int latency_on;
+	uint64_t *out_hash;
+	int *out_committed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32], cmd[256];
+	uint64_t h = 1469598103934665603ull;
+	int i, ret, committed = 0;
+
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	(void)system(cmd);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0664)) != 0)
+		return (ret);
+
+	__db_sim_activate(seed);
+	if (latency_on)
+		__db_sim_io_faults_enable(2000, 40000, 0);   /* 2-40us/IO */
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if (env->txn_begin(env, NULL, &txn, 0) != 0)
+			continue;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if (db->put(db, txn, &key, &data, 0) != 0) {
+			(void)txn->abort(txn);
+			continue;
+		}
+		if (txn->commit(txn, DB_TXN_SYNC) == 0) {
+			committed++;
+			/* Fold the committed key+value into the hash. */
+			{
+				const unsigned char *p;
+				for (p = (unsigned char *)kbuf; *p; p++)
+					{ h ^= *p; h *= 1099511628211ull; }
+				for (p = (unsigned char *)vbuf; *p; p++)
+					{ h ^= *p; h *= 1099511628211ull; }
+			}
+		}
+	}
+
+	if (latency_on)
+		__db_sim_io_faults_disable();
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	*out_hash = h;
+	*out_committed = committed;
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x1A7E;
+	uint64_t h_slow = 0, h_fast = 0;
+	unsigned long lat_fires;
+	int c_slow = 0, c_fast = 0;
+
+	/* Slow-disk run (latency armed). */
+	if (run_once(seed, 1, &h_slow, &c_slow) != 0) {
+		fprintf(stderr, "test_sim_latency_load: slow run setup "
+		    "error\n");
+		return (EXIT_FAILURE);
+	}
+	lat_fires = __db_sim_fault_count(DB_SIM_FC_LATENCY);
+
+	/* Fast run (no latency) -- same seed, must produce the SAME
+	 * committed set. */
+	if (run_once(seed, 0, &h_fast, &c_fast) != 0) {
+		fprintf(stderr, "test_sim_latency_load: fast run setup "
+		    "error\n");
+		return (EXIT_FAILURE);
+	}
+
+	printf("test_sim_latency_load: slow committed=%d hash=%016llx, "
+	    "fast committed=%d hash=%016llx; latency fired %lu times "
+	    "(seed 0x%llx)\n", c_slow, (unsigned long long)h_slow,
+	    c_fast, (unsigned long long)h_fast, lat_fires,
+	    (unsigned long long)seed);
+
+	if (c_slow != NCOMMIT || c_fast != NCOMMIT) {
+		fprintf(stderr, "test_sim_latency_load: FAIL -- not all txns "
+		    "committed (slow %d, fast %d of %d) -- latency broke "
+		    "progress\n", c_slow, c_fast, NCOMMIT);
+		return (EXIT_FAILURE);
+	}
+	if (h_slow != h_fast) {
+		fprintf(stderr, "test_sim_latency_load: FAIL -- committed set "
+		    "differs between slow and fast disk (latency changed the "
+		    "DATA, not just timing) seed 0x%llx\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (lat_fires == 0) {
+		fprintf(stderr, "test_sim_latency_load: FAIL -- the latency "
+		    "knob never fired; the slow-disk path is not exercised\n");
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_latency_load: PASS -- slow disk made forward "
+	    "progress, committed set identical to fast disk, latency "
+	    "exercised (%lu I/O delays)\n", lat_fires);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_multi_fault.c
+++ b/test/sim/test_sim_multi_fault.c
@@ -1,0 +1,237 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_multi_fault.c --
+ *	MULTI-fault combination: seeded I/O latency AND ENOSPC armed
+ *	together across a transactional crash+recover.  A workload runs
+ *	against a slow disk that also intermittently reports "disk full"
+ *	on a write; a put/commit that hits ENOSPC fails cleanly (the txn is
+ *	aborted), one that succeeds under DB_TXN_SYNC is durable.  The
+ *	process then crashes; recovery runs.  Every OBSERVED-committed txn
+ *	must survive, the uncommitted one must not, and the tree verifies
+ *	clean -- under two independent fault classes at once (a slow, full
+ *	disk), a combination that must not produce a failure mode neither
+ *	fault produces alone.
+ *
+ *	Why latency+ENOSPC (not latency+torn): ENOSPC fails a WHOLE write
+ *	cleanly (nothing persists, the error is returned and handled), so it
+ *	combines with latency across a crash without corrupting a live page
+ *	the writer re-reads mid-run.  Torn-write-during-a-workload is
+ *	covered by test_sim_split_torn / test_sim_torn_log; corrupt-read is
+ *	test_sim_torn.  This scenario is the two-graceful-faults-at-once
+ *	durability check.
+ *
+ *	Invariant (DESIGN.md, multi-fault): observed-committed survives,
+ *	uncommitted gone, no corruption, EVEN with latency + ENOSPC both
+ *	active -- and both fault classes actually fire (activation counters).
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_multi_fault && ./test_sim_multi_fault [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_multi"
+#define DBFILE  "multi.db"
+#define NCOMMIT 64
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "mf-%08d", i);
+	(void)snprintf(vbuf, 32, "mv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+/* Records whose commit returned 0 (observed durable): the child writes a
+ * bitmap so the parent knows what MUST survive. */
+static unsigned char g_committed[NCOMMIT];
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+	FILE *fp;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+	/* Latency on from the start (a slow disk, always graceful).  ENOSPC
+	 * is armed AFTER the DB is created + a durable prefix is written (so
+	 * the create/meta writes are not failed), modelling a disk that fills
+	 * mid-workload. */
+	__db_sim_io_faults_enable(1000, 30000, 0);   /* 1-30us latency */
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	memset(g_committed, 0, sizeof(g_committed));
+	for (i = 0; i < NCOMMIT; i++) {
+		if (i == NCOMMIT / 4)
+			__db_sim_io_enospc_enable(120);   /* disk fills at 25% */
+		mkrec(i, kbuf, vbuf);
+		if (env->txn_begin(env, NULL, &txn, 0) != 0)
+			continue;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		/* An ENOSPC write may fail the put/commit cleanly. */
+		if (db->put(db, txn, &key, &data, 0) != 0) {
+			(void)txn->abort(txn);
+			continue;
+		}
+		if (txn->commit(txn, DB_TXN_SYNC) == 0)
+			g_committed[i] = 1;   /* observed durable */
+	}
+
+	/* Hand the observed-committed bitmap to the parent. */
+	if ((fp = fopen(HOME "/committed.map", "wb")) != NULL) {
+		(void)fwrite(g_committed, 1, sizeof(g_committed), fp);
+		(void)fclose(fp);
+	}
+
+	/* Uncommitted txn (best-effort; may itself hit ENOSPC), then crash. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if (env->txn_begin(env, NULL, &txn, 0) == 0) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		(void)db->put(db, txn, &key, &data, 0);
+	}
+
+	/* Disarm ENOSPC so the crash truncation is clean, then drop
+	 * un-fsync'd bytes and exit. */
+	__db_sim_io_enospc_enable(0);
+	__db_sim_io_faults_disable();
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x33FA;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	unsigned char committed[NCOMMIT];
+	FILE *fp;
+	int i, ret, missing = 0, silent_bad = 0, saw_uncommitted = 0;
+	int ncommitted = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	memset(committed, 0, sizeof(committed));
+	if ((fp = fopen(HOME "/committed.map", "rb")) != NULL) {
+		(void)fread(committed, 1, sizeof(committed), fp);
+		(void)fclose(fp);
+	}
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if (!committed[i])
+			continue;   /* commit failed under ENOSPC -- no guarantee */
+		ncommitted++;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				silent_bad++;
+		} else {
+			missing++;   /* an observed-committed txn LOST: bad */
+		}
+	}
+	mkrec(NCOMMIT, kbuf, vbuf);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		saw_uncommitted = 1;
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_multi_fault: verify FAILED: %s "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	printf("test_sim_multi_fault: %d observed-committed present of %d, %d "
+	    "missing, %d silent-bad, uncommitted=%d; latency=%lu enospc=%lu "
+	    "(seed 0x%llx)\n", ncommitted - missing, ncommitted, missing,
+	    silent_bad, saw_uncommitted,
+	    __db_sim_fault_count(DB_SIM_FC_LATENCY),
+	    __db_sim_fault_count(DB_SIM_FC_ENOSPC),
+	    (unsigned long long)seed);
+
+	/* Hard invariants: no observed-committed txn lost, no silently-wrong
+	 * data, no uncommitted survivor, tree clean -- under latency+ENOSPC. */
+	if (missing != 0 || silent_bad != 0 || saw_uncommitted != 0) {
+		fprintf(stderr, "test_sim_multi_fault: FAIL -- missing=%d "
+		    "silent_bad=%d uncommitted=%d under latency+ENOSPC "
+		    "(seed 0x%llx)\n", missing, silent_bad, saw_uncommitted,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_multi_fault: PASS -- all observed-committed durable, "
+	    "no silent corruption, uncommitted gone, tree clean under "
+	    "latency+ENOSPC\n");
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_recover_corrupt.c
+++ b/test/sim/test_sim_recover_corrupt.c
@@ -1,0 +1,200 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_recover_corrupt.c --
+ *	Corrupt read DURING recovery.  A DB_CHKSUM transactional workload
+ *	commits N durable txns, then crashes (write-back drop of un-fsync'd
+ *	bytes).  Recovery is then run with corrupt reads ARMED, so pages/log
+ *	records read during the recovery replay can be bit-flipped.
+ *
+ *	Invariant (DESIGN.md catalog #14, recovery robustness): recovery
+ *	must never silently accept corrupt data.  Either it succeeds and
+ *	every committed txn is correct (the corrupt read either missed the
+ *	live pages this seed, or the checksum caught + the page was re-read),
+ *	or recovery/verify fails CLEANLY.  A recovered DB that hands back a
+ *	committed value not matching what was stored, with no error, is
+ *	SILENT-BAD and fails.  A crash/hang during recovery also fails.
+ *
+ *	Because a corrupt read during recovery can legitimately make
+ *	recovery ERROR (a checksum-failed log/meta page), a clean recovery
+ *	failure is an ACCEPTABLE outcome for a seed -- what is NOT acceptable
+ *	is silent bad data or a crash.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_recover_corrupt && ./test_sim_recover_corrupt [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_rec_corrupt"
+#define DBFILE  "reccorrupt.db"
+#define NCOMMIT 80
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "rc-%08d", i);
+	for (j = 0; j < 24; j++)
+		vbuf[j] = (char)('a' + ((i + j) % 26));
+	vbuf[24] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0)
+		return (ret);
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/*
+	 * Crash abruptly WITHOUT the write-back truncation: this scenario
+	 * isolates corrupt reads DURING recovery, so the on-disk files must
+	 * be whole (a torn DB page would be a different fault -- that is
+	 * test_sim_split_torn/test_sim_torn_log).  The committed txns are
+	 * durable in the fsync'd log; recovery replays them, and we inject
+	 * corrupt reads into THAT replay.
+	 */
+	fflush(NULL);
+	_exit(42);
+	/* NOTREACHED */
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xEC0;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, silent_bad = 0, rec_failed = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Recover with corrupt reads armed: pages read during replay can be
+	 * bit-flipped.  A checksum-failed recovery is a CLEAN failure. */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (EXIT_FAILURE);
+	__db_sim_activate(seed);
+	__db_sim_io_corrupt_enable(40);   /* 4% corrupt reads during recovery */
+	ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG |
+	    DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER, 0664);
+	__db_sim_io_corrupt_disable();
+	if (ret != 0) {
+		/* Recovery refused to proceed on corruption: clean failure. */
+		rec_failed = 1;
+		printf("test_sim_recover_corrupt: recovery cleanly refused "
+		    "corrupt input: %s (corrupt=%lu, seed 0x%llx)\n",
+		    db_strerror(ret),
+		    __db_sim_fault_count(DB_SIM_FC_CORRUPT),
+		    (unsigned long long)seed);
+		__db_sim_deactivate();
+		return (EXIT_SUCCESS);
+	}
+	__db_sim_deactivate();
+
+	if (open_db(env, &db, 0) != 0) {
+		/* A clean open failure after a corrupt recovery is acceptable
+		 * too -- what matters is no silent bad data. */
+		(void)env->close(env, 0);
+		printf("test_sim_recover_corrupt: DB open cleanly refused "
+		    "after corrupt recovery (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_SUCCESS);
+	}
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				silent_bad++;
+		} else {
+			missing++;   /* a clean error is acceptable */
+		}
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_recover_corrupt: %d ok-committed, %d clean-error, "
+	    "%d SILENT-BAD, rec_failed=%d; corrupt=%lu (seed 0x%llx)\n",
+	    NCOMMIT - missing - silent_bad, missing, silent_bad, rec_failed,
+	    __db_sim_fault_count(DB_SIM_FC_CORRUPT),
+	    (unsigned long long)seed);
+
+	if (silent_bad != 0) {
+		fprintf(stderr, "test_sim_recover_corrupt: FAIL -- %d "
+		    "committed values silently wrong after recovery under "
+		    "corrupt reads\n", silent_bad);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_recover_corrupt: PASS -- recovery under corrupt "
+	    "reads never returned silently-wrong committed data\n");
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_secondary_crash.c
+++ b/test/sim/test_sim_secondary_crash.c
@@ -1,0 +1,206 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_secondary_crash.c --
+ *	Secondary-index (associate) consistency after crash + recovery.  A
+ *	primary btree has a secondary index associated (DB_CREATE, keyed by
+ *	a field of the primary value).  N durable txns insert primary
+ *	records (each put also updates the secondary via the callback).  The
+ *	process crashes; recovery runs; then EVERY committed primary record
+ *	must be reachable BOTH by its primary key AND by a secondary-key
+ *	lookup (pget), and the count via the secondary must equal the count
+ *	via the primary -- no dangling or missing secondary entries.
+ *
+ *	Invariant (DESIGN.md catalog #5): the primary and its secondary
+ *	index stay mutually consistent across a crash.  A secondary that
+ *	lost or gained entries relative to the primary is a corruption the
+ *	recovery must not leave behind.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_secondary_crash && ./test_sim_secondary_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_secondary"
+#define PRIDB   "pri.db"
+#define SECDB   "sec.db"
+#define NCOMMIT 80
+
+/* Primary value layout: "sec:<8 hex tok>|pri:<index>".  The secondary key
+ * is the "<8 hex tok>" field (unique per record via the seeded token). */
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "p-%08d", i);
+	(void)snprintf(vbuf, 40, "%08llx|pri-%08d",
+	    (unsigned long long)(tok & 0xffffffffull), i);
+}
+
+/* Secondary key = the leading "%08x" token of the primary value. */
+static int
+getsec(secondary, pkey, pdata, skey)
+	DB *secondary;
+	const DBT *pkey, *pdata;
+	DBT *skey;
+{
+	(void)secondary;
+	(void)pkey;
+	memset(skey, 0, sizeof(DBT));
+	skey->data = pdata->data;   /* first 8 chars: the hex token */
+	skey->size = 8;
+	return (0);
+}
+
+static int
+open_dbs(env, prip, secp, create)
+	DB_ENV *env;
+	DB **prip, **secp;
+	int create;
+{
+	DB *pri, *sec;
+	int ret;
+
+	if ((ret = db_create(&pri, env, 0)) != 0)
+		return (ret);
+	if ((ret = pri->open(pri, NULL, PRIDB, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "pri open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	if ((ret = db_create(&sec, env, 0)) != 0)
+		return (ret);
+	/* Secondary allows dups (different records could share a token). */
+	(void)sec->set_flags(sec, DB_DUPSORT);
+	if ((ret = sec->open(sec, NULL, SECDB, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "sec open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	if ((ret = pri->associate(pri, NULL, sec, getsec,
+	    create ? DB_CREATE : 0)) != 0) {
+		fprintf(stderr, "associate: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*prip = pri;
+	*secp = sec;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *pri, *sec;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[40];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_dbs(env, &pri, &sec, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = pri->put(pri, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x5EC0;
+	DB_ENV *env;
+	DB *pri, *sec;
+	DBT skey, pkey, pdata;
+	char kbuf[32], vbuf[40];
+	int i, ret, missing_pri = 0, missing_sec = 0;
+	db_recno_t seccount = 0, pricount = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_dbs(env, &pri, &sec, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		DBT k, d;
+		mkrec(i, kbuf, vbuf);
+		/* (a) primary lookup */
+		memset(&k, 0, sizeof(k));
+		memset(&d, 0, sizeof(d));
+		k.data = kbuf; k.size = (u_int32_t)strlen(kbuf) + 1;
+		if (pri->get(pri, NULL, &k, &d, 0) != 0) {
+			missing_pri++;
+			continue;
+		}
+		pricount++;
+		/* (b) secondary lookup by token (pget returns the primary
+		 * record); the primary key it returns must match ours. */
+		memset(&skey, 0, sizeof(skey));
+		memset(&pkey, 0, sizeof(pkey));
+		memset(&pdata, 0, sizeof(pdata));
+		skey.data = vbuf; skey.size = 8;   /* the token field */
+		if (sec->pget(sec, NULL, &skey, &pkey, &pdata, 0) != 0) {
+			missing_sec++;
+			continue;
+		}
+		seccount++;
+		/* pdata must equal the primary value we stored. */
+		if (pdata.size != strlen(vbuf) + 1 ||
+		    memcmp(pdata.data, vbuf, pdata.size) != 0)
+			missing_sec++;
+	}
+	__db_sim_deactivate();
+
+	(void)sec->close(sec, 0);
+	(void)pri->close(pri, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_secondary_crash: %u via primary, %u via secondary, "
+	    "%d missing-pri, %d missing/wrong-sec (seed 0x%llx)\n",
+	    (u_int)pricount, (u_int)seccount, missing_pri, missing_sec,
+	    (unsigned long long)seed);
+
+	if (missing_pri != 0 || missing_sec != 0 || pricount != seccount) {
+		fprintf(stderr, "test_sim_secondary_crash: FAIL -- primary/"
+		    "secondary inconsistent after recovery (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_secondary_crash: PASS -- all %d committed records "
+	    "consistent across primary and secondary after crash+recover "
+	    "(seed 0x%llx)\n", NCOMMIT, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_split_torn.c
+++ b/test/sim/test_sim_split_torn.c
@@ -1,0 +1,192 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_split_torn.c --
+ *	Torn write DURING a btree split, caught by the page checksum.  A
+ *	small-page DB_CHKSUM btree takes a scatter-insert churn heavy enough
+ *	to force many page splits; torn writes are armed during the churn so
+ *	some split-produced pages persist only a strict prefix (a latent bad
+ *	tail).  The env is then reopened COLD (DB_PRIVATE small cache) and
+ *	every key scanned so every page is re-read from disk.
+ *
+ *	Invariant (DESIGN.md catalog #17/#21): a torn split page is NEVER
+ *	returned as silently-wrong data -- the per-page checksum either
+ *	catches it (a clean get error) or the page was a checksum-consistent
+ *	earlier full write.  A get that returns bytes not matching what was
+ *	stored, with no error, is SILENT-BAD and fails.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_split_torn && ./test_sim_split_torn [seed]
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+#define HOME    "TESTDIR_sim_split_torn"
+#define DBFILE  "splittorn.db"
+#define NKEYS   500
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "st-%08u", (i * 2654435761u) % 1000000u);
+	/* Verifiable pattern so a silent torn tail shows as a mismatch. */
+	for (j = 0; j < 30; j++)
+		vbuf[j] = (char)('A' + ((i + j) % 26));
+	vbuf[30] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    create ? DB_CREATE : 0, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x5701;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32], cmd[256];
+	int i, ret, correct = 0, detected = 0, silent_bad = 0;
+	unsigned long torn_phase1;
+
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	(void)system(cmd);
+
+	/* ---- phase 1: split-heavy build with torn writes armed ---- */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		goto env_err;
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_MPOOL, 0664)) != 0)
+		goto env_err;
+	if ((ret = open_db(env, &db, 1)) != 0)
+		goto env_err;
+
+	__db_sim_activate(seed);
+	/* Build the tree CLEAN (so all keys are present), forcing many splits
+	 * via scatter inserts. */
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		(void)db->put(db, NULL, &key, &data, 0);
+	}
+
+	/* Now arm torn writes and FLUSH: every dirty split-produced page is
+	 * written to disk under the torn fault, so some persist only a strict
+	 * prefix (a latent bad tail).  Shares the IO stream but only writes
+	 * are in flight here, so this exercises __db_sim_io_torn_prefix. */
+	__db_sim_io_corrupt_enable(150);
+	(void)db->sync(db, 0);
+	torn_phase1 = __db_sim_fault_count(DB_SIM_FC_TORN);
+
+	__db_sim_io_corrupt_disable();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+	__db_sim_deactivate();
+
+	/* ---- phase 2: reopen COLD (no new faults) and scan every key so
+	 *      every leaf/internal page is re-read from disk; a torn tail
+	 *      from phase 1 must be caught by the checksum, never silent. ---- */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		goto env_err;
+	(void)env->set_cachesize(env, 0, 64 * 1024, 1);
+	if ((ret = env->open(env, HOME,
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0664)) != 0)
+		goto env_err;
+	if ((ret = db_create(&db, env, 0)) != 0)
+		goto env_err;
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE, 0, 0664)) != 0) {
+		/* A torn META/root page makes the open itself fail with a
+		 * checksum error -- that IS the checksum catching the torn
+		 * write cleanly (not silent-bad).  A clean, PASSing outcome. */
+		printf("test_sim_split_torn: torn meta/root page caught at open "
+		    "(clean checksum error: %s); torn(writes)=%lu (seed 0x%llx)\n",
+		    db_strerror(ret), torn_phase1, (unsigned long long)seed);
+		(void)env->close(env, 0);
+		__db_sim_deactivate();
+		printf("test_sim_split_torn: PASS -- torn write caught, never "
+		    "silently-wrong data\n");
+		return (EXIT_SUCCESS);
+	}
+
+	__db_sim_activate(seed);
+
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size == strlen(vbuf) + 1 &&
+			    memcmp(data.data, vbuf, data.size) == 0)
+				correct++;
+			else
+				silent_bad++;
+		} else {
+			detected++;   /* checksum / page error: clean detect */
+		}
+	}
+
+	__db_sim_io_corrupt_disable();
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_split_torn: %d correct, %d detected(clean error), "
+	    "%d SILENT-BAD; torn(writes)=%lu (seed 0x%llx)\n",
+	    correct, detected, silent_bad, torn_phase1,
+	    (unsigned long long)seed);
+
+	if (silent_bad != 0) {
+		fprintf(stderr, "test_sim_split_torn: FAIL -- %d silently "
+		    "corrupt split pages slipped past the checksum\n",
+		    silent_bad);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_split_torn: PASS -- no torn split page ever returned "
+	    "as silently-wrong data\n");
+	return (EXIT_SUCCESS);
+
+env_err:
+	fprintf(stderr, "test_sim_split_torn: setup error: %s\n",
+	    db_strerror(ret));
+	return (EXIT_FAILURE);
+}

--- a/test/sim/test_sim_stale.c
+++ b/test/sim/test_sim_stale.c
@@ -1,0 +1,208 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_stale.c --
+ *	Stale-read (out-of-date read) fault + the version/LSN check that
+ *	catches it.  FoundationDB's stale-data fault class: the disk hands
+ *	back a page that is STRUCTURALLY VALID but OUT OF DATE -- a durable
+ *	version that was later overwritten.  A bare page checksum does NOT
+ *	catch this: the stale page's own checksum is consistent with its
+ *	old contents.  The only defense is a monotonic version / LSN stamped
+ *	in the page and checked on read (exactly what BDB's recovery does
+ *	with page LSNs).
+ *
+ *	This drives the REAL libdb OS seam (__os_open / __os_io / __os_fsync)
+ *	so the stale-read ring is exercised end to end through the actual
+ *	hooks: the write path's __db_sim_io_presnapshot_hook snapshots the
+ *	current on-disk bytes before each overwrite, and the read path's
+ *	__db_sim_io_read_hook returns a prior version on a seeded coin.  Each
+ *	page carries a monotonically increasing version in its first 8
+ *	bytes; the writer knows the highest version it has durably written,
+ *	so a read whose version is LOWER is a detected stale read.
+ *
+ *	Two invariants, both proven across a seed sweep:
+ *	  (1) DETECTION: the version check CATCHES every stale read -- no
+ *	      stale page is ever adopted as current (a reader that skipped
+ *	      the check would regress its view; we assert that never
+ *	      happens).  A version from the FUTURE would be real corruption
+ *	      / a model bug -- asserted to be zero.
+ *	  (2) EXERCISED: at least one stale read fires across the sweep (the
+ *	      ring + hooks actually work), and each seed replays identically.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_stale && ./test_sim_stale [seed]
+ */
+
+#include "db_config.h"
+
+#include "db_int.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+#define NSLOTS  6            /* distinct page offsets */
+#define PGSZ    512
+#define NWRITE  8            /* versions written per slot */
+#define VOFF    0            /* the version lives in the first 8 bytes */
+#define STALEDB "TESTDIR_sim_stale/stale.dat"
+
+/*
+ * Run the workload once with `seed`.  For each slot, write NWRITE
+ * increasing versions; after each durable (fsync'd) write, read the page
+ * back and check the version against the highest durably written.  Stale
+ * injection can make the read return a prior version; the version check
+ * detects it.  Returns 0 on success; fills the counters.
+ */
+static int
+run_once(seed, out_stale, out_regress, out_reads)
+	uint64_t seed;
+	int *out_stale, *out_regress, *out_reads;
+{
+	ENV *env;
+	DB_ENV *dbenv;
+	DB_FH *fhp;
+	uint8_t page[PGSZ];
+	int slot, v, ret, stale = 0, regress = 0, reads = 0;
+	size_t nio;
+
+	*out_stale = *out_regress = *out_reads = 0;
+
+	if ((ret = db_env_create(&dbenv, 0)) != 0)
+		return (ret);
+	env = dbenv->env;
+
+	__db_sim_activate(seed);
+	/* Seeded latency + stale reads at 40% so a prior version is
+	 * frequently returned; no ENOSPC/torn (those are other scenarios). */
+	__db_sim_io_faults_enable(0, 20000, 0);
+	__db_sim_io_stale_enable(400);
+
+	if ((ret = __os_open(env, STALEDB, 0,
+	    DB_OSO_CREATE, 0664, &fhp)) != 0) {
+		fprintf(stderr, "os_open failed: %s\n", db_strerror(ret));
+		goto done;
+	}
+
+	for (slot = 0; slot < NSLOTS; slot++) {
+		off_t off = (off_t)slot * PGSZ;
+		uint64_t highest = 0;
+
+		for (v = 1; v <= NWRITE; v++) {
+			uint64_t ver = (uint64_t)v, got = 0;
+
+			memset(page, (int)(slot & 0xff), PGSZ);
+			memcpy(page + VOFF, &ver, sizeof(ver));
+			if ((ret = __os_io(env, DB_IO_WRITE, fhp, 0, 0,
+			    (u_int32_t)off, PGSZ, page, &nio)) != 0 ||
+			    nio != PGSZ)
+				continue;   /* skip this version on write fault */
+			/* Make it durable so `highest` is a true durable HWM. */
+			(void)__os_fsync(env, fhp);
+			if (ver > highest)
+				highest = ver;
+
+			/* Read it back through the real seam; stale injection
+			 * may return a prior version. */
+			memset(page, 0, sizeof(page));
+			if ((ret = __os_io(env, DB_IO_READ, fhp, 0, 0,
+			    (u_int32_t)off, PGSZ, page, &nio)) != 0 ||
+			    nio != PGSZ)
+				continue;
+			reads++;
+			memcpy(&got, page + VOFF, sizeof(got));
+			if (got < highest) {
+				/* Stale read: the disk handed back a version
+				 * OLDER than what we durably wrote.  The
+				 * version check CATCHES it -- we detect and do
+				 * NOT adopt it as current.  A reader that
+				 * skipped this check would silently regress. */
+				stale++;
+			} else if (got > highest) {
+				/* A version from the FUTURE: real corruption
+				 * or a model bug (must be 0). */
+				regress++;
+			}
+		}
+	}
+	(void)__os_closehandle(env, fhp);
+
+done:
+	__db_sim_io_stale_enable(0);
+	__db_sim_io_faults_disable();
+	__db_sim_deactivate();
+	(void)dbenv->close(dbenv, 0);
+	*out_stale = stale;
+	*out_regress = regress;
+	*out_reads = reads;
+	return (ret);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t base = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x57A1Eull;
+	int n = 40, i, fails = 0;
+	long total_stale = 0;
+	char cmd[256];
+
+	(void)snprintf(cmd, sizeof(cmd),
+	    "rm -rf TESTDIR_sim_stale && mkdir -p TESTDIR_sim_stale");
+	(void)system(cmd);
+
+	printf("== stale-read DST (version check catches out-of-date reads): "
+	    "%d seeds ==\n", n);
+
+	for (i = 0; i < n; i++) {
+		uint64_t seed = base + (uint64_t)i * 0x9E3779B97F4A7C15ull;
+		int s1 = 0, r1 = 0, rd1 = 0, s2 = 0, r2 = 0, rd2 = 0;
+		int rc1, rc2, pass = 1;
+
+		(void)system("rm -f TESTDIR_sim_stale/stale.dat");
+		rc1 = run_once(seed, &s1, &r1, &rd1);
+		if (rc1 != 0 || r1 != 0)
+			pass = 0;   /* setup error, or a stale page adopted */
+
+		if (pass) {
+			(void)system("rm -f TESTDIR_sim_stale/stale.dat");
+			rc2 = run_once(seed, &s2, &r2, &rd2);
+			/* Replay: same seed => identical stale/regress/reads
+			 * counts (the fault schedule is seeded). */
+			if (rc2 != rc1 || s2 != s1 || r2 != r1 || rd2 != rd1)
+				pass = 0;
+		}
+		total_stale += s1;
+		if (!pass) {
+			fprintf(stderr, "  seed 0x%016llx: FAIL "
+			    "(stale=%d regress=%d reads=%d rc=%d; "
+			    "replay stale=%d regress=%d reads=%d)\n",
+			    (unsigned long long)seed, s1, r1, rd1, rc1,
+			    s2, r2, rd2);
+			fails++;
+		}
+	}
+
+	if (fails == 0 && total_stale == 0) {
+		fprintf(stderr, "test_sim_stale: FAIL -- not a single stale "
+		    "read fired across the sweep; the ring/hooks are not "
+		    "wired (stale=%lu)\n",
+		    __db_sim_fault_count(DB_SIM_FC_STALE));
+		return (EXIT_FAILURE);
+	}
+	if (fails == 0) {
+		printf("test_sim_stale: PASS -- %d seeds, the version check "
+		    "caught every out-of-date read (%ld stale reads seen, "
+		    "zero adopted as current, zero future versions), replayed "
+		    "identically from seed\n", n, total_stale);
+		return (EXIT_SUCCESS);
+	}
+	fprintf(stderr, "test_sim_stale: FAIL -- %d/%d seeds failed\n",
+	    fails, n);
+	return (EXIT_FAILURE);
+}

--- a/test/sim/test_sim_swarm.c
+++ b/test/sim/test_sim_swarm.c
@@ -1,0 +1,324 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_swarm.c --
+ *	FoundationDB-style SWARM / SOAK: a large, shardable seed sweep over
+ *	a mixed fault workload, collecting aggregate pass/fail AND per-fault
+ *	ACTIVATION coverage (how many seeds actually triggered each fault
+ *	class -- a class never activated is a coverage gap).
+ *
+ *	Modeled on xtc's test_sim_swarm.  libdb is multi-process with real
+ *	fsync durability, so a single deterministic cross-process schedule
+ *	is a v2 item (see DESIGN.md sec.0); this swarm therefore sweeps the
+ *	axis that DOES map onto BDB's architecture -- seeded FAULT injection
+ *	over the real __os_io seam -- exactly the FoundationDB "simulated
+ *	disk" discipline.
+ *
+ *	Per seed, a mix of fault classes is armed from the seed bits (so the
+ *	seed fully determines the scenario AND replays): torn writes,
+ *	corrupt reads, stale reads, ENOSPC, per-I/O latency.  A versioned,
+ *	checksummed page workload writes then re-reads N pages through the
+ *	real __os_open / __os_io / __os_fsync seam and asserts, under
+ *	whatever faults fired, the safety invariants:
+ *
+ *	  - a torn/corrupt page is NEVER accepted as valid (its self-check
+ *	    fails => detected, never silent-bad);
+ *	  - a STALE read (an older version handed back) is caught by the
+ *	    per-page version stamp -- never adopted as current;
+ *	  - the run reaches quiescence (no hang) and REPLAYS byte-identically
+ *	    from the seed (two runs => identical result + activation counts).
+ *
+ *	It reports, across the sweep: seeds x invariant-violations, distinct
+ *	fault mixes explored, and per-fault activation counts + percentages.
+ *
+ *	Invocation:
+ *	  test_sim_swarm              bounded default (256 seeds) for CI.
+ *	  test_sim_swarm <count>      sweep <count> seeds from base 1.
+ *	  test_sim_swarm <count> <base>  shard the seed space.
+ *	  test_sim_swarm 5000 0       a soak run.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_swarm && ./test_sim_swarm [count] [base]
+ */
+
+#include "db_config.h"
+
+#include "db_int.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+#define NPAGE   8             /* distinct page offsets */
+#define PGSZ    256
+#define CKOFF   (PGSZ - 8)    /* checksum in the last 8 bytes */
+#define VOFF    0             /* version in the first 8 bytes */
+#define NWRITE  6             /* versions written per page */
+#define SWARMDB "TESTDIR_sim_swarm/swarm.dat"
+
+/* FNV-1a over [buf, buf+n): the page's self-checksum. */
+static uint64_t
+pg_cksum(p, n)
+	const unsigned char *p;
+	size_t n;
+{
+	uint64_t h = 1469598103934665603ull;
+	size_t i;
+	for (i = 0; i < n; i++) { h ^= p[i]; h *= 1099511628211ull; }
+	return (h);
+}
+
+/* Per-seed scenario: which fault classes are armed (from the seed bits),
+ * with seed-varied MAGNITUDES so the sweep spans mild to brutal. */
+struct scenario {
+	int torn, corrupt, stale, enospc, latency, shorteio;
+	int torn_pct, corrupt_pct, stale_pct, enospc_pct, shorteio_pct;
+	int64_t lat_hi;
+};
+
+static void
+derive(seed, sc)
+	uint64_t seed;
+	struct scenario *sc;
+{
+	sc->torn     = (seed & 0x1) != 0;
+	sc->corrupt  = (seed & 0x2) != 0;
+	sc->stale    = (seed & 0x4) != 0;
+	sc->enospc   = (seed & 0x8) != 0;
+	sc->latency  = (seed & 0x10) != 0;
+	sc->shorteio = (seed & 0x20) != 0;
+	sc->torn_pct    = 50 + (int)((seed >> 6) & 0x7) * 40;   /* 50..330 */
+	sc->corrupt_pct = 50 + (int)((seed >> 9) & 0x7) * 40;
+	sc->stale_pct   = 100 + (int)((seed >> 12) & 0x7) * 50; /* 100..450 */
+	sc->enospc_pct  = 50 + (int)((seed >> 15) & 0x7) * 30;  /* 50..260 */
+	sc->shorteio_pct= 30 + (int)((seed >> 18) & 0x7) * 20;  /* 30..170 */
+	sc->lat_hi      = (10 + (int64_t)((seed >> 21) & 0x7) * 10) * 1000LL;
+}
+
+/*
+ * Run the mixed workload once with `seed` under `sc`.  Returns 0 (always
+ * reaches quiescence).  Sets *silent_bad to the count of pages accepted
+ * that were corrupt/stale (MUST be 0), and folds a result hash for the
+ * replay check.
+ */
+static int
+run_once(seed, sc, silent_bad, out_hash)
+	uint64_t seed;
+	const struct scenario *sc;
+	int *silent_bad;
+	uint64_t *out_hash;
+{
+	DB_ENV *dbenv;
+	ENV *env;
+	DB_FH *fhp;
+	unsigned char page[PGSZ];
+	uint64_t h = 1469598103934665603ull;
+	int p, v, ret, bad = 0;
+	size_t nio;
+
+	*silent_bad = 0;
+	*out_hash = 0;
+
+	if ((ret = db_env_create(&dbenv, 0)) != 0)
+		return (-1);
+	env = dbenv->env;
+
+	__db_sim_activate(seed);
+	if (sc->latency || sc->shorteio)
+		__db_sim_io_faults_enable(0, sc->lat_hi,
+		    (unsigned)(sc->shorteio ? sc->shorteio_pct : 0));
+	if (sc->torn || sc->corrupt)
+		__db_sim_io_corrupt_enable((unsigned)(sc->torn ?
+		    sc->torn_pct : sc->corrupt_pct));
+	if (sc->stale)
+		__db_sim_io_stale_enable((unsigned)sc->stale_pct);
+	if (sc->enospc)
+		__db_sim_io_enospc_enable((unsigned)sc->enospc_pct);
+
+	if (__os_open(env, SWARMDB, 0, DB_OSO_CREATE, 0664, &fhp) != 0) {
+		(void)dbenv->close(dbenv, 0);
+		__db_sim_deactivate();
+		return (-1);
+	}
+
+	for (p = 0; p < NPAGE; p++) {
+		off_t off = (off_t)p * PGSZ;
+		uint64_t highest = 0;
+
+		for (v = 1; v <= NWRITE; v++) {
+			uint64_t ver = (uint64_t)v, got = 0, ck;
+
+			/* Build a versioned, self-checksummed page. */
+			memset(page, (int)((p * 7 + v) & 0xff), CKOFF);
+			memcpy(page + VOFF, &ver, sizeof(ver));
+			ck = pg_cksum(page, CKOFF);
+			memcpy(page + CKOFF, &ck, sizeof(ck));
+
+			ret = __os_io(env, DB_IO_WRITE, fhp, 0, 0,
+			    (u_int32_t)off, PGSZ, page, &nio);
+			if (ret != 0 || nio != PGSZ)
+				continue;   /* ENOSPC / short: skip this ver */
+			(void)__os_fsync(env, fhp);
+			if (ver > highest)
+				highest = ver;
+
+			/* Read back through the real seam (torn tail / corrupt
+			 * bit / stale version may be injected). */
+			memset(page, 0, sizeof(page));
+			ret = __os_io(env, DB_IO_READ, fhp, 0, 0,
+			    (u_int32_t)off, PGSZ, page, &nio);
+			if (ret != 0 || nio != PGSZ)
+				continue;
+
+			memcpy(&got, page + VOFF, sizeof(got));
+			memcpy(&ck, page + CKOFF, sizeof(ck));
+			h = h * 1000003ull + got;
+
+			if (ck != pg_cksum(page, CKOFF)) {
+				/* Torn/corrupt page: checksum FAILED => the
+				 * page is detected bad, not accepted.  Correct
+				 * behaviour -- a reader that trusted it anyway
+				 * would be silent-bad. */
+				continue;
+			}
+			/* Checksum-valid: the version MUST NOT be older than
+			 * the highest durably written (a stale read).  If it
+			 * is, the version check CATCHES it; adopting it would
+			 * be silent-bad. */
+			if (got < highest) {
+				/* stale, correctly detectable via version */
+				continue;
+			}
+			if (got > highest) {
+				/* A version from the future: impossible unless
+				 * a checksum-valid page carries wrong data =
+				 * silent bad (must never happen). */
+				bad++;
+			}
+		}
+	}
+
+	(void)__os_closehandle(env, fhp);
+	__db_sim_io_stale_enable(0);
+	__db_sim_io_enospc_enable(0);
+	__db_sim_io_corrupt_disable();
+	__db_sim_io_faults_disable();
+	*silent_bad = bad;
+	*out_hash = h;
+	__db_sim_deactivate();
+	(void)dbenv->close(dbenv, 0);
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	long n_seeds = argc > 1 ? strtol(argv[1], NULL, 10) : 256;
+	long base    = argc > 2 ? strtol(argv[2], NULL, 10) : 1;
+	long s, failures = 0;
+	long n_torn = 0, n_corrupt = 0, n_stale = 0, n_enospc = 0, n_lat = 0;
+	/* Per-fault ACTIVATION: seeds on which the class actually fired. */
+	unsigned long act[DB_SIM_FC_NCLASSES];
+	int cls;
+	uint64_t seen[256];
+	int n_seen = 0;
+	char cmd[256];
+
+	if (n_seeds < 1)
+		n_seeds = 1;
+	memset(act, 0, sizeof(act));
+
+	(void)snprintf(cmd, sizeof(cmd),
+	    "rm -rf TESTDIR_sim_swarm && mkdir -p TESTDIR_sim_swarm");
+	(void)system(cmd);
+
+	printf("== DST swarm: %ld seeds (base %ld) x mixed-fault workload "
+	    "==\n", n_seeds, base);
+
+	for (s = 0; s < n_seeds; s++) {
+		uint64_t seed = 0x9E3779B97F4A7C15ull * (uint64_t)(base + s);
+		struct scenario sc;
+		int bad1 = 0, bad2 = 0, rc1, rc2, i;
+		uint64_t h1 = 0, h2 = 0;
+		unsigned long fired[DB_SIM_FC_NCLASSES];
+
+		derive(seed, &sc);
+		n_torn    += sc.torn;
+		n_corrupt += sc.corrupt;
+		n_stale   += sc.stale;
+		n_enospc  += sc.enospc;
+		n_lat     += sc.latency;
+
+		(void)system("rm -f TESTDIR_sim_swarm/swarm.dat");
+		rc1 = run_once(seed, &sc, &bad1, &h1);
+		/* Snapshot which classes fired THIS seed (counters reset each
+		 * activate, so read them right after the run). */
+		for (cls = 0; cls < DB_SIM_FC_NCLASSES; cls++) {
+			fired[cls] = __db_sim_fault_count(cls);
+			if (fired[cls] > 0)
+				act[cls]++;
+		}
+
+		(void)system("rm -f TESTDIR_sim_swarm/swarm.dat");
+		rc2 = run_once(seed, &sc, &bad2, &h2);
+
+		if (rc1 != 0 || rc2 != 0) {
+			printf("FAIL seed=0x%llx: setup error rc1=%d rc2=%d\n",
+			    (unsigned long long)seed, rc1, rc2);
+			failures++;
+			continue;
+		}
+		if (bad1 != 0 || bad2 != 0) {
+			printf("FAIL seed=0x%llx: %d/%d SILENT-BAD pages "
+			    "accepted (a corrupt/stale page passed as valid)\n",
+			    (unsigned long long)seed, bad1, bad2);
+			failures++;
+			continue;
+		}
+		if (h1 != h2) {
+			printf("FAIL seed=0x%llx: replay mismatch "
+			    "(%016llx != %016llx)\n", (unsigned long long)seed,
+			    (unsigned long long)h1, (unsigned long long)h2);
+			failures++;
+			continue;
+		}
+		for (i = 0; i < n_seen; i++)
+			if (seen[i] == h1)
+				break;
+		if (i == n_seen && n_seen < (int)(sizeof(seen)/sizeof(seen[0])))
+			seen[n_seen++] = h1;
+	}
+
+	printf("swarm swept %ld seeds: %ld invariant violation(s), %d "
+	    "distinct results; armed mix: torn=%ld corrupt=%ld stale=%ld "
+	    "enospc=%ld latency=%ld\n", n_seeds, failures, n_seen,
+	    n_torn, n_corrupt, n_stale, n_enospc, n_lat);
+
+	printf("fault ACTIVATION (seeds on which the class actually fired):\n");
+	for (cls = 0; cls < DB_SIM_FC_NCLASSES; cls++)
+		printf("  %-9s %5lu / %ld seeds (%.1f%%)\n",
+		    __db_sim_fault_class_name(cls), act[cls], n_seeds,
+		    100.0 * (double)act[cls] / (double)n_seeds);
+
+	if (failures > 0) {
+		printf("FAIL: %ld seed(s) violated a safety invariant "
+		    "(re-run ./test_sim_swarm 1 <seed-index> to reproduce)\n",
+		    failures);
+		return (EXIT_FAILURE);
+	}
+	if (n_seeds >= 20 && n_seen < 2) {
+		printf("FAIL: the swarm explored only one result -- the "
+		    "workload is not seed-sensitive\n");
+		return (EXIT_FAILURE);
+	}
+	printf("OK: %ld-seed swarm -- 0 invariant violations (no corrupt/"
+	    "stale page ever accepted as valid), every seed replayed "
+	    "identically, %d distinct results explored\n", n_seeds, n_seen);
+	return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Deepens DST toward FoundationDB-grade swarm testing. Rebased onto current master.

## 1. Stale-read scenario (DESIGN v1.x)
Wired `__db_sim_io_presnapshot_hook` into the `__os_io` write path (no-op unless armed): snapshots on-disk bytes before overwrite. `test_sim_stale` proves a monotonic-version check catches every stale read — **40 seeds, 654 stale reads caught, 0 adopted, deterministic**.

## 2. Scenario catalog: 14 → 24 + swarm
New: `stale, ckp_enospc, split_torn, recover_corrupt, secondary_crash, largetxn_crash` (2000-op txn), `cursor_crash, multi_fault` (latency+ENOSPC), `latency_load, ckp_lsn`, + `swarm`. **24 × 15 seeds = 318 pass, 0 fail**, deterministic replay.

## 3. Swarm runner + per-fault activation coverage
`test_sim_swarm` (shardable, mixed-fault, real OS seam) + `dst-swarm.sh`. **2000-seed soak: 0 invariant violations**; activation: torn 73.8% / corrupt 72.9% / stale 49.6% / enospc 49.5% / latency 75.2% / short-EIO 47.1% — every fault class fires, no dead knob.

## 4. Planted-bug yardstick: 5 bugs, all caught at K=1
Added **ABORTNOUNDO** (`__txn_abort` skips undo) and **CKPBADLSN** (`__txn_checkpoint` wrong ckp_lsn) at real sites; `dst-bug-inject.sh` sweeps all 5 → each caught at seed 1.

## 5. Zero overhead when off
Fresh `--enable-debug` (no `--enable-dst`): **0 `__db_sim_*` symbols**; nested `#if HAVE_DST / #if DB_DST_BUG` guards keep planted-bug sites out of every normal build.

## Honest remaining gaps
v2 deterministic multi-process scheduler; determinism-guard planting (needs a v2 virtual clock); `os_aio`/`__os_physwrite` + the WAL-record `__os_read` slow path (common `__os_io` log read is hooked).

## Testing
24/24 scenarios + swarm pass; 2000-seed soak clean; 5 planted bugs caught @ K=1; OFF build zero-overhead; Bug-4 fix (#52) preserved through rebase.