### PR TITLE
fix(env): free DB_PRIVATE regions on the corrupt-open error path

### DIFF
--- a/src/btree/bt_verify.c
+++ b/src/btree/bt_verify.c
@@ -817,8 +817,8 @@ __bam_vrfy_inp(dbp, vdp, h, pgno, nentriesp, flags)
 				    "Page %lu: gap between items at offset %lu",
 				    "%lu %lu"), (u_long)pgno, (u_long)i));
 				/* Find the end of the gap */
-				for (; pagelayout[i + 1] == VRFY_ITEM_NOTSET &&
-				    (size_t)(i + 1) < dbp->pgsize; i++)
+				for (; (size_t)(i + 1) < dbp->pgsize &&
+				    pagelayout[i + 1] == VRFY_ITEM_NOTSET; i++)
 					;
 				break;
 			case VRFY_ITEM_BEGIN:

--- a/src/env/env_open.c
+++ b/src/env/env_open.c
@@ -550,10 +550,36 @@ __env_close_pp(dbenv, flags)
 		if (IS_ENV_REPLICATED(env))
 			(void)__repmgr_close(env);
 
-		/* Close all underlying file handles. */
-		(void)__file_handle_cleanup(env);
-
-		PANIC_CHECK(env);
+		/*
+		 * For a shared (multi-process) environment we stop here: the
+		 * panicked region may be corrupt and belongs to other processes,
+		 * so we must not tear it down.  But a DB_PRIVATE environment is
+		 * just this process's heap -- there is no other process to hand
+		 * it to, and returning here leaks every malloc'd region (mpool,
+		 * log, ...) and all their buffers.  So for a private env we fall
+		 * through to __env_close/__env_refresh to free the heap, exactly
+		 * as __env_open's own post-panic error path does.
+		 *
+		 * For the shared case, force-close any leaked file handles now and
+		 * bail via PANIC_CHECK.  For the private case we must NOT do that
+		 * force-close here: the orderly teardown below closes files
+		 * through the mpoolfile path (__memp_fclose), which still
+		 * dereferences env->fdlist handles -- freeing them first would be
+		 * a use-after-free.
+		 *
+		 * To reach the teardown we suppress the panic for the duration of
+		 * the close: both this explicit check and the PANIC_CHECK inside
+		 * ENV_ENTER below would otherwise bail out.  We also suppress the
+		 * cache flush (__env_refresh's __memp_sync_int) -- the pages may
+		 * be corrupt and there is nothing durable to preserve for a
+		 * private, panicked env; we only want to reclaim memory.
+		 */
+		if (!F_ISSET(env, ENV_PRIVATE)) {
+			/* Close all underlying file handles. */
+			(void)__file_handle_cleanup(env);
+			PANIC_CHECK(env);
+		}
+		F_SET(dbenv, DB_ENV_NOPANIC | DB_ENV_NOFLUSH);
 	}
 
 	ENV_ENTER(env, ip);
@@ -578,6 +604,12 @@ __env_close_pp(dbenv, flags)
 		close_flags |= DBENV_CLOSE_REPCHECK;
 	if ((t_ret = __env_close(dbenv, close_flags)) != 0 && ret == 0)
 		ret = t_ret;
+
+	/*
+	 * Note: we do NOT restore the NOPANIC/NOFLUSH bits we may have set
+	 * above -- __env_close is the DB_ENV handle destructor and has freed
+	 * dbenv by now, so touching its flags here is a use-after-free.
+	 */
 
 	/* Don't ENV_LEAVE as we have already detached from the region. */
 	return (ret);

--- a/src/env/env_region.c
+++ b/src/env/env_region.c
@@ -454,6 +454,7 @@ creation:
 	 * we're manipulating the list.
 	 */
 	renv->region_cnt = nregions;
+	renv->region_off = INVALID_ROFF;
 	if ((ret = __env_alloc(infop, nregions * sizeof(REGION), &rp)) != 0) {
 		__db_err(env, ret, DB_STR("1543",
 		    "unable to create new master region array"));
@@ -547,11 +548,22 @@ retry:	/* Close any open file handle. */
 		if (infop->rp == NULL)
 			infop->rp = &tregion;
 
+		/*
+		 * For a private (heap-backed) region, each __env_alloc call is
+		 * a separate malloc, so freeing infop->addr (the REGENV block)
+		 * in __env_sys_detach does NOT free the region array allocated
+		 * out of the region.  Free it here, the same way __env_detach
+		 * does, BEFORE __env_sys_detach frees the REGENV block that
+		 * renv->region_off is relative to.  (rp is unusable here: it
+		 * may have been reassigned or NULLed by __env_des_get above, so
+		 * recover the array via renv->region_off instead.)
+		 */
+		if (F_ISSET(env, ENV_PRIVATE) && F_ISSET(infop, REGION_CREATE) &&
+		    renv != NULL && renv->region_off != INVALID_ROFF)
+			__env_alloc_free(infop, R_ADDR(infop, renv->region_off));
+
 		(void)__env_sys_detach(env,
 		    infop, F_ISSET(infop, REGION_CREATE));
-
-		if (rp != NULL && F_ISSET(env, DB_PRIVATE))
-			__env_alloc_free(infop, rp);
 	}
 
 	/* Free the allocated name and/or REGINFO structure. */

--- a/src/log/log.c
+++ b/src/log/log.c
@@ -160,6 +160,21 @@ __log_open(env)
 err:	if (dblp->reginfo.addr != NULL) {
 		if (region_locked)
 			LOG_SYSTEM_UNLOCK(env);
+		/*
+		 * If we created and initialized the region, __log_init
+		 * allocated the log buffer as a separate heap block for a
+		 * private (heap-backed) environment.  __env_region_detach frees
+		 * the region primary (the LOG struct) but not that buffer, so a
+		 * failed open (e.g. corrupt-log recovery) would leak it -- the
+		 * normal-close path frees it in __log_env_refresh.  Free it here
+		 * to match, before we detach and lose the primary reference.
+		 */
+		if (F_ISSET(env, ENV_PRIVATE) &&
+		    F_ISSET(&dblp->reginfo, REGION_CREATE) &&
+		    (lp = dblp->reginfo.primary) != NULL &&
+		    lp->buffer_off != INVALID_ROFF)
+			__env_alloc_free(&dblp->reginfo,
+			    R_ADDR(&dblp->reginfo, lp->buffer_off));
 		(void)__env_region_detach(env, &dblp->reginfo, 0);
 	}
 	env->lg_handle = NULL;

--- a/test/fuzz/check-crashes.sh
+++ b/test/fuzz/check-crashes.sh
@@ -6,10 +6,10 @@
 # crashed the engine (OOB read, SIGFPE, ...) and must now return an error
 # instead.  A crash/ASan fault here is a regression.
 #
-# Leak detection is intentionally OFF: some seeds reach the verify /
-# recovery cleanup paths that carry a documented, pre-existing leak (see
-# crashes/README.md and .agents/fuzz-found-bugs.md).  We assert only the
-# memory-safety property (no crash/OOB/FPE), which is what the fixes deliver.
+# Leak detection is ON: the DB_PRIVATE region-teardown leak that used to
+# fire on these verify / recovery cleanup paths is now fixed (see
+# .agents/fuzz-found-bugs.md), so every committed seed replays leak-clean.
+# We assert both the memory-safety property (no crash/OOB/FPE) and no leak.
 #
 # Build target: the standard (--enable-debug) build that run.sh uses.  Do NOT
 # run this against an --enable-diagnostic build: there DB_ASSERT / __env_panic
@@ -50,7 +50,7 @@ for seed in crashes/*.seed; do
 		echo "SKIP (unknown harness): $seed"
 		continue
 	fi
-	if ASAN_OPTIONS=detect_leaks=0 "build/fuzz_${h}_standalone" \
+	if ASAN_OPTIONS=detect_leaks=1 "build/fuzz_${h}_standalone" \
 	    "$seed" >/dev/null 2>&1; then
 		echo "PASS: $seed ($h)"
 	else

--- a/test/fuzz/run.sh
+++ b/test/fuzz/run.sh
@@ -87,15 +87,12 @@ smoke() {
 		# writes newly found inputs into work_$h, keeping the tracked
 		# corpus/ dir pristine.
 		cp "$CORPUS/$h/"* "$OUT/work_$h/" 2>/dev/null || true
-		# The recover harness trips a KNOWN engine leak on the
-		# corrupt-log recovery-cleanup path (reported, not a harness
-		# bug) -- run it with leak detection off so ASan still catches
-		# crashes/OOB without halting on that documented leak.  See
-		# crashes/README.md and test/fuzz/README.md.
-		leakopt=1
-		[ "$h" = recover ] && leakopt=0
+		# Leak detection is ON for all harnesses: the DB_PRIVATE
+		# region-teardown leak on the corrupt verify / recovery-cleanup
+		# path (which used to force the recover harness to run with
+		# leaks off) is now fixed -- see .agents/fuzz-found-bugs.md.
 		# -artifact_prefix so any crashing input lands in a known dir.
-		if ASAN_OPTIONS="detect_leaks=$leakopt" \
+		if ASAN_OPTIONS="detect_leaks=1" \
 			"$OUT/fuzz_$h" "$OUT/work_$h" \
 			-max_total_time="$secs" -max_len=65536 -rss_limit_mb=4096 \
 			-artifact_prefix="$OUT/artifacts_$h/" \


### PR DESCRIPTION
Fixes the one known issue from the v5.3.31 release: opening/verifying a **corrupt database file** that fails partway leaked the heap-backed `DB_PRIVATE` regions (mpool, log, ...) and their buffers. It was a **resource leak, not a memory-safety fault** — previously masked in the fuzzers by `detect_leaks=0`.

## Root cause + fix
- **`__env_close_pp` (env_open.c)**: on a **panicked** `DB_PRIVATE` env, close bailed early (correct for a shared/mmap'd region owned by other processes) — but a private env is just this process's heap, so bailing leaked every malloc'd region. Now falls through to orderly teardown (`__env_close`/`__env_refresh`) for the private case, suppressing panic + cache-flush (nothing durable to preserve on a corrupt private env). Careful: does NOT force-close file handles first (the orderly teardown closes them via `__memp_fclose`; freeing them early would be a UAF), and does NOT touch `dbenv` flags after `__env_close` frees it.
- **`__env_region.c`**: free the private region-array (via `renv->region_off`) before `__env_sys_detach` frees the REGENV block it's relative to.
- **`__log.c`**: `__log_open` error-path region cleanup.
- **`bt_verify.c`**: bounds-order fix — check `i+1 < pgsize` *before* indexing `pagelayout[i+1]` (an OOB-order issue surfaced alongside).
- **fuzz scripts** (`run.sh`, `check-crashes.sh`): re-enable leak detection now that this leak is fixed.

## Verification
- ASan + debug builds clean.
- Smoke fuzz (leak detection ON): **0 leaks** over 1729 units — was **264669 bytes leaked in 221 allocations** before.
- All 4 crash reproducers pass; **no new UAF/double-free** (the teardown-fix risk).
- Regression: `test001 btree/hash`, `test003 btree` via `run_method` pass.

(Fix started by one agent, verified + finished by another after the first hit its turn cap mid-commit; independently re-verified before this PR.)