### PR TITLE
fix(mpool): cache shrink detached one region past the end (SIGSEGV)

### DIFF
--- a/src/mp/mp_resize.c
+++ b/src/mp/mp_resize.c
@@ -447,8 +447,15 @@ __memp_remove_region(dbmp)
 		if ((ret = __memp_remove_bucket(dbmp)) != 0)
 			return (ret);
 
-	/* Detach from the region then destroy it. */
-	infop = &dbmp->reginfo[mp->nreg];
+	/*
+	 * Detach from the region then destroy it.  Live cache regions occupy
+	 * reginfo[0 .. nreg-1], so the last one -- the region being removed --
+	 * is at index nreg-1.  (The add path uses reginfo[nreg] because it is
+	 * initializing the next, not-yet-counted slot before incrementing nreg;
+	 * removal is the mirror and must index the last LIVE region, else it
+	 * detaches/munmaps a stale slot one past the end -> SIGSEGV.)
+	 */
+	infop = &dbmp->reginfo[mp->nreg - 1];
 	if (F_ISSET(env, ENV_PRIVATE)) {
 		hp = R_ADDR(infop, ((MPOOL*)infop->primary)->htab);
 		for (i = 0; i < env->dbenv->mp_mtxcount; i++)


### PR DESCRIPTION
**Real crash bug** found by the MVCC/cache-resize coverage work (PR #81).

`__memp_remove_region` detached `dbmp->reginfo[mp->nreg]` — but live cache regions occupy `reginfo[0 .. nreg-1]`, so `reginfo[nreg]` is **one slot past the last region**. `__env_region_detach` then `munmap()`'d that stale/garbage REGINFO, reliably **SIGSEGV**'ing (in `__os_detach`) whenever the cache was shrunk to fewer regions (`DB_ENV->resize_cache` / `memp_resize` downward).

It was a mirror-image copy-paste of the add path: `__memp_add_region` correctly uses `reginfo[mp->nreg]` because it's initializing the **next, not-yet-counted** slot before `mp->nreg++`. Removal is the opposite — it must index the **last live** region (`reginfo[nreg-1]`), then decrement.

**Fix:** detach `reginfo[mp->nreg - 1]`.

## Reproduction (now fixed)
```tcl
set e [berkdb_env -create -txn -cache_max {0 16777216} -cachesize {0 1048576 2} -home $dir]
# ... populate ...
$e resize_cache {0 4194304}   ;# grow  — OK
$e resize_cache {0 2097152}   ;# shrink — was SIGSEGV, now clean
```

## Verified
- Grow-then-shrink completes cleanly (was SIGSEGV in `__os_detach`)
- Data survives repeated grow/shrink cycles intact
- `memp001/003` + `mvcc001` pass

This is the **3rd real bug** surfaced by the coverage program (after #67 heap-regression and #77 upstream `__db_set_lastpgno` off-by-one).