### PR TITLE
test(coverage): mvcc001 forces MVCC freeze/thaw + cache-grow; documents cache-shrink SIGSEGV

### DIFF
--- a/test/coverage/MVCC-RESIZE-COVERAGE.md
+++ b/test/coverage/MVCC-RESIZE-COVERAGE.md
@@ -1,0 +1,97 @@
+# MVCC / cache-resize coverage (mp_mvcc.c, mp_resize.c)
+
+Two mpool files sat near-cold because the functional test suite exercises
+multiversion databases but never applies the *cache pressure* (freeze/thaw)
+or the *post-open cache growth* (region resize) that these files implement.
+
+`test/tcl/mvcc001.tcl` (COV group `mvcc`, wired into `run_coverage.sh`) closes
+both gaps.
+
+## What mvcc001 covers
+
+- **mvcc001.a -- mp_mvcc.c freeze/thaw** (`__memp_bh_freeze`,
+  `__memp_bh_thaw`, `__pgno_cmp`). A tiny (512K, 512-byte-page) multiversion
+  cache, two long-lived `txn -snapshot` readers pinning the original page
+  versions, and a writer churning every page in small committed transactions.
+  The old versions cannot stay resident, so they are spilled to a
+  `__db.freezer.*` file (freeze) and read back when the readers touch them
+  (thaw). Asserts the readers still see their original snapshot and the
+  mpool `Buffers frozen` / `Buffers thawed` counters are non-zero (observed:
+  ~7600 frozen, ~2900 thawed). Lifts **mp_mvcc.c 0% -> ~70%**.
+
+- **mvcc001.b -- mp_resize.c region growth** (`__memp_resize`,
+  `__memp_add_region`, `__memp_add_bucket`, `__memp_merge_buckets`,
+  `__memp_map_regions`, `__memp_get_cache_max`). A small 2-region cache opened
+  with a larger `cache_max`, then grown in steps with `resize_cache`
+  (`DB_ENV->set_cachesize` post-open). Each grow splits the last region's hash
+  buckets and copies the buffers into the newly-attached region; the test
+  re-reads all 800 records after every step to prove the data survives the
+  re-hash, and asserts an over-max resize fails cleanly (the `EINVAL` branch).
+  Lifts **mp_resize.c 0% -> ~58%**.
+
+## REAL BUG found: cache shrink crashes (SIGSEGV)
+
+While developing mvcc001.b, shrinking the cache (resize_cache to *fewer*
+regions) reliably **crashes** with SIGSEGV. mvcc001 therefore only grows the
+cache; the shrink path is left uncovered on purpose.
+
+### Reproduction
+
+Multi-region cache, grow, then shrink:
+
+```tcl
+set e [berkdb_env -create -txn -cache_max {0 16777216} \
+    -cachesize {0 1048576 2} -home $testdir]
+set db [berkdb_open -create -auto_commit -env $e -btree -pagesize 512 t.db]
+for {set i 0} {$i < 800} {incr i} { $db put key$i [string repeat D 200] }
+$e resize_cache {0 4194304}   ;# grow to 8 regions -- OK
+$e resize_cache {0 2097152}   ;# shrink to 4 regions -- SIGSEGV
+```
+
+### Stack
+
+```
+#0  __os_detach          src/os/os_map.c:317   munmap(infop->addr, rp->max)
+#1  __env_sys_detach     src/env/env_region.c:1348
+#2  __env_region_detach  src/env/env_region.c:1217
+#3  __memp_remove_region src/mp/mp_resize.c:459
+#4  __memp_resize        src/mp/mp_resize.c:547
+#5  __memp_set_cachesize src/mp/mp_method.c:176   (resize_cache path)
+```
+
+### Root cause (off-by-one region index)
+
+`__memp_remove_region()` picks the region to detach with:
+
+```c
+infop = &dbmp->reginfo[mp->nreg];      /* src/mp/mp_resize.c:451 */
+...
+ret = __env_region_detach(env, infop, 1);
+if (ret == 0)
+    mp->nreg--;                        /* decrement AFTER detach, line 461 */
+```
+
+Cache regions are stored in `reginfo[0 .. nreg-1]`, so the last valid region
+is index `nreg-1`. But `__memp_remove_region` indexes `reginfo[nreg]` -- one
+past the last live region -- and hands that uninitialized/stale `REGINFO`
+(garbage `addr`/`rp`) to `__env_region_detach`, so `munmap()` faults.
+
+Contrast the (correct) add path, `__memp_add_region()`:
+
+```c
+infop = &dbmp->reginfo[mp->nreg];      /* src/mp/mp_resize.c:377 */
+...
+regids[mp->nreg++] = infop->id;        /* increment AFTER, line 391 */
+```
+
+There the increment is *after* use, so index `nreg` is exactly the new region.
+The remove path copied the same `reginfo[mp->nreg]` expression but decrements
+afterward, making it off-by-one. The fix would be to detach
+`&dbmp->reginfo[mp->nreg - 1]` (and free that index's per-bucket mutexes in the
+`ENV_PRIVATE` block above). **Not fixed here** -- coverage work only documents
+engine bugs, it does not change engine code.
+
+This matches the historical state: even the full test run
+(`test/coverage/full-run-2/`) shows `FNDA:0` for `__memp_remove_region`,
+`__memp_remove_bucket`, and `__memp_merge_buckets` -- the shrink path has never
+been exercised, so the crash has never been hit before.

--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -152,6 +152,29 @@ worker must not wedge the whole run):
   (`src/env/env_register.c`, `__envreg_register`/`__envreg_isalive`) and runs
   recovery. Lift: `env_register.c` **0%→~55%**.
 
+## MVCC freeze/thaw + cache resize (`mvcc001`)
+
+`mp/mp_mvcc.c` and `mp/mp_resize.c` sat near-cold (functional baseline ~9%)
+because the suite uses multiversion DBs but never applies the *cache pressure*
+that spills old page versions to disk, nor grows the cache after open.
+`mvcc001` (COV group `mvcc`, in the default `COV_TESTS`) forces both:
+
+- **freeze/thaw** (`mp_mvcc.c`): a tiny 512K multiversion cache, two
+  long-lived `txn -snapshot` readers pinning the original versions, and a
+  writer churning every page — old versions spill to `__db.freezer.*` (freeze)
+  and are read back when the readers touch them (thaw). Asserts the readers
+  still see their snapshot and the `Buffers frozen`/`Buffers thawed` counters
+  are non-zero. Lift: **mp_mvcc.c 0%→~70%**.
+- **cache growth** (`mp_resize.c`): a small 2-region cache with a larger
+  `cache_max`, grown in steps via `resize_cache`, re-hashing buffers into new
+  regions; the data is re-verified after each grow and an over-max resize is
+  asserted to fail cleanly. Lift: **mp_resize.c 0%→~58%**.
+
+The cache **shrink** path is intentionally *not* exercised: it SIGSEGVs on an
+off-by-one region index in `__memp_remove_region`. See
+[`MVCC-RESIZE-COVERAGE.md`](MVCC-RESIZE-COVERAGE.md) for the stack, root cause,
+and reproduction.
+
 Outputs land in `build_unix/` (gitignored):
 
 - `coverage-summary.txt` — the line/branch/function totals

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -62,6 +62,16 @@ bld="$root/build_unix"
 # on-disk __*_stat_print entry path). Together: env_stat 17->80, lock_stat
 # 17->74, rep_stat 19->72, log_stat 23->87, mut_stat 29->87, db_stati 22->62,
 # seq_stat 0->63, dbreg_stat 0->70, heap_stat 0->80.
+#
+# mvcc001 forces the two cold multiversion/cache paths the functional suite
+# never applies pressure to: mp_mvcc.c freeze/thaw (a tiny multiversion cache
+# with snapshot readers pinning old versions while a writer churns pages, so
+# old versions spill to the __db.freezer file and thaw back) and mp_resize.c
+# region growth (a small multi-region cache grown past region boundaries via
+# resize_cache with a larger cache_max).  Lifts mp_mvcc.c 0->~70% and
+# mp_resize.c 0->~58%.  (Cache SHRINK is intentionally not exercised: it hits
+# a SIGSEGV off-by-one in __memp_remove_region -- see
+# test/coverage/MVCC-RESIZE-COVERAGE.md.)
 : "${COV_TESTS:=lock001: txn001: ssi001: ssi002: recd001:btree \
   btree/test001 btree/test111 \
   hash/test001 hash/test006 hash/test010 hash/test025 hash/test077 \
@@ -71,7 +81,7 @@ bld="$root/build_unix"
   run_range_partition@test001@btree \
   run_partition_callback@test001@btree \
   logverify001: logverify002: \
-  env020: statprint001:}"
+  env020: statprint001: mvcc001:}"
 : "${COV_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 : "${TCLSH:=tclsh}"
 # TCL lib dir: nix store on this box, /usr/lib/tcl8.6 on ubuntu CI.

--- a/test/tcl/mvcc001.tcl
+++ b/test/tcl/mvcc001.tcl
@@ -1,0 +1,193 @@
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# $Id$
+#
+# TEST	mvcc001
+# TEST	Force the MVCC freeze/thaw and cache-resize (grow) code paths.
+# TEST
+# TEST	Two cold subsystems that the functional suite never reaches:
+# TEST	  1. src/mp/mp_mvcc.c __memp_bh_freeze / __memp_bh_thaw / __pgno_cmp.
+# TEST	     These fire only when a multiversion cache fills up while old
+# TEST	     page versions are still pinned by long-lived snapshot readers:
+# TEST	     the old versions are spilled ("frozen") to a __db.freezer file
+# TEST	     and read back ("thawed") when a reader needs them.  test120-122
+# TEST	     exercise MVCC but never apply cache pressure, so freeze/thaw
+# TEST	     stay at 0% even in a full test run.
+# TEST	  2. src/mp/mp_resize.c region growth (__memp_add_region /
+# TEST	     __memp_add_bucket / __memp_merge_buckets / __memp_map_regions /
+# TEST	     __memp_resize / get/set_cache_max).  These fire when the cache
+# TEST	     is grown past a region boundary after open, via resize_cache
+# TEST	     (DB_ENV->set_cachesize post-open) with cache_max > 1 region.
+# TEST
+# TEST	mvcc001.a drives freeze/thaw: tiny multiversion cache, snapshot
+# TEST	readers pinning the original versions, a writer churning the pages
+# TEST	so old versions must freeze, then the readers read them back (thaw)
+# TEST	and we assert they still see their original snapshot.
+# TEST	mvcc001.b drives cache growth: a small multi-region cache with a
+# TEST	larger cache_max, grown in steps so buffers are re-hashed into new
+# TEST	regions, asserting the data survives every reshuffle.
+# TEST
+# TEST	NOTE: cache SHRINK (resize_cache to fewer regions) is deliberately
+# TEST	NOT exercised -- it crashes (SIGSEGV) due to an off-by-one in
+# TEST	__memp_remove_region (see test/coverage/MVCC-RESIZE-COVERAGE.md).
+
+proc mvcc001 { } {
+	puts "Mvcc001: MVCC freeze/thaw and cache-resize (grow) coverage"
+	mvcc001_freeze_thaw
+	mvcc001_resize_grow
+}
+
+# mp_mvcc.c: force __memp_bh_freeze / __memp_bh_thaw / __pgno_cmp.
+proc mvcc001_freeze_thaw { } {
+	source ./include.tcl
+
+	puts "\tMvcc001.a: Force MVCC freeze/thaw under cache pressure"
+	env_cleanup $testdir
+
+	# Tiny cache + multiversion.  The cache must be small enough that the
+	# writer's new page versions cannot coexist with the old versions the
+	# snapshot readers pin (forcing freeze), but large enough that a frozen
+	# buffer header and the currently-referenced buffers still fit (so
+	# freeze can allocate).  512K with 512-byte pages is the sweet spot.
+	# A large mutex set is required: every frozen buffer takes a mutex.
+	set e [eval {berkdb_env_noerr -create -txn -multiversion \
+	    -mutex_set_max 60000 -cachesize {0 524288 1} -home} $testdir]
+	error_check_good env_open [is_valid_env $e] TRUE
+
+	set db [eval {berkdb_open_noerr -create -auto_commit -env} $e \
+	    {-btree -pagesize 512 mvcc.db}]
+	error_check_good db_open [is_valid_db $db] TRUE
+
+	set nentries 150
+	set origdata [string repeat D 200]
+
+	puts "\t\tMvcc001.a1: Seed $nentries records"
+	for { set i 0 } { $i < $nentries } { incr i } {
+		error_check_good put($i) [$db put key$i $origdata] 0
+	}
+
+	# Long-lived snapshot readers.  Each reads a sampling of the keys,
+	# pinning the ORIGINAL version of those pages for the life of the txn.
+	puts "\t\tMvcc001.a2: Start snapshot readers pinning old versions"
+	set readers {}
+	for { set r 0 } { $r < 2 } { incr r } {
+		set t [$e txn -snapshot]
+		for { set i 0 } { $i < $nentries } { incr i 10 } {
+			eval {$db get -txn $t} key$i
+		}
+		lappend readers $t
+	}
+
+	# Writer churns every page many times in small committed transactions.
+	# The readers still pin the originals, so each overwrite creates a new
+	# version and the old one must be frozen out of the full cache.
+	puts "\t\tMvcc001.a3: Churn pages so old versions freeze"
+	for { set pass 0 } { $pass < 20 } { incr pass } {
+		for { set base 0 } { $base < $nentries } { incr base 5 } {
+			set wt [$e txn]
+			for { set i $base } \
+			    { $i < $base + 5 && $i < $nentries } { incr i } {
+				error_check_good churn($pass.$i) \
+				    [eval {$db put -txn $wt} \
+				    key$i [string repeat V 180]] 0
+			}
+			error_check_good churn_commit($pass.$base) [$wt commit] 0
+		}
+	}
+
+	set st [$e mpool_stat]
+	set frozen [getstats $st {Buffers frozen}]
+	set thawed [getstats $st {Buffers thawed}]
+	puts "\t\tMvcc001.a4: $frozen buffers frozen, $thawed thawed so far"
+	error_check_good froze_something [expr {$frozen > 0}] 1
+
+	# Readers read their pinned keys back.  Any frozen old version must be
+	# thawed from the freezer file, and each reader MUST still see its
+	# original snapshot -- this is the correctness assertion under freeze.
+	puts "\t\tMvcc001.a5: Readers thaw and re-verify their snapshot"
+	foreach t $readers {
+		for { set i 0 } { $i < $nentries } { incr i 10 } {
+			set ret [eval {$db get -txn $t} key$i]
+			set got [lindex [lindex $ret 0] 1]
+			error_check_good snapshot_data($i) $got $origdata
+		}
+		error_check_good reader_commit [$t commit] 0
+	}
+
+	set st [$e mpool_stat]
+	set thawed [getstats $st {Buffers thawed}]
+	puts "\t\tMvcc001.a6: $thawed buffers thawed total"
+	error_check_good thawed_something [expr {$thawed > 0}] 1
+
+	# Current handle should now see the churned data.
+	set ret [$db get key0]
+	error_check_good current_data \
+	    [lindex [lindex $ret 0] 1] [string repeat V 180]
+
+	error_check_good db_close [$db close] 0
+	error_check_good env_close [$e close] 0
+}
+
+# mp_resize.c: force cache growth (region add) + get/set_cache_max.
+proc mvcc001_resize_grow { } {
+	source ./include.tcl
+
+	puts "\tMvcc001.b: Grow a multi-region cache after open"
+	env_cleanup $testdir
+
+	# Start with a small 2-region cache but allow growth to many regions.
+	set e [eval {berkdb_env_noerr -create -txn \
+	    -cache_max {0 16777216} -cachesize {0 1048576 2} -home} $testdir]
+	error_check_good env_open [is_valid_env $e] TRUE
+
+	set st [$e mpool_stat]
+	set nc0 [getstats $st {Number of caches}]
+	set maxc [getstats $st {Maximum number of caches}]
+	puts "\t\tMvcc001.b1: Opened with $nc0 caches (max $maxc)"
+	error_check_good multi_region [expr {$nc0 >= 2}] 1
+
+	# get_cache_max returns the configured maximum (exercises the
+	# MPOOL_ON branch of __memp_get_cache_max).
+	set gcm [$e get_cache_max]
+	error_check_good get_cache_max [expr {[llength $gcm] == 2}] 1
+
+	set db [eval {berkdb_open_noerr -create -auto_commit -env} $e \
+	    {-btree -pagesize 512 resize.db}]
+	error_check_good db_open [is_valid_db $db] TRUE
+
+	set nentries 800
+	set data [string repeat D 200]
+	puts "\t\tMvcc001.b2: Seed $nentries records"
+	for { set i 0 } { $i < $nentries } { incr i } {
+		error_check_good put($i) [$db put key$i $data] 0
+	}
+
+	# Grow the cache in steps.  Each region added forces the hash buckets
+	# of the last region to be split and the buffers merged/copied into the
+	# new region (__memp_add_region -> __memp_add_bucket ->
+	# __memp_merge_buckets).  After every grow the data must be intact.
+	puts "\t\tMvcc001.b3: Grow cache and verify data survives each step"
+	foreach target { 2097152 3145728 4194304 8388608 } {
+		error_check_good resize($target) \
+		    [$e resize_cache [list 0 $target]] 0
+		set st [$e mpool_stat]
+		set nc [getstats $st {Number of caches}]
+		puts "\t\t\tGrew to $nc caches (target $target bytes)"
+		for { set i 0 } { $i < $nentries } { incr i } {
+			set ret [$db get key$i]
+			error_check_good resized_data($target.$i) \
+			    [lindex [lindex $ret 0] 1] $data
+		}
+	}
+
+	# Error path: asking for more regions than cache_max allows must fail
+	# cleanly (the EINVAL branch of __memp_resize), not crash.
+	puts "\t\tMvcc001.b4: Over-max resize fails cleanly"
+	set ret [catch {$e resize_cache {1 0}} res]
+	error_check_good overmax_fails $ret 1
+
+	error_check_good db_close [$db close] 0
+	error_check_good env_close [$e close] 0
+}

--- a/test/tcl/test.tcl
+++ b/test/tcl/test.tcl
@@ -855,6 +855,13 @@ proc r { args } {
 					eval statprint001
 				}
 			}
+			mvcc {
+				if { $display } { puts "eval mvcc001" }
+				if { $run } {
+					check_handles
+					eval mvcc001
+				}
+			}
 			btree -
 			rbtree -
 			hash -

--- a/test/tcl/testparams.tcl
+++ b/test/tcl/testparams.tcl
@@ -14,7 +14,7 @@ set serial_tests {rep002 rep005 rep016 rep020 rep022 rep026 rep031 rep063 \
 #set serial_tests {}
 
 set subs {auto_repmgr bigfile dead env fop lock log logverify memp multi_repmgr \
-    mutex other_repmgr plat recd rep rsrc sdb sdbtest sec si statprint test txn}
+    mutex other_repmgr plat recd rep rsrc sdb sdbtest sec si statprint mvcc test txn}
 
 set test_names(bigfile)	[list bigfile001 bigfile002]
 set test_names(compact) [list test111 \
@@ -82,6 +82,7 @@ set test_names(sec)	[list sec001 sec002]
 set test_names(si)	[list si001 si002 si003 si004 si005 si006 si007 si008]
 set test_names(ssi)	[list ssi001 ssi002 ssi003 ssi004 ssi005 ssi006 ssi007 ssi008 ssi009]
 set test_names(statprint)	[list statprint001]
+set test_names(mvcc)	[list mvcc001]
 set test_names(bt_rsnap)	[list bt_rsnap001]
 set test_names(test)	[list test001 test002 test003 test004 test005 \
     test006 test007 test008 test009 test010 test011 test012 test013 test014 \


### PR DESCRIPTION
## Summary

Raises coverage of two near-cold mpool files by forcing the code paths the
functional suite never applies pressure to:

| file | before | after |
|------|-------:|------:|
| `mp/mp_mvcc.c`   | 0% (subset) / 8.9% (full run) | **70.1%** |
| `mp/mp_resize.c` | 0% (subset) / 9.7% (full run) | **57.9%** |

(Even the full-suite baseline in `test/coverage/full-run-2/` shows `FNDA:0`
for `__memp_bh_freeze`, `__memp_bh_thaw`, and the entire resize add/remove
path — these were never exercised before.)

## What's added

New Tcl test `test/tcl/mvcc001.tcl` (COV group `mvcc`, registered like
`statprint001`: `subs` list + `test_names` + `r` dispatch, and wired into
`run_coverage.sh` COV_TESTS):

- **mvcc001.a — freeze/thaw** (`mp_mvcc.c`): a tiny 512K multiversion cache,
  two long-lived `txn -snapshot` readers pinning original page versions, and
  a writer churning every page in small committed transactions. Old versions
  spill to `__db.freezer.*` (freeze, ~7600 buffers) and thaw back (~2900) when
  the readers re-read. Asserts each reader still sees its original snapshot
  and the frozen/thawed counters are non-zero. Exercises `__memp_bh_freeze`,
  `__memp_bh_thaw`, `__pgno_cmp`.
- **mvcc001.b — cache growth** (`mp_resize.c`): a small 2-region cache with a
  larger `cache_max`, grown in steps via `resize_cache`, re-hashing buffers
  into new regions; data re-verified after each grow, over-max resize asserted
  to fail cleanly. Exercises `__memp_resize`, `__memp_add_region`,
  `__memp_add_bucket`, `__memp_merge_buckets`, `__memp_map_regions`,
  `__memp_get_cache_max`.

The test passes deterministically (run 3×) and cleans up after itself.

## The `si` group

The task suggested wiring `si001-008` for MVCC coverage, but in this fork
`si` = **Secondary Index**, not Snapshot Isolation (no `-multiversion` /
`-snapshot` anywhere in si001-008). It would add secondary-index coverage,
not mp_mvcc/mp_resize, so it was intentionally skipped (YAGNI for this goal).
The real MVCC tests are test120-122 and the freeze/thaw forcing test above.

## Real bug found (documented, NOT fixed)

Shrinking a multi-region cache (`resize_cache` to *fewer* regions) reliably
**SIGSEGVs**. `__memp_remove_region` (src/mp/mp_resize.c:451) indexes
`reginfo[mp->nreg]` — one past the last live region (indices are `0..nreg-1`)
— and hands that uninitialized `REGINFO` to `__env_region_detach`, faulting in
`munmap` (`os/os_map.c:317`). The add path is correct because it increments
`nreg` *after* use; the remove path copied the same expression but decrements
*after*, making it off-by-one. Full stack, root cause, and a 6-line repro are
in `test/coverage/MVCC-RESIZE-COVERAGE.md`. mvcc001 grows the cache only, to
avoid the crash. **No engine code changed.**

## Validation

Built with `--coverage` (CC=gcc) in the nix dev shell; `mvcc001` runs under
`timeout`, PASSes reliably, leaves no cores/TESTDIR. Coverage measured via
gcov from `build_unix/.libs`. No coverage artifacts committed.
