### PR TITLE
test(coverage): exercise the encryption path (sec001+sec002) in the subset

### DIFF
--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -233,6 +233,53 @@ off-by-one region index in `__memp_remove_region`. See
 [`MVCC-RESIZE-COVERAGE.md`](MVCC-RESIZE-COVERAGE.md) for the stack, root cause,
 and reproduction.
 
+## Encryption (`sec001` + `sec002`)
+
+`crypto/` + `hmac/` sat cold in the subset because **no other subset test opens
+an encrypted env or db** -- AES page/log encryption, the HMAC-SHA1 password /
+checksum path, and the mt19937 IV generator (`__db_generate_iv`) only run when
+`DB_ENV->set_encrypt(passwd, DB_ENCRYPT_AES)` + `DB->set_flags(DB_ENCRYPT)` are
+in play. `sec001` and `sec002` (both now in the default `COV_TESTS`, both
+already-registered Tcl tests -- no new Tcl written) drive that whole path:
+
+- **`sec001`** -- the encryption *interface*: create/open/join an encrypted
+  env + db, `DB_ENCRYPT_ANY`, and every failure branch (empty password,
+  algorithm-not-supplied, joining a non-encrypted env with a key and vice
+  versa, wrong-length password, **wrong password**, opening an encrypted db
+  with no key). These light up `crypto.c`'s cipher setup + the auth-failure
+  branches and `aes_method.c`'s key-derivation.
+- **`sec002`** -- the page-encryption *round-trip* and *tamper* paths:
+  encrypted put/get across pages (AES CBC block encrypt/decrypt +
+  IV generation), then scribbling on the meta page / swapping a root page and
+  reopening -- driving the HMAC-SHA1 `metadata page checksum error` and the
+  `checksum error` -> `DB_RUNRECOVERY` branches.
+
+Measured lift (subset baseline -> with sec001+sec002):
+
+| file | before | after (line% / br%) |
+|------|:------:|:------:|
+| `crypto/mersenne/mt19937db.c` | 0.0 | **95.6 / 56.2** |
+| `hmac/hmac.c`                 | 10.4 | **91.0 / 80.0** |
+| `crypto/rijndael/rijndael-alg-fst.c` | 18.8 | **83.5 / 55.0** |
+| `crypto/crypto.c`             | 50.7 | **77.9 / 60.5** |
+| `crypto/aes_method.c`         | 27.8 | **44.3 / 36.6** |
+| `crypto/rijndael/rijndael-api-fst.c` | 6.3 | **29.8 / 21.9** |
+| `hmac/sha1.c`                 | 97.4 | **98.7 / 72.7** |
+
+`rijndael-api-fst.c` caps at ~30% *by design*: `aes_method.c` only ever calls
+`__db_blockEncrypt`/`__db_blockDecrypt` with `MODE_CBC`, so the file's ECB and
+CFB1 branches and the entire `__db_padEncrypt`/`__db_padDecrypt` /
+`__db_cipherUpdateRounds` halves are **dead code from BDB's point of view** --
+unreachable by any Tcl workload. Similarly, `aes_method.c`'s remaining cold
+lines are the `HAVE_CRYPTO_IPP` alternate-backend blocks (this build is not
+IPP) and the `__aes_err` message table + `EAGAIN` branches, which fire only if
+an internal cipher call returns a negative error (bad key length / bad cipher
+state) -- states not reachable through the public API without fault injection.
+
+(`run_secmethod` / `run_secenv`, which run a full access-method test *twice*
+under encryption, add only ~1-2 pp over sec001+sec002 -- not worth ~doubling
+the subset runtime, so they are left out.)
+
 Outputs land in `build_unix/` (gitignored):
 
 - `coverage-summary.txt` — the line/branch/function totals

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -72,6 +72,17 @@ bld="$root/build_unix"
 # mp_resize.c 0->~58%.  (Cache SHRINK is intentionally not exercised: it hits
 # a SIGSEGV off-by-one in __memp_remove_region -- see
 # test/coverage/MVCC-RESIZE-COVERAGE.md.)
+#
+# sec001 + sec002 run the ENCRYPTION path (AES page/log encryption + HMAC-SHA1
+# checksums + the mt19937 IV generator).  No other subset test opens an
+# encrypted env/db, so crypto/ + hmac/ were the coldest reachable surface:
+# sec001 drives the create/open/join interface plus every wrong-password /
+# empty-password / algorithm-mismatch error branch; sec002 drives the
+# page-encryption round-trip (encrypted put/get across pages) and the
+# metadata/root-page checksum-error + DB_RUNRECOVERY paths.  Lift:
+# mt19937db.c 0->~96, hmac.c 10->~91, rijndael-alg-fst.c 19->~84,
+# crypto.c 51->~78, aes_method.c 28->~44, rijndael-api-fst.c 6->~30 (capped:
+# BDB only uses AES MODE_CBC, so the ECB/CFB1/pad* halves are dead code here).
 : "${COV_TESTS:=lock001: txn001: ssi001: ssi002: recd001:btree \
   recd002:btree recd016:btree env007: \
   btree/test001 btree/test111 \
@@ -82,7 +93,8 @@ bld="$root/build_unix"
   run_range_partition@test001@btree \
   run_partition_callback@test001@btree \
   logverify001: logverify002: \
-  env020: statprint001: mvcc001:}"
+  env020: statprint001: mvcc001: \
+  sec001: sec002:}"
 : "${COV_JOBS:=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 4)}"
 : "${TCLSH:=tclsh}"
 # TCL lib dir: nix store on this box, /usr/lib/tcl8.6 on ubuntu CI.


### PR DESCRIPTION
Raises coverage of the cold crypto/hmac surface by running an **encrypted workload** in the bounded coverage subset.

## Why it was cold
`crypto/` + `hmac/` sat cold in `run_coverage.sh`'s subset because **no subset test opened an encrypted env or db**. AES page/log encryption, the HMAC-SHA1 password/checksum path, and the mt19937 IV generator (`__db_generate_iv`) only run under `DB_ENV->set_encrypt(passwd, DB_ENCRYPT_AES)` + `DB->set_flags(DB_ENCRYPT)`.

## What changed
Added the two already-registered encryption Tcl tests to the default `COV_TESTS` (`sec001: sec002:`). **No new Tcl written.**

- **sec001** — encryption interface: create/open/join encrypted env+db, `DB_ENCRYPT_ANY`, and every failure branch (empty password, algorithm-not-supplied, join-mismatch, wrong-length password, **wrong password**, open-encrypted-with-no-key). Drives cipher setup + auth-failure branches in `crypto.c` and key derivation in `aes_method.c`.
- **sec002** — page-encryption round-trip (AES CBC block encrypt/decrypt + IV generation) and tamper paths (meta-page scribble / root-page swap → HMAC-SHA1 `metadata page checksum error` → `DB_RUNRECOVERY`).

`run_secmethod`/`run_secenv` (full access-method test twice under encryption) add only ~1–2 pp over sec001+sec002 for ~double the runtime, so they are deliberately left out.

## Coverage before → after (bounded subset)
| file | before | after (line% / br%) |
|------|:------:|:------:|
| `crypto/mersenne/mt19937db.c` | 0.0 | **95.6 / 56.2** |
| `hmac/hmac.c` | 10.4 | **91.0 / 80.0** |
| `crypto/rijndael/rijndael-alg-fst.c` | 18.8 | **83.5 / 55.0** |
| `crypto/crypto.c` | 50.7 | **77.9 / 60.5** |
| `crypto/aes_method.c` | 27.8 | **44.3 / 36.6** |
| `crypto/rijndael/rijndael-api-fst.c` | 6.3 | **29.8 / 21.9** |
| `hmac/sha1.c` | 97.4 | **98.7 / 72.7** |

### Ceilings (not bugs)
- `rijndael-api-fst.c` caps at ~30% **by design**: `aes_method.c` only ever calls `__db_blockEncrypt`/`__db_blockDecrypt` with `MODE_CBC`, so the ECB/CFB1 branches and the entire `__db_padEncrypt`/`__db_padDecrypt`/`__db_cipherUpdateRounds` halves are dead code from BDB's point of view — unreachable by any Tcl workload.
- `aes_method.c`'s remaining cold lines are the `HAVE_CRYPTO_IPP` alternate-backend blocks (this build is not IPP) and the `__aes_err` message table + `EAGAIN` branches, which fire only on an internal cipher error (bad key length / bad state) not reachable through the public API without fault injection.

## Validation
Built + ran in the nix dev shell (`--enable-debug --enable-test`, `HAVE_CRYPTO 1`, non-IPP). `has_crypto=1` in the harness. Both tests **PASS** through the exact `test:arg` loop mechanism `run_coverage.sh` uses. No real encryption/decryption or wrong-password bug surfaced — every error branch behaved as the tests assert.

No engine code touched; docs + coverage wiring only.