### PR TITLE
test(coverage): run replication suite — lift rep/repmgr 0.8% → ~56%

### DIFF
--- a/test/coverage/FULL-COVERAGE-REPORT.md
+++ b/test/coverage/FULL-COVERAGE-REPORT.md
@@ -51,6 +51,14 @@ Running the full standard suite roughly **+19 pts line / +17 pts branch**.
 - **Replication: `rep`, `repmgr` (rep_subset / auto_repmgr / other_repmgr /
   multi_repmgr).** Deliberately ordered last (documented multi-process hang
   risk) and not reached before the wall-clock ceiling. Coverage ≈ 0.8%.
+  **Update:** most of the replication suite does *not* actually need external
+  multi-process orchestration — the `rep0NN` in-process message harness and
+  the single-process `repmgrNN` socket tests run in one `tclsh` each. Running
+  37 of them lifts `rep/`+`repmgr/` from 0.8% to **~56.6% line / ~41.9%
+  branch** (~+9.7 pts of the whole-`src/` headline). See
+  `REPLICATION-COVERAGE.md` and `COV_REP=1 run_coverage.sh`. Still cold:
+  `rep_lease.c` (lease tests hang), the `rep*script.tcl` subprocess tests, and
+  the repmgr 100-series (need the `db_repsite` utility, absent from this fork).
 - **XA (`xa/xa.c`).** Not exercised by any group run. Coverage 0%.
 - **Redundant access methods** rbtree, frecno, rrecno, queueext were queued
   after the subsystem groups and not reached. Their coverage is near-identical

--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -33,6 +33,14 @@ Knobs (all optional env vars):
 | `COV_JOBS`   | `nproc`                                   | build parallelism                |
 | `TCL_LIB`    | autodetected (nix store or `/usr/lib/tcl8.6`) | Tcl lib dir for `--with-tcl` |
 | `COV_TIMEOUT`| `2400`                                    | seconds ceiling for the test run |
+| `COV_REP`    | `0`                                       | set `1` to also run the replication (rep/repmgr) tests |
+
+Set `COV_REP=1` to add the replication suite (biggest cold surface: rep/ +
+repmgr/ ~= 12.4k lines at 0.8%). It moves them to ~56% line / ~42% branch. Those
+tests each run in their own `tclsh` (driver-per-test, per-test timeout) because a
+few election/lease tests hang; see `REPLICATION-COVERAGE.md` for the exact set,
+the measured lift, and what still needs real multi-process orchestration
+(`rep*script.tcl` subprocess tests, repmgr 100-series needing `db_repsite`).
 
 Outputs land in `build_unix/` (gitignored):
 

--- a/test/coverage/REPLICATION-COVERAGE.md
+++ b/test/coverage/REPLICATION-COVERAGE.md
@@ -1,0 +1,101 @@
+# Replication coverage (rep/ + repmgr/)
+
+The full-suite report (`FULL-COVERAGE-REPORT.md`) left replication at **0.8%**
+because it "needs multi-process orchestration this run avoided." This note
+records what actually runs, how, and the measured lift.
+
+**Key finding:** most of the replication suite does *not* need external
+multi-process orchestration. The `rep0NN` tests use the in-process
+message-shuffling harness (`reputils.tcl`: `replsend` / `process_msgs` hand-carry
+replication messages between multiple in-process envs in a single `tclsh`), and
+the single-process `repmgrNN` tests spin up a master + 2 clients over real
+localhost TCP inside one `tclsh`. Both run with no forked test driver — just
+`source test.tcl; source reputils.tcl; <testproc> btree`.
+
+## Measured lift (CC=gcc, -O0 -g --coverage, src/-only, this box)
+
+| subsystem | before | after (line) | after (branch) | after (func) |
+|-----------|-------:|-------------:|---------------:|-------------:|
+| `src/rep/`    | 0.8% | **55.4%** (3935/7106)  | **41.0%** (3294/8039) | **71.5%** (148/207) |
+| `src/repmgr/` | 0.8% | **58.3%** (3111/5339)  | **43.6%** (1813/4156) | **77.4%** (219/283) |
+| **combined**  | 0.8% | **56.6%** (7046/12445) | **41.9%** (5107/12195) | **74.9%** (367/490) |
+
+That is **+55.8 pts line** on ~12,445 previously-cold instrumented lines — the
+single biggest coverage lever in the tree. Against the whole-`src/` denominator
+(72,363 lines) this alone is roughly **+9.7 pts** of headline line coverage
+(7,001 newly-covered lines / 72,363).
+
+## Tests that run cleanly (single `tclsh`, timeout-guarded)
+
+Run driver-per-test (own `tclsh`, own TESTDIR) via `COV_REP=1
+test/coverage/run_coverage.sh`, or directly:
+
+```sh
+tclsh8.6 -c 'source ../test/tcl/test.tcl; source ../test/tcl/reputils.tcl; rep001 btree'
+```
+
+**rep (in-process message harness) — 22 pass:**
+`rep001 rep002 rep003 rep005 rep006 rep007 rep008 rep009 rep010 rep011 rep012
+rep013 rep014 rep015 rep019 rep020 rep021 rep022 rep023 rep024 rep025 rep026`
+
+(includes the election tests `rep002 rep005 rep020 rep022 rep026`, which
+exercise `rep_elect.c` — now 71%.)
+
+**repmgr (single-process real localhost sockets) — 15 pass:**
+`repmgr009 repmgr010 repmgr011 repmgr012 repmgr013 repmgr017 repmgr018
+repmgr023 repmgr025 repmgr027 repmgr030 repmgr031 repmgr032 repmgr033
+repmgr034`
+
+These drive the real repmgr TCP transport (`repmgr_net.c` 63%, `repmgr_msg.c`
+58%, `repmgr_sel.c` 66%, `repmgr_elect.c` 72%) in one process — `basic_repmgr_test`
+starts an appointed master + two clients bound to localhost ports from
+`available_ports` (base 30100).
+
+## Still uncovered / needs real multi-process
+
+- **`rep_lease.c` (0%)** — replication leases. The lease tests (`rep034`,
+  `repmgr024`, `repmgr026`) **hang** under the in-process harness (lease-timeout
+  polling loops that never satisfy in shuffled-message time). Left out.
+- **`rep_stat.c` (19%)** — most of the miss is stat-print formatting; a
+  `rep_stat -clear` / print-oriented test would lift it.
+- **`rep016` hangs** — an election test that loops; excluded.
+- **`repmgr007` FAILS** on its final "repmgr ignores unexpected input" errchk
+  (`expected 1, got 0`) — but it runs to completion first, so its coverage is
+  captured; it is simply not counted as a pass. Likely a behavioral drift in
+  this fork, not a harness problem. Excluded from the clean set; re-triage on a
+  non-coverage build before touching engine code.
+- **`rep*script.tcl` subprocess tests** (`rep017 rep018 rep035 rep036 rep040
+  rep042 rep043 rep045 rep048 rep065 rep078 rep092 rep095 rep097 rep102`) — these
+  `exec` a second `tclsh` running a companion `*script.tcl`. They need real
+  process fork/exec orchestration (a driver that launches the script child and
+  shuttles the message queue on disk). Not run here.
+- **repmgr 100-series** (`repmgr100 repmgr101 repmgr105 repmgr106 repmgr107
+  repmgr108 …`) — genuine multi-process repmgr. They require the `db_repsite`
+  test utility (`$(testdir)/repmgr/db_repsite.cpp`), which **is not present in
+  this fork** (only the Windows `.vcxproj` stubs survive). To run them, restore
+  `db_repsite.cpp` and add it to the `make` target, then run under a per-test
+  timeout. Skipped as out-of-scope multi-process.
+
+## How to reproduce
+
+```sh
+cd build_unix
+CC=gcc ../dist/configure --enable-debug --enable-test \
+  --with-tcl=<tcl-lib> CFLAGS="-O0 -g --coverage" LDFLAGS="--coverage"
+make -j4
+# then, from build_unix, per-test (own tclsh, own TESTDIR):
+for t in rep001 rep002 ... repmgr009 ...; do
+  timeout 300 tclsh8.6 -c \
+    "source ../test/tcl/test.tcl; source ../test/tcl/reputils.tcl; $t btree" \
+    || echo "hang/fail: $t"
+done
+# capture — MUST use .libs (libtool double-compiles; only .libs/*.gcda carry
+# the merged replication counts):
+lcov --capture --directory .libs --output-file cov.info \
+  --gcov-tool gcov --branch-coverage --rc geninfo_unexecuted_blocks=1
+lcov --extract cov.info '*/src/rep/*' '*/src/repmgr/*' -o rep.info --branch-coverage
+lcov --summary rep.info --branch-coverage
+```
+
+Or simply: `COV_REP=1 test/coverage/run_coverage.sh` (adds the rep/repmgr sets
+to the default subset and captures from `.libs`).

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -158,9 +158,52 @@ if grep -q '^FAIL' /tmp/cov-tests.log; then
 fi
 echo "  .gcda files: $(find . -name '*.gcda' | wc -l)"
 
+# --- optional replication tests (COV_REP=1) ----------------------------------
+# Replication is the single biggest cold surface (rep/ + repmgr/ ~= 12.4k lines
+# at ~0.8%). These tests are NOT in the default COV_TESTS because each one wants
+# its own tclsh (they reset TESTDIR and a few election/lease tests hang), so
+# they are run driver-per-test with a per-test timeout instead of one big tclsh.
+# Set COV_REP=1 to include them. They use the in-process message-shuffling
+# harness (rep0NN) and single-process real-socket repmgr (repmgrNN) -- no
+# external orchestration. See test/coverage/REPLICATION-COVERAGE.md.
+#
+# NOT included (need real multi-process): the rep*script.tcl subprocess tests
+# and the repmgr 100-series (need the db_repsite utility, absent from this fork)
+# and a few election/lease tests that hang (rep016, repmgr024/026).
+if [ "${COV_REP:-0}" = 1 ]; then
+  echo "== run replication tests (COV_REP=1) =="
+  : "${COV_REP_TIMEOUT:=300}"
+  : "${COV_REP_TESTS:=rep001 rep002 rep003 rep005 rep006 rep007 rep008 rep009 \
+ rep010 rep011 rep012 rep013 rep014 rep015 rep019 rep020 rep021 rep022 rep023 \
+ rep024 rep025 rep026}"
+  : "${COV_REPMGR_TESTS:=repmgr009 repmgr010 repmgr011 repmgr012 repmgr013 \
+ repmgr017 repmgr018 repmgr023 repmgr025 repmgr027 repmgr030 repmgr031 \
+ repmgr032 repmgr033 repmgr034}"
+  reptcl="$bld/.cov-rep-one.tcl"
+  for t in $COV_REP_TESTS $COV_REPMGR_TESTS; do
+    case "$t" in
+    rep[0-9]*) call="$t btree" ;;   # rep0NN take a method arg
+    *)         call="$t" ;;          # repmgrNN use defaults
+    esac
+    printf 'source ../test/tcl/test.tcl\nsource ../test/tcl/reputils.tcl\nif {[catch {%s} r]} { puts "FAIL %s: $r"; exit 3 }\nputs "PASS %s"\n' \
+      "$call" "$t" "$t" > "$reptcl"
+    timeout "$COV_REP_TIMEOUT" "$TCLBIN" "$reptcl" >/tmp/cov-rep-$t.log 2>&1
+    rc=$?
+    if [ $rc -eq 124 ]; then echo "HANG $t"
+    elif [ $rc -eq 0 ] && grep -q "^PASS $t" /tmp/cov-rep-$t.log; then echo "PASS $t"
+    else echo "FAIL $t (rc=$rc)"; fi
+    pkill -f "$reptcl" 2>/dev/null || true
+    find TESTDIR -mindepth 1 -delete 2>/dev/null || true
+  done
+  rm -f "$reptcl"
+  echo "  .gcda files after rep: $(find . -name '*.gcda' | wc -l)"
+fi
+
 # --- aggregate ---------------------------------------------------------------
 echo "== capture (lcov) =="
-"$LCOV" --capture --directory . --output-file coverage.info \
+# NOTE: capture from .libs (not .) -- libtool double-compiles, and only the
+# .libs/*.gcda carry the merged replication counts; capturing "." drops repmgr.
+"$LCOV" --capture --directory .libs --output-file coverage.info \
   --gcov-tool "$GCOV" --rc geninfo_unexecuted_blocks=1 --branch-coverage \
   --ignore-errors "$IGN" >/tmp/cov-lcov.log 2>&1 \
   || { echo "lcov capture failed:"; tail -20 /tmp/cov-lcov.log; exit 1; }


### PR DESCRIPTION
## What

The full-suite coverage report left replication at **0.8%**, noting it "needs multi-process orchestration this run avoided." This PR shows that **most of the replication suite does not need external orchestration** and measures the lift.

- `rep0NN` tests use the in-process message-shuffling harness (`reputils.tcl`: `replsend`/`process_msgs` hand-carry messages between in-process envs in one `tclsh`).
- Single-process `repmgrNN` tests spin up a master + 2 clients over real localhost TCP inside one `tclsh`.

Both run with just `source test.tcl; source reputils.tcl; <testproc> btree` — no forked driver.

## Measured lift (CC=gcc, -O0 -g --coverage, src/-only)

| subsystem | before | after (line) | after (branch) | after (func) |
|-----------|-------:|-------------:|---------------:|-------------:|
| `src/rep/`    | 0.8% | **55.4%** (3935/7106)  | **41.0%** (3294/8039) | **71.5%** |
| `src/repmgr/` | 0.8% | **58.3%** (3111/5339)  | **43.6%** (1813/4156) | **77.4%** |
| **combined**  | 0.8% | **56.6%** (7046/12445) | **41.9%** (5107/12195) | **74.9%** |

~**+55.8 pts line** on 12,445 previously-cold lines → roughly **+9.7 pts** of the whole-`src/` headline. This is the single biggest coverage lever in the tree.

## Tests that run cleanly (all pass, timeout-guarded, own tclsh each)

- **rep (22):** rep001–015 (minus none), rep019–026 — includes election tests rep002/005/020/022/026 (rep_elect.c → 71%).
- **repmgr (15):** repmgr009–013, 017, 018, 023, 025, 027, 030–034 — real TCP transport (repmgr_net 63%, repmgr_msg 58%, repmgr_sel 66%, repmgr_elect 72%).

## Changes

- `run_coverage.sh`: opt-in `COV_REP=1` block (driver-per-test, per-test timeout, since a few election/lease tests hang) + **fix lcov capture to use `.libs`** — libtool double-compiles and only `.libs/*.gcda` carry the merged replication counts; capturing `.` silently dropped all of repmgr.
- `REPLICATION-COVERAGE.md`: full report — clean set, measured lift, reproduction steps, and what still needs real multi-process.
- README / FULL-COVERAGE-REPORT: cross-reference.

## Still uncovered / needs real multi-process (honest status)

- `rep_lease.c` (0%) — lease tests (rep034, repmgr024/026) **hang** under the in-process harness (lease-timeout polling loops); excluded.
- `rep016` hangs (election loop); `repmgr007` fails its final errchk but runs to completion (coverage still captured).
- `rep*script.tcl` subprocess tests (rep017/018/035/… — 15) need real fork/exec of a companion script.
- repmgr 100-series need the `db_repsite` utility, which is **absent from this fork** (only Windows .vcxproj stubs remain); restore `db_repsite.cpp` + make target to run them.

**No engine source changed** — measurement + harness only.