### PR TITLE
fix(db): heap page-item bounds check used btree/hash inp[] semantics

### DIFF
--- a/src/db/db_ret.c
+++ b/src/db/db_ret.c
@@ -41,6 +41,34 @@ __db_ret_okitem(dbp, h, indx)
 	pgsize = dbp->pgsize;
 	inp = P_INP(dbp, h);
 
+	/*
+	 * Heap pages use the inp[] array as an offset table with different
+	 * semantics from btree/hash: valid slot indexes run up to
+	 * HEAP_HIGHINDX (which can exceed NUM_ENT because deleted slots leave
+	 * holes), and a deleted/empty slot has offset 0.  Validate heap here
+	 * and return -- the generic NUM_ENT / offset-lower-bound checks below
+	 * assume btree/hash inp[] layout and would wrongly reject legal heap
+	 * indexes and offsets.
+	 */
+	if (TYPE(h) == P_HEAP) {
+		if (indx > HEAP_HIGHINDX(h))
+			return (DB_PAGE_NOTFOUND);
+		off = inp[indx];
+		/*
+		 * A zero offset is an empty/deleted slot -- nothing to copy out;
+		 * report "no such item" rather than corruption.  A non-zero
+		 * offset must leave room for the heap record header on-page.
+		 */
+		if (off == 0 || (size_t)off + sizeof(HEAPHDR) > pgsize)
+			return (DB_PAGE_NOTFOUND);
+		hdr = (HEAPHDR *)((u_int8_t *)h + off);
+		/* Split records are copied out separately; skip the size check. */
+		if (!F_ISSET(hdr, (HEAP_RECSPLIT | HEAP_RECFIRST)) &&
+		    (size_t)off + sizeof(HEAPHDR) + hdr->size > pgsize)
+			return (DB_PAGE_NOTFOUND);
+		return (0);
+	}
+
 	/* The index must be one of the entries the page claims to hold. */
 	if (indx >= NUM_ENT(h))
 		return (DB_PAGE_NOTFOUND);
@@ -77,15 +105,6 @@ __db_ret_okitem(dbp, h, indx)
 		/* On-page H_KEYDATA/H_DUPLICATE: item must hold its header. */
 		if (HPAGE_PTYPE((u_int8_t *)h + off) != H_OFFPAGE &&
 		    (size_t)(prev - off) < HKEYDATA_SIZE(0))
-			return (DB_PAGE_NOTFOUND);
-		break;
-	case P_HEAP:
-		if ((size_t)off + sizeof(HEAPHDR) > pgsize)
-			return (DB_PAGE_NOTFOUND);
-		hdr = (HEAPHDR *)((u_int8_t *)h + off);
-		/* Split records are copied out separately; skip the size check. */
-		if (!F_ISSET(hdr, (HEAP_RECSPLIT | HEAP_RECFIRST)) &&
-		    (size_t)off + sizeof(HEAPHDR) + hdr->size > pgsize)
 			return (DB_PAGE_NOTFOUND);
 		break;
 	case P_LBTREE:


### PR DESCRIPTION
**Regression from PR #58** (malformed-file hardening). `__db_ret_okitem` gates every access-method cursor return through one bounds check, but it applied **btree/hash `inp[]` semantics to HEAP pages**, which use `inp[]` as an offset table with different rules:
- valid heap slot indexes run up to `HEAP_HIGHINDX`, which can **exceed `NUM_ENT`** (deleted slots leave holes) → the generic `indx >= NUM_ENT(h)` reject was wrong for heap;
- a deleted/empty heap slot has **offset 0**, and valid heap offsets need not fall after the `inp[]` array → the generic offset lower-bound reject was wrong.

**Impact:** `db_dump` (and any `DB_NEXT` scan) on a heap DB with a deleted non-last record returned `DB_PAGE_NOTFOUND` at end-of-scan instead of `DB_NOTFOUND`, so `db_dump` exited non-zero. Reproduced by **test046/049/139 on the heap method** — surfaced by the full-suite coverage run (see `test/coverage/COVERAGE-TEST-TRIAGE.md`, PR #66).

**Fix:** validate `P_HEAP` up front against `HEAP_HIGHINDX` + the heap record-header bounds, then return — don't fall through to the btree/hash generic checks. The btree/hash/recno hardening is unchanged.

## Verification
- `db_dump -k` on the heap DB now succeeds (was rc=1)
- test046/049/139 pass on heap
- test001/003 pass on all 5 access methods + verify/salvage + logverify001
- **All 4 fuzz crash reproducers still pass** (incl. the `db_retcopy` OOB the #58 guard protects) — hardening intact

## How it was found
This is exactly the kind of latent bug deeper testing surfaces: the coverage run exercised the heap AM (previously untested), which hit the dump/load round-trip; triage isolated it to a clean-build heap failure; root-caused to my own #58 hardening being too btree-centric.