### PR TITLE
fix(upgrade): __db_set_lastpgno stored page count, not last page number

### DIFF
--- a/src/db/db_upg.c
+++ b/src/db/db_upg.c
@@ -506,6 +506,7 @@ __db_set_lastpgno(dbp, real_name, fhp)
 {
 	DBMETA meta;
 	ENV *env;
+	db_pgno_t last_pgno;
 	int ret;
 	size_t n;
 
@@ -515,8 +516,18 @@ __db_set_lastpgno(dbp, real_name, fhp)
 	if ((ret = __os_read(env, fhp, &meta, sizeof(meta), &n)) != 0)
 		return (ret);
 	dbp->pgsize = meta.pagesize;
-	if ((ret = __db_lastpgno(dbp, real_name, fhp, &meta.last_pgno)) != 0)
+	/*
+	 * __db_lastpgno returns the page COUNT (file bytes / pagesize), but
+	 * meta.last_pgno is the last valid page NUMBER (0-indexed).  For an
+	 * N-page file the last page number is N-1, so convert; a page-count of
+	 * 0 (impossible for a real DB, which always has a meta page) would map
+	 * to PGNO_INVALID rather than underflowing.  Storing the raw count here
+	 * left last_pgno one too high, which db_verify rejects under
+	 * HAVE_FTRUNCATE ("last_pgno is not correct").
+	 */
+	if ((ret = __db_lastpgno(dbp, real_name, fhp, &last_pgno)) != 0)
 		return (ret);
+	meta.last_pgno = last_pgno == 0 ? PGNO_INVALID : last_pgno - 1;
 	if ((ret = __os_seek(env, fhp, 0, 0, 0)) != 0)
 		return (ret);
 	if ((ret = __os_write(env, fhp, &meta, sizeof(meta), &n)) != 0)


### PR DESCRIPTION
**Long-standing latent defect** (byte-identical to upstream BDB 4.7/4.8), found by the access-method upgrade coverage work (PR #75).

`__db_lastpgno()` returns the page **count** (bytes/pagesize) — its other caller `__db_page_pass` uses it correctly as a loop bound (`for i=0; i<pgno_last`). But `__db_set_lastpgno` assigned that count straight into `meta.last_pgno`, which the engine treats as the last valid page **number** (0-indexed). For an N-page file this left `last_pgno = N` instead of `N-1`.

On the v8→v9 upgrade path (`__db_upgrade` case 8), `db_verify` then rejects the file under `HAVE_FTRUNCATE`: `Page 0: last_pgno is not correct: N != N-1`. The hash path masked it (its v8→v9 pass goes through mpool, which recomputes `last_pgno` on close).

**Fix:** store the last page number (`count - 1`), mapping an impossible 0-page file to `PGNO_INVALID` rather than underflowing.

## Verified
- A v8 meta upgraded via `db_upgrade` now **passes** `db_verify` (was "last_pgno is not correct")
- Normal v9 upgrade + `test001 btree`/`hash` unaffected

(The v7-flip synthetic fixture still fails verify — that's a known synthetic-fixture artifact per PR #75, not this bug; flipping a real v9 file to v7 doesn't produce a byte-accurate v7 page layout.)