### PR TITLE
test(coverage): stat_print / DB_STAT_ALL coverage (statprint001 + wire env020 into the suite)

### DIFF
--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -64,6 +64,49 @@ timeout, so they cannot hang:
   per-version fixture tree (`test/tcl/upgrade/databases/`) is **not present in
   this fork**. See `DB-REPSITE-TODO.md` for the analogous repmgr gap.
 
+## The statistics (`*_stat_print`) surface
+
+The verbose `stat_print` / `DB_STAT_ALL` formatters (`env_stat.c`,
+`lock_stat.c`, `rep_stat.c`, `db_stati.c`, `log_stat.c`, `mut_stat.c`,
+`seq_stat.c`, `dbreg_stat.c`, `heap_stat.c` …) were ~0-29% covered: functional
+tests call `stat()` for values but almost never `stat_print(DB_STAT_ALL)`. Two
+Tcl tests now drive the whole surface (both in the default `COV_TESTS`):
+
+- **`env020`** (already registered, was just never in the coverage subset)
+  exercises every Tcl `*_stat_print` binding
+  (`env`/`lock`/`log`/`mpool`/`mutex`/`txn`/`rep`/`repmgr`/`db`/`seq`) with
+  each flag (default, `-clear`, `-all`, `-subsystem`, `-lk_*`, `-hash`, …).
+- **`statprint001`** (new) closes the two spots `env020` misses and adds the
+  `db_stat` **utility** entry path:
+  - `heap_stat.c` — `env020` opens no heap DB.
+  - `dbreg_stat.c`'s `__dbreg_print_all` — reached only with
+    `DB_STAT_ALL | DB_STAT_SUBSYSTEM` set *together* and databases open;
+    `env020` passes those flags separately.
+  - a `db_stat` flag sweep (`-e -E -c -C -l -L -m -M -x -X -r -R -t -Z -d -f`)
+    over a populated all-subsystems env, driving `util/db_stat.c ->
+    __*_stat_print` through the read-only on-disk path.
+
+  Measured lift (env020 + statprint001 vs. the full-suite baseline in
+  `full-run-2/cov-ranking.txt`):
+
+  | file | before | after |
+  |------|-------:|------:|
+  | `env/env_stat.c`     | 16.8% | **79.9%** |
+  | `lock/lock_stat.c`   | 17.4% | **73.6%** |
+  | `rep/rep_stat.c`     | 19.4% | **72.4%** |
+  | `db/db_stati.c`      | 22.0% | **61.8%** |
+  | `log/log_stat.c`     | 22.9% | **87.1%** |
+  | `mutex/mut_stat.c`   | 29.4% | **86.8%** |
+  | `sequence/seq_stat.c`| 0.0%  | **63.0%** |
+  | `dbreg/dbreg_stat.c` | 0.0%  | **69.6%** |
+  | `heap/heap_stat.c`   | 0.0%  | **80.3%** |
+  | `qam/qam_stat.c`     | 57.6% | **78.0%** |
+  | `txn/txn_stat.c`     | 56.8% | **69.0%** |
+
+  Still cold: `seq_stat.c`'s `__seq_print_all` (a no-op stub, and the Tcl seq
+  binding exposes only `-clear`, not `-all`); `repmgr_stat.c` needs a live
+  repmgr transport (`repmgr009`+, `COV_REP=1`) for its send-path counters.
+
 Outputs land in `build_unix/` (gitignored):
 
 - `coverage-summary.txt` — the line/branch/function totals

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -53,6 +53,15 @@ bld="$root/build_unix"
 # the whole suite, to keep the run bounded while lighting up the red files.
 # btree/test111 adds compaction coverage (src/btree/bt_compact.c); the
 # run_range_partition/run_partition_callback entries add src/db/partition.c.
+# env020 + statprint001 drive every *_stat_print / stat_print(DB_STAT_ALL)
+# path -- the verbose stat formatters that functional tests never reach.
+# env020 covers the Tcl bindings (lock/log/mpool/mutex/txn/rep/repmgr/db/seq),
+# statprint001 adds the two cold spots env020 misses (heap_stat.c, and
+# dbreg_stat.c's __dbreg_print_all which needs DB_STAT_ALL|DB_STAT_SUBSYSTEM
+# together with open DBs) plus a db_stat *utility* flag sweep (the read-only
+# on-disk __*_stat_print entry path). Together: env_stat 17->80, lock_stat
+# 17->74, rep_stat 19->72, log_stat 23->87, mut_stat 29->87, db_stati 22->62,
+# seq_stat 0->63, dbreg_stat 0->70, heap_stat 0->80.
 : "${COV_TESTS:=lock001: txn001: ssi001: ssi002: recd001:btree \
   btree/test001 btree/test111 \
   hash/test001 hash/test006 hash/test010 hash/test025 hash/test077 \
@@ -61,7 +70,8 @@ bld="$root/build_unix"
   heap/test001 heap/test013 heap/test024 \
   run_range_partition@test001@btree \
   run_partition_callback@test001@btree \
-  logverify001: logverify002:}"
+  logverify001: logverify002: \
+  env020: statprint001:}"
 : "${COV_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 : "${TCLSH:=tclsh}"
 # TCL lib dir: nix store on this box, /usr/lib/tcl8.6 on ubuntu CI.

--- a/test/tcl/statprint001.tcl
+++ b/test/tcl/statprint001.tcl
@@ -1,0 +1,174 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# TEST	statprint001
+# TEST	Exercise every stat_print (verbose / DB_STAT_ALL) code path.
+# TEST
+# TEST	env020 already covers the Tcl stat_print bindings, but two cold
+# TEST	spots remain and the db_stat *utility* entry point (util/db_stat.c ->
+# TEST	__*_stat_print) is never exercised by the Tcl suite at all:
+# TEST	  1. heap_stat.c (0%): env020 opens no heap database.
+# TEST	  2. dbreg_stat.c __dbreg_print_all (cold): reached only with
+# TEST	     DB_STAT_ALL | DB_STAT_SUBSYSTEM set together and databases open;
+# TEST	     env020 passes those flags separately, never combined.
+# TEST	  3. the db_stat utility drives the same __*_stat_print functions
+# TEST	     through a separate (read-only, on-disk) code path.
+# TEST
+# TEST	This test closes those gaps: a heap DB stat_print sweep, an
+# TEST	env stat_print -all -subsystem call with live open DBs (dbreg), and a
+# TEST	db_stat utility sweep over a populated all-subsystems env with every
+# TEST	meaningful flag combination.
+
+proc statprint001 { } {
+	puts "Statprint001: stat_print verbose / DB_STAT_ALL coverage sweep"
+	statprint001_heap
+	statprint001_dbreg
+	statprint001_dbstat_util
+}
+
+# heap_stat.c: env020 never opens a heap DB.  Drive stat_print with the
+# default, -fast (DB_FAST_STAT) and -all (DB_STAT_ALL) flags.
+proc statprint001_heap { } {
+	source ./include.tcl
+	# Substrings emitted by __heap_stat_print (src/heap/heap_stat.c).
+	set pattern "Heap magic number"
+
+	puts "\tStatprint001: DB->stat_print for heap"
+	env_cleanup $testdir
+	set env [eval berkdb_env_noerr -create -home $testdir]
+	error_check_good is_valid_env [is_valid_env $env] TRUE
+
+	foreach {opt tag} {"" default -fast fast -all all} {
+		puts "\t\tUsing the $tag option"
+		set db [eval berkdb_open_noerr -create -env $env -heap \
+		    -msgfile $testdir/msgfile_$tag heap_$tag.db]
+		error_check_good is_valid_db [is_valid_db $db] TRUE
+		# Put a few records so the region/page counts are non-trivial.
+		for {set i 1} {$i <= 20} {incr i} {
+			set ret [$db put -append [chop_data heap "data$i"]]
+			error_check_good "heap put $i" [expr {$ret > 0}] 1
+		}
+		error_check_good heap_stat_print [eval $db stat_print $opt] 0
+		error_check_good "$db close" [$db close] 0
+		# Confirm __heap_stat_print emitted its output.
+		set found 0
+		set f [open $testdir/msgfile_$tag r]
+		while {[gets $f line] >= 0} {
+			if {[string first $pattern $line] >= 0} { set found 1; break }
+		}
+		close $f
+		error_check_good heap_stat_output_$tag $found 1
+		file delete -force $testdir/msgfile_$tag
+	}
+	error_check_good "$env close" [$env close] 0
+}
+
+# dbreg_stat.c __dbreg_print_all: reached only via env stat_print with
+# DB_STAT_ALL | DB_STAT_SUBSYSTEM set together AND databases open (so the
+# LOG FNAME list has entries to iterate).  env020 passes -all and -subsystem
+# separately, never combined -- this leaves __dbreg_print_all cold.
+proc statprint001_dbreg { } {
+	source ./include.tcl
+	# Substring that only appears in __dbreg_print_all's output.
+	set pattern "LOG FNAME list:"
+
+	puts "\tStatprint001: env stat_print -all -subsystem (dbreg)"
+	env_cleanup $testdir
+	set env [eval berkdb_env_noerr -create -txn -lock -log \
+	    -home $testdir -msgfile $testdir/dbregmsg]
+	error_check_good is_valid_env [is_valid_env $env] TRUE
+
+	# Open (and keep open) several DBs so they are registered with dbreg.
+	set dbs {}
+	foreach am {btree hash recno} {
+		set db [eval berkdb_open_noerr -create -env $env -$am \
+		    -auto_commit dbreg_$am.db]
+		error_check_good is_valid_db_$am [is_valid_db $db] TRUE
+		set k [expr {$am eq "recno" ? 1 : "k1"}]
+		error_check_good put_$am \
+		    [$db put $k [chop_data $am data1]] 0
+		lappend dbs $db
+	}
+
+	# The combined flags that hit __dbreg_print_all.
+	error_check_good env_stat_all_sub \
+	    [$env stat_print -all -subsystem] 0
+	$env msgfile /dev/stdout
+
+	# Confirm __dbreg_print_all actually ran and iterated the FNAME list.
+	set found 0
+	set f [open $testdir/dbregmsg r]
+	while {[gets $f line] >= 0} {
+		if {[string first $pattern $line] >= 0} { set found 1; break }
+	}
+	close $f
+	error_check_good dbreg_print_all_ran $found 1
+
+	foreach db $dbs { error_check_good db_close [$db close] 0 }
+	error_check_good "$env close" [$env close] 0
+	file delete -force $testdir/dbregmsg
+}
+
+# db_stat utility sweep: drives util/db_stat.c -> __*_stat_print through the
+# read-only on-disk entry path with every meaningful flag combination.  This
+# is the cheapest way to hit all the __*_stat_print branches at once (env,
+# lock, log, mpool, mutex, rep, txn) including DB_STAT_ALL/SUBSYSTEM (-E) which
+# reaches __dbreg_stat_print, DB_STAT_MEMP_HASH (-Mh) and DB_STAT_CLEAR (-Z).
+proc statprint001_dbstat_util { } {
+	source ./include.tcl
+	global util_path
+
+	puts "\tStatprint001: db_stat utility flag sweep"
+	env_cleanup $testdir
+
+	# Build a fully-populated all-subsystems env (rep enabled so rep_stat
+	# has something to print), then close the DBs so db_stat can open the
+	# env read-only.
+	set env [eval berkdb_env_noerr -create -txn -lock -log -rep -home $testdir]
+	error_check_good is_valid_env [is_valid_env $env] TRUE
+	foreach am {btree hash recno queue} {
+		if {$am eq "queue"} {
+			set db [eval berkdb_open_noerr -create -env $env -$am \
+			    -len 64 -pad 0 -auto_commit stat_$am.db]
+		} else {
+			set db [eval berkdb_open_noerr -create -env $env -$am \
+			    -auto_commit stat_$am.db]
+		}
+		error_check_good is_valid_db_$am [is_valid_db $db] TRUE
+		for {set i 1} {$i <= 50} {incr i} {
+			set k [expr {$am eq "queue" || $am eq "recno" ? $i : "key$i"}]
+			error_check_good put_$am \
+			    [$db put $k [chop_data $am "data$i"]] 0
+		}
+		error_check_good db_close_$am [$db close] 0
+	}
+	error_check_good txn_chkpt [$env txn_checkpoint] 0
+	error_check_good "$env close" [$env close] 0
+
+	# Every db_stat flag combination that drives a __*_stat_print.  Each is
+	# expected to exit 0 and emit non-empty output.
+	set flagsets {
+		{-e}				{-E}
+		{-c}				{-C A}		{-C clop}
+		{-l}				{-L A}
+		{-m}				{-M A}		{-M h}
+		{-x}				{-X A}
+		{-r}				{-R A}
+		{-t}
+		{-Z -e}				{-Z -c}		{-Z -l}
+		{-Z -m}				{-Z -t}
+		{-d stat_btree.db}		{-d stat_btree.db -f}
+		{-d stat_hash.db}		{-d stat_recno.db}
+		{-d stat_queue.db}
+	}
+	foreach fs $flagsets {
+		set ret [catch {eval exec $util_path/db_stat \
+		    -h $testdir $fs} output]
+		error_check_good "db_stat $fs rc" $ret 0
+		error_check_good "db_stat $fs output" \
+		    [expr {[string length $output] > 0}] 1
+	}
+}

--- a/test/tcl/test.tcl
+++ b/test/tcl/test.tcl
@@ -848,6 +848,13 @@ proc r { args } {
 					}
 				}
 			}
+			statprint {
+				if { $display } { puts "eval statprint001" }
+				if { $run } {
+					check_handles
+					eval statprint001
+				}
+			}
 			btree -
 			rbtree -
 			hash -

--- a/test/tcl/testparams.tcl
+++ b/test/tcl/testparams.tcl
@@ -14,7 +14,7 @@ set serial_tests {rep002 rep005 rep016 rep020 rep022 rep026 rep031 rep063 \
 #set serial_tests {}
 
 set subs {auto_repmgr bigfile dead env fop lock log logverify memp multi_repmgr \
-    mutex other_repmgr plat recd rep rsrc sdb sdbtest sec si test txn}
+    mutex other_repmgr plat recd rep rsrc sdb sdbtest sec si statprint test txn}
 
 set test_names(bigfile)	[list bigfile001 bigfile002]
 set test_names(compact) [list test111 \
@@ -81,6 +81,7 @@ set test_names(sdbtest)	[list sdbtest001 sdbtest002]
 set test_names(sec)	[list sec001 sec002]
 set test_names(si)	[list si001 si002 si003 si004 si005 si006 si007 si008]
 set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006 ssi007 ssi008 ssi009]
+set test_names(statprint)	[list statprint001]
 set test_names(bt_rsnap)	[list bt_rsnap001]
 set test_names(test)	[list test001 test002 test003 test004 test005 \
     test006 test007 test008 test009 test010 test011 test012 test013 test014 \


### PR DESCRIPTION
## What

Raises coverage of the statistics subsystem — the biggest tractable single-process gap (~2k lines across 8 files at 0-29%). These are the verbose `stat_print` / `DB_STAT_ALL` formatters (`__*_print_*`) that format every field to a message file; functional tests read `stat()` values but almost never call `stat_print(DB_STAT_ALL)`.

## How

Two levers, both wired into the default `COV_TESTS`:

1. **`env020`** (already existed, was just never in the coverage subset) exercises every Tcl `*_stat_print` binding — `env` / `lock` / `log` / `mpool` / `mutex` / `txn` / `rep` / `repmgr` / `db` / `seq` — with each flag (`default`, `-clear`, `-all`, `-subsystem`, `-lk_*`, `-hash`, …).

2. **`statprint001`** (new) closes the two spots `env020` misses and adds the `db_stat` *utility* entry path:
   - **heap_stat.c** — `env020` opens no heap DB. Sweeps `stat_print` default / `-fast` / `-all`.
   - **dbreg_stat.c `__dbreg_print_all`** — reached only with `DB_STAT_ALL | DB_STAT_SUBSYSTEM` set *together* and databases open (so the LOG FNAME list has entries to iterate); `env020` passes those flags separately. Calls `env stat_print -all -subsystem` with live open DBs and asserts the FNAME list is printed.
   - **db_stat utility sweep** — `util/db_stat.c -> __*_stat_print` (a separate read-only on-disk path the Tcl suite never touches). Runs `db_stat` with every meaningful flag: `-e -E -c -C -l -L -m -M -x -X -r -R -t -Z -d -f` over a populated all-subsystems env.

Registered `statprint` in `testparams.tcl` (`subs` + `test_names`), added a `statprint` case to the `r` dispatcher, and added `env020` + `statprint001` to `run_coverage.sh` `COV_TESTS` (README updated).

## Measured lift (env020 + statprint001 vs `full-run-2/cov-ranking.txt` baseline)

| file | before | after |
|------|-------:|------:|
| `env/env_stat.c`      | 16.8% | **79.9%** |
| `lock/lock_stat.c`    | 17.4% | **73.6%** |
| `rep/rep_stat.c`      | 19.4% | **72.4%** |
| `db/db_stati.c`       | 22.0% | **61.8%** |
| `log/log_stat.c`      | 22.9% | **87.1%** |
| `mutex/mut_stat.c`    | 29.4% | **86.8%** |
| `sequence/seq_stat.c` | 0.0%  | **63.0%** |
| `dbreg/dbreg_stat.c`  | 0.0%  | **69.6%** |
| `heap/heap_stat.c`    | 0.0%  | **80.3%** |
| `qam/qam_stat.c`      | 57.6% | **78.0%** |
| `txn/txn_stat.c`      | 56.8% | **69.0%** |

The two 0% files (`seq_stat.c`, `dbreg_stat.c`, `heap_stat.c`) are now substantially covered.

## Validation

Built with `CC=gcc ... CFLAGS="-O0 -g --coverage"`, ran `env020` + `statprint001` under `timeout` in the nix dev shell, captured with `lcov` from `.libs`. Both tests PASS. `r statprint` also runs the new test via the dispatcher. No coverage artifacts / TESTDIR / cores committed.

## Still cold (documented, not fixed)

- `seq_stat.c __seq_print_all` is a no-op stub, and the Tcl `seq stat_print` binding exposes only `-clear`, not `-all` — reaching the `DB_STAT_ALL` branch would need a binding change for a 2-line stub. Left alone.
- `repmgr_stat.c` send-path counters need a live repmgr transport (`repmgr009`+, `COV_REP=1`).

## No bugs found
All stat_print paths behaved correctly under the sweep.