### PR TITLE
test(faultinject): deepen malloc-failure sweep (M 506->947) — 1 new crash + 2 new OOM leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build_unix/**
+build_asan/**
 compile_commands.json
 test/tcl/tclIndex
 

--- a/test/faultinject/README.md
+++ b/test/faultinject/README.md
@@ -50,7 +50,9 @@ The driver:
 1. **Phase 1 (baseline):** run the workload with injection OFF to count the
    total allocations `M` (a transactional `DB_PRIVATE` env + a btree AND a
    hash DB, put/get, a cursor walk, a committed txn, an aborted txn, a
-   checkpoint).
+   checkpoint, plus a secondary index / `pget`, a join cursor, bulk
+   put/get, an in-memory DB, a subdatabase, `DB->compact`, `DB->stat`, and a
+   2PC prepare — **M ≈ 947**).
 2. **Phase 2 (sweep):** for `K = 1..M`, run the SAME workload with "fail the
    Kth allocation." Each K runs in a **forked, watchdogged child** so a
    crash/hang/leak in one failure point can't wedge the sweep.
@@ -96,88 +98,145 @@ The in-process API (`fi_alloc.h`) — `__db_fi_arm(K)`, `__db_fi_disarm()`,
 `__db_fi_reset()`, `__db_fi_count()`, `__db_fi_fired()` — is what the driver
 uses to sweep without rebuilding.
 
-## Measured results (this branch, 2026-07-27)
+## Measured results (agent/malloc-deepen, 2026-07-30)
 
-Workload baseline: **M = 506 allocations.**
+The workload was broadened from the original basic flow (open env + btree +
+hash, put/get/cursor/txn commit+abort, checkpoint; **M = 506**) to also drive
+the warmer error paths functional tests miss:
+
+- a **secondary index** (`associate` + get-by-secondary + `pget`),
+- a **join cursor** (`DB->join`),
+- **bulk put/get** (`DB_MULTIPLE_KEY` write buffer + `DB_MULTIPLE_KEY` cursor scan),
+- an **in-memory DB** (NULL filename),
+- a **subdatabase** open (named DB inside a container file),
+- **compaction** (`DB->compact` with `DB_FREE_SPACE`),
+- **`DB->stat`**,
+- a **2PC prepare** (`txn->prepare` then resolve).
+
+New workload baseline: **M = 947 allocations** (up from 506 — +441 sites,
+~87% more failure points swept).
 
 | Metric | Count |
 |--------|------:|
-| Failure points exercised (K = 1..506) | 506 |
-| Clean error return (OOM → error, env re-openable) | 467 |
-| Clean/tolerated | 31 |
-| **CRASH** | **8** |
+| Failure points exercised (K = 1..947) | 947 |
+| Clean error return (OOM → error, env re-openable) | 861 |
+| Clean/tolerated | 81 |
+| **CRASH** | **5** |
 | HANG | 0 |
 | DIRTY | 0 |
 
-The 467 clean-error paths are the good news: the vast majority of OOM sites
-return a clean error and leave a recoverable environment (many print a `PANIC`
-to stderr and return an error — that is BDB's *defined* in-region-OOM
-behavior, not a crash). The 8 crashes are **real pre-existing bugs** on OOM
-return paths, listed below.
+The 5 crashes are a **single new root cause** on the hash-abort *undo* path
+(reached now that the wider workload leaves an aborted-hash txn to undo at
+env teardown). The ASan one-shot pass additionally flagged **leaks** on the
+`db_create` / `__db_join` OOM teardown paths (advisory). All are new,
+pre-existing engine bugs surfaced by the wider sweep; per the harness policy
+they are reported here, not fixed in this PR.
 
-## Bugs found (report only — NOT fixed in this PR)
+Note on `txn_recover`: it was intentionally left out of the workload. In a
+single live process the prepared txn is still active, so a `txn_recover` +
+resolve double-resolves it and panics the region (`transaction already
+committed` → `DB_RUNRECOVERY`). `txn_recover` is a separate-process recovery
+operation; `txn->prepare` alone reaches the new 2PC prepare/gid alloc sites.
 
-Per the task, this PR is the harness; engine bugs are for the maintainer to
-fix separately. Four distinct root causes, all NULL-deref / use-after-free on
-allocation-failure paths — exactly the #47 class the Coccinelle static rules
-target statically and this sweep confirms dynamically.
+### Reproduce the new findings
 
-### Bug 1 — NULL-deref in `db_env_create` OOM teardown (K=2)
-`src/rep/rep_method.c:95` (`__rep_env_destroy`), via
-`src/env/env_method.c:105,123`.
+```sh
+# plain-debug build (crash):
+DB_FI_FAIL_AT=490 ./libtool --mode=execute ./fi_sweep --one   # SIGSEGV
+# ASan build (leaks):
+DB_FI_FAIL_AT=503 ./.libs/fi_sweep --one    # db_create bt_internal leak
+DB_FI_FAIL_AT=641 ./.libs/fi_sweep --one    # __db_join cursor leak
+```
 
-In `db_env_create`, alloc #1 is the `DB_ENV`, alloc #2 is the `ENV`. When the
-`ENV` alloc fails (`env_method.c:87`), `dbenv->env` is still NULL and the
-`err:` path calls `__db_env_destroy(dbenv)` → `__rep_env_destroy(dbenv)`, which
-does `env = dbenv->env; if (env->rep_handle != NULL)` → dereferences NULL.
-Fix shape: guard `__rep_env_destroy` (and siblings) on `dbenv->env == NULL`.
+## Historical results (agent/malloc-inject, 2026-07-27)
 
-Repro: `DB_FI_FAIL_AT=2 ./fi_sweep --one`
+Original basic-workload baseline: **M = 506 allocations.** That sweep found
+8 crashes across 4 root causes on OOM return paths (`db_env_create` teardown,
+`__lock_getlocker_int`, `__db_pgin`, and a txn/lock double-free). Those four
+were fixed separately (see PR #52); the current tree returns clean errors at
+those K.
 
-### Bug 2 — NULL-deref in `__lock_getlocker_int` shared-region OOM (K=212, 214, 220, 353, 359)
-`src/lock/lock_id.c:349`.
+## Bugs found by the expanded sweep (report only — NOT fixed in this PR)
 
-When the free-locker list is empty and `__env_alloc` (shared-region alloc) can
-never satisfy the request, the `while (__env_alloc(...) != 0) if ((nlockers >> 1) == 0) break;`
-loop breaks with `nlockers` still ≥ 1 and `sh_locker` still NULL, then the
-`for (i = 0; i < nlockers; i++) SH_TAILQ_INSERT_HEAD(..., sh_locker, ...)`
-loop dereferences the NULL `sh_locker`. The `if (nlockers == 0)` nomem check
-comes *after* the deref and never fires. Reached via `__txn_begin_int` and
-`__db_open`/`__fop_file_setup`'s `__lock_id`.
-Fix shape: on the `break`, set `nlockers = 0` (or bail to `__lock_nomem`)
-*before* the insert loop.
+Per the harness policy, this PR broadens the workload and reports engine bugs;
+fixes are separate focused PRs (like PR #52 for the first batch). The wider
+workload surfaced **one new crash root cause** (5 K values) plus a **family of
+OOM-teardown leaks** the ASan pass flags.
 
-Repro: `DB_FI_FAIL_AT=212 ./fi_sweep --one`
+### New Bug A — NULL-deref in hash-abort undo cursor open (K=490, 491, 492, 493, 497)
+`src/db/db_iface.c:370` (`__db_cursor`, the `MULTIVERSION(dbp)` check reads an
+atomic off a partially-built handle), via
+`src/hash/hash_rec.c:84` (`__ham_insdel_recover`) ←
+`src/txn/txn.c:1942,2036` (`__txn_dispatch_undo`/`__txn_undo`) ←
+`src/txn/txn.c:1242` (`__txn_abort`) ←
+`src/txn/txn_region.c:252` (`__txn_env_refresh`) ← `__env_refresh` at env close.
 
-### Bug 3 — NULL-deref in `__db_pgin` with a NULL pgin cookie (K=375, 376)
-`src/db/db_conv.c:76`, via `__memp_pg`/`__memp_pgread`/`__memp_fget` ←
-`__ham_get_meta` ← `__ham_open`.
+The wider workload leaves an **aborted hash transaction** whose insdel log
+records must be undone. When an allocation on the undo path fails (K in
+490..497), `__ham_insdel_recover` still calls `__db_cursor` on a dbp whose
+backing (mpf / cursor prerequisites) was never allocated, and
+`__os_atomic_read(p=0xa4)` dereferences a NULL base + field offset.
+Same stack for all five K.
+Fix shape: propagate the undo-path alloc failure so `__ham_insdel_recover`
+does not open a cursor on a half-built handle (or guard `__db_cursor` /
+`REC_INTRO` when the handle's mpf is NULL).
 
-`__db_pgin` does `pginfo = (DB_PGINFO *)cookie->data;` with `cookie == NULL` —
-the pgin cookie / DB_PGINFO allocation failed upstream (in the hash-open page
-read setup) but the page-in proceeds and dereferences the NULL cookie.
-Fix shape: propagate the upstream alloc failure so `__db_pgin` is never called
-with a NULL cookie (or guard it).
+Repro: `DB_FI_FAIL_AT=490 ./libtool --mode=execute ./fi_sweep --one`
 
-Repro: `DB_FI_FAIL_AT=375 ./fi_sweep --one`
+### New Bug B — `db_create` OOM teardown leaks the access-method private struct (ASan; K=485,488,503,540,641,775,813,823,860,886,909,928,930,932,933,935,937,…)
+`src/db/db_method.c:206` (`__db_create_internal` `err:` path), leaking the
+struct allocated by `__db_init` → `__bam_db_create` (`src/btree/bt_method.c:47`,
+152 bytes) or `__qam_db_create` (queue), and analogous `__env_alloc` /
+`__lock_vec` region allocations.
 
-### Bug 4 — heap-use-after-free in txn/lock OOM cleanup (K≈213, 215, 216; ASan-only)
-`src/lock/lock_id.c:507` (`__lock_freelocker_int` → `__os_atomic_read`), via
-`src/txn/txn.c:1854` (`__txn_end`) ← `__txn_abort`.
+`__db_create_internal`'s `err:` path frees only `dbp` and `dbp->mpf`:
+```c
+err:    if (dbp != NULL) {
+                if (dbp->mpf != NULL)
+                        (void)__memp_fclose(dbp->mpf, 0);
+                __os_free(env, dbp);   /* does NOT free dbp->bt_internal */
+        }
+```
+When an allocation *after* `__bam_db_create`/`__qam_db_create` fails (e.g.
+`__memp_fcreate`), the access-method private struct hung off
+`dbp->bt_internal` / `dbp->q_internal` leaks, and `*dbpp` is set to NULL so
+the caller cannot free it either. A per-access-method OOM leak.
+Fix shape: call the access-method's own destructor (or free
+`dbp->bt_internal`/`dbp->q_internal`/`dbp->h_internal`) on the `err:` path.
 
-When `__txn_begin_int` partially fails under OOM (locker allocated at
-`txn.c:423`), the abort path's `__txn_end` frees the locker once (`txn.c:1816`)
-and then calls `__lock_freelocker` again at `txn.c:1854` on the already-freed
-locker, whose `__os_atomic_read` reads freed memory. A double-cleanup on the
-transaction OOM path. Caught by the ASan build; the plain-debug build
-tolerates the adjacent reads and instead segfaults at the nearby K in Bug 2.
-Fix shape: null out / de-link the locker after the first free so `__txn_end`
-does not free it twice.
+Repro (ASan build): `DB_FI_FAIL_AT=503 ./.libs/fi_sweep --one`
 
-Repro (ASan build): `DB_FI_FAIL_AT=213 ./.libs/fi_sweep --one`
+### New Bug C — `__db_join` leaks the join cursor on OOM (ASan; K=641, and nearby)
+`src/db/db_join.c:93` (`__db_join`).
+
+`__db_join` allocates the join-cursor struct (256 bytes) and then does further
+allocations while wiring up the constituent cursors. When one of those later
+allocations fails, `__db_join` returns an error **without freeing the
+already-allocated join cursor**, and since it never set `*dbcp` the caller
+cannot free it. An OOM leak local to `__db_join`.
+Fix shape: free the partially-built join cursor on `__db_join`'s error path.
+
+Repro (ASan build): `DB_FI_FAIL_AT=641 ./.libs/fi_sweep --one`
+
+### Note on classification
+
+Bug A is caught by BOTH the plain-debug forking sweep (as a `CRASH`) and the
+ASan one-shot pass (as `SEGV`). Bugs B and C are **leaks** that the plain
+segfault check cannot see; only the ASan build flags them (`LeakSanitizer`),
+so they are advisory. The four original bugs (K=2, 212…, 375…, txn/lock UAF)
+are no longer reproducible on the current tree — they were fixed in PR #52.
 
 ## CI
 
-`.github/workflows/faultinject.yml` runs the plain-debug sweep as the primary
-signal plus a bounded ASan one-shot pass, both `continue-on-error: true`
-(advisory) until the bugs above are fixed. See the workflow header for detail.
+`.github/workflows/faultinject.yml` runs the full plain-debug sweep
+(K = 1..M, ~46s at M=947) as the primary signal plus a full ASan one-shot
+pass (K = 1..M, ~2min), both `continue-on-error: true` (advisory) until the
+bugs above are fixed. The full sweep is cheap enough to run unbounded in CI;
+cap it with `FI_MAXK` locally if needed. See the workflow header for detail.
+
+Updating the workflow requires a token with `workflow` scope, which agent
+pushes do not carry, so the updated workflow is staged alongside this README
+as `test/faultinject/faultinject.yml.workflow`. A maintainer syncs it into
+`.github/workflows/faultinject.yml` (the only change vs. the installed file:
+the ASan one-shot pass now sweeps the full K = 1..M range instead of
+stopping at K = 260, so it reaches the new leaks/crashes past K = 480).

--- a/test/faultinject/faultinject.yml.workflow
+++ b/test/faultinject/faultinject.yml.workflow
@@ -1,0 +1,138 @@
+# Malloc-failure injection (SQLite-style) — advisory fault-injection tier.
+#
+# Dedicated workflow (does NOT touch ci.yml). Builds libdb with the opt-in
+# --enable-faultinject allocation hook (zero-overhead when off) and runs the
+# test/faultinject/ sweep: measure the workload's baseline allocation count M,
+# then for K = 1..M fail the Kth allocation and assert the library returns a
+# clean error, holds no lock (a hang is caught by a per-run watchdog), and
+# leaves a re-openable environment.
+#
+# This is the dynamic complement to the Coccinelle malloc-leak /
+# mutex-unbalanced static rules — it exercises the OOM RETURN PATHS the static
+# rules can only inspect, and it catches exactly the #47 class of bug (a lock
+# or handle mishandled on the error return).
+#
+# continue-on-error is set so this tier is ADVISORY: the sweep is expected to
+# surface pre-existing OOM-path bugs (it already found several — see
+# test/faultinject/README.md), and this job reports them without gating merges
+# while those bugs are fixed separately.
+
+name: faultinject
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    paths:
+      - 'test/faultinject/**'
+      - 'src/os/os_alloc.c'
+      - 'dist/configure.ac'
+      - 'dist/aclocal/options.m4'
+      - 'dist/Makefile.in'
+      - '.github/workflows/faultinject.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: faultinject-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  sweep:
+    name: malloc-failure sweep
+    runs-on: ubuntu-latest
+    continue-on-error: true   # advisory tier: surfaces pre-existing OOM bugs
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential autoconf
+
+      # --- Gate signal: plain debug build, clean crash/hang/dirty
+      #     classification, completes fast. ---
+      - name: Configure (debug + faultinject)
+        run: |
+          mkdir -p build_unix
+          cd build_unix
+          ../dist/configure --enable-debug --enable-faultinject
+
+      - name: Build library + sweep driver
+        run: |
+          cd build_unix
+          make -j"$(nproc)"
+          make fi_tests
+
+      - name: Run the malloc-failure sweep
+        id: sweep
+        run: |
+          cd build_unix
+          # The driver forks + watchdogs each K, so a crash/hang in one
+          # failure point cannot wedge the sweep. It exits non-zero iff any
+          # run crashed, hung, or left the env un-reopenable.
+          set +e
+          ./libtool --mode=execute ./fi_sweep 2>fi_stderr.log | tee fi_result.log
+          echo "sweep_rc=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+          set -e
+          echo "----- summary -----"
+          grep -E 'CRASH|HANG|DIRTY|BADSTATE|RESULT|baseline|exercised|= [0-9]' fi_result.log || true
+
+      # --- Advisory ASan pass: catch heap-UAF / leak on the OOM paths a
+      #     plain segfault-check misses. Full one-shot loop (not the
+      #     forking sweep) so ASan's halt-on-first-error stays contained; a
+      #     one-shot run is ~0.13s under ASan so the full M-wide loop is
+      #     ~2min. ---
+      - name: Configure ASan build
+        run: |
+          mkdir -p build_asan
+          cd build_asan
+          ../dist/configure --enable-debug --enable-faultinject \
+            CFLAGS="-g -O1 -fsanitize=address -fno-omit-frame-pointer" \
+            LDFLAGS="-fsanitize=address"
+
+      - name: Build ASan library + driver
+        run: |
+          cd build_asan
+          make -j"$(nproc)"
+          make fi_tests
+
+      - name: Run bounded ASan one-shot pass
+        run: |
+          cd build_asan
+          export LD_LIBRARY_PATH="$PWD/.libs:$LD_LIBRARY_PATH"
+          export ASAN_OPTIONS=abort_on_error=0:detect_leaks=1:halt_on_error=1
+          # Measure the workload's baseline allocation count M, then sweep
+          # every K one-shot under ASan and report any ASan-flagged K
+          # (SEGV / heap-UAF / leak) a plain segfault check misses. One
+          # one-shot run is ~0.13s under ASan, so the full M-wide sweep is
+          # ~2min -- cheap enough to run in full and still catch the OOM
+          # leaks/crashes that live past K=480 (the expanded workload).
+          M=$(DB_FI_FAIL_AT=0 ./.libs/fi_sweep --one 2>/dev/null \
+            | grep -oE 'allocs=[0-9]+' | head -1 | cut -d= -f2)
+          M=${M:-947}
+          echo "ASan sweep over K=1..$M"
+          hits=0
+          for K in $(seq 1 "$M"); do
+            out=$(DB_FI_FAIL_AT=$K ./.libs/fi_sweep --one 2>&1 || true)
+            if echo "$out" | grep -q "ERROR: AddressSanitizer\|ERROR: LeakSanitizer"; then
+              kind=$(echo "$out" | grep -m1 -oE 'AddressSanitizer: [a-z-]+|LeakSanitizer|SEGV' || echo '?')
+              site=$(echo "$out" | grep -oE 'in [A-Za-z_0-9]+ [^ ]*/src/[^ ]*\.c:[0-9]+' | grep -v 'os_alloc\|os_atomic' | head -1 || echo '(site unknown)')
+              echo "ASan K=$K: $kind $site"
+              hits=$((hits+1))
+            fi
+          done
+          echo "ASan flagged $hits failure point(s) in K=1..$M (advisory)."
+
+      - name: Upload sweep logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: faultinject-logs
+          path: |
+            build_unix/fi_result.log
+            build_unix/fi_stderr.log
+          if-no-files-found: ignore

--- a/test/faultinject/fi_sweep.c
+++ b/test/faultinject/fi_sweep.c
@@ -46,7 +46,11 @@
 #define HOME     "TESTDIR_fi_sweep"
 #define BTFILE   "fi_bt.db"
 #define HFILE    "fi_h.db"
+#define SECFILE  "fi_sec.db"      /* secondary index DB          */
+#define MULTIFILE "fi_multi.db"    /* subdatabase container       */
 #define NREC     40
+#define NBULK    24               /* records for the bulk put    */
+#define GID_A    0x51             /* first byte of the 2PC gid   */
 
 /* Child exit codes the parent interprets. */
 #define EX_OK        0   /* workload completed with no injected failure   */
@@ -58,6 +62,29 @@ static int workload __P((int *));
 static int reopen_ok __P((void));
 static int run_child __P((long));
 static void cleanup __P((void));
+static int seckey __P((DB *, const DBT *, const DBT *, DBT *));
+
+/*
+ * seckey --
+ *	Secondary-index key extractor: the secondary key is the first 4
+ *	bytes of the primary value (deterministic, so associate/pget/
+ *	get-by-secondary hit the same alloc sites every run).
+ */
+static int
+seckey(sdb, pkey, pdata, skey)
+	DB *sdb;
+	const DBT *pkey, *pdata;
+	DBT *skey;
+{
+	(void)sdb;
+	(void)pkey;
+	memset(skey, 0, sizeof(*skey));
+	if (pdata->size < 4)
+		return (DB_DONOTINDEX);
+	skey->data = pdata->data;
+	skey->size = 4;
+	return (0);
+}
 
 /*
  * cleanup --
@@ -75,8 +102,13 @@ cleanup()
  *	A representative single-process DB_PRIVATE workload touching the
  *	paths a real app hits: open a transactional env, a btree AND a
  *	hash DB, put/get, a cursor walk, a committed txn and an aborted
- *	txn, and a checkpoint.  Returns the first non-zero DB error it
- *	sees (so an injected OOM surfaces as that op's error), or 0.
+ *	txn, and a checkpoint.  It then broadens into the warmer error
+ *	paths functional tests miss: a secondary index (associate +
+ *	get-by-secondary + pget), a 2PC transaction (prepare + resolve),
+ *	bulk put/get (DB_MULTIPLE / DB_MULTIPLE_KEY), an in-memory DB, a
+ *	subdatabase open, a join cursor, DB->compact, and DB->stat.
+ *	Returns the first non-zero DB error it sees (so an injected OOM
+ *	surfaces as that op's error), or 0.
  *
  *	The point is NOT that every op succeeds under injection -- it is
  *	that whichever op the injected OOM lands in returns cleanly and
@@ -91,12 +123,17 @@ workload(heldp)
 	int *heldp;
 {
 	DB_ENV *env = NULL;
-	DB *bt = NULL, *h = NULL;
+	DB *bt = NULL, *h = NULL, *sec = NULL, *mem = NULL, *sub = NULL;
 	DB_TXN *txn = NULL;
-	DBC *dbc = NULL;
-	DBT key, data;
+	DBC *dbc = NULL, *jc[2] = { NULL, NULL }, *jcur = NULL;
+	DB_COMPACT c_data;
+	DBT key, data, pkey, skey;
+	void *bulk = NULL;
+	void *ptr;
+	u_int8_t gid[DB_GID_SIZE];
 	int i, ret, t_ret;
 	char kbuf[32], vbuf[64];
+	DB_BTREE_STAT *bstat = NULL;
 
 	*heldp = 0;
 
@@ -189,8 +226,234 @@ workload(heldp)
 		goto done;
 
 	/* Checkpoint the environment. */
-	ret = env->txn_checkpoint(env, 0, 0, 0);
+	if ((ret = env->txn_checkpoint(env, 0, 0, 0)) != 0)
+		goto done;
 
+	/*
+	 * --- Secondary index: associate a secondary DB with the btree,
+	 * then read back through it (get-by-secondary + pget).  This
+	 * reaches the associate/callback/secondary-cursor alloc sites.
+	 */
+	if ((ret = db_create(&sec, env, 0)) != 0)
+		goto done;
+	/* Secondary keys are the 4-byte value prefix -> duplicates. */
+	if ((ret = sec->set_flags(sec, DB_DUPSORT)) != 0)
+		goto done;
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	if ((ret = sec->open(sec, txn, SECFILE, NULL, DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		goto done;
+	if ((ret = bt->associate(bt, txn, sec, seckey, DB_CREATE)) != 0)
+		goto done;
+	ret = txn->commit(txn, 0);
+	txn = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
+	/* get-by-secondary: look up a primary row via its secondary key. */
+	memset(&skey, 0, sizeof(skey));
+	memset(&data, 0, sizeof(data));
+	skey.data = "bval"; skey.size = 4;
+	if ((ret = sec->get(sec, NULL, &skey, &data, 0)) != 0 &&
+	    ret != DB_NOTFOUND)
+		goto done;
+	/* pget: fetch secondary key + primary key + primary data. */
+	memset(&skey, 0, sizeof(skey));
+	memset(&pkey, 0, sizeof(pkey));
+	memset(&data, 0, sizeof(data));
+	skey.data = "bval"; skey.size = 4;
+	if ((ret = sec->pget(sec, NULL, &skey, &pkey, &data, 0)) != 0 &&
+	    ret != DB_NOTFOUND)
+		goto done;
+
+	/*
+	 * --- Join cursor: build two btree cursors positioned on the same
+	 * secondary key and join them (a single-DB self-join is enough to
+	 * reach the join-cursor alloc sites).
+	 */
+	if ((ret = sec->cursor(sec, NULL, &jc[0], 0)) != 0)
+		goto done;
+	*heldp = 1;
+	memset(&skey, 0, sizeof(skey));
+	memset(&data, 0, sizeof(data));
+	skey.data = "bval"; skey.size = 4;
+	if ((ret = jc[0]->get(jc[0], &skey, &data, DB_SET)) != 0 &&
+	    ret != DB_NOTFOUND)
+		goto done;
+	if (ret == 0) {
+		if ((ret = bt->join(bt, jc, &jcur, 0)) != 0)
+			goto done;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		while ((ret = jcur->get(jcur, &key, &data, 0)) == 0)
+			;
+		if (ret == DB_NOTFOUND)
+			ret = 0;
+		(void)jcur->close(jcur);
+		jcur = NULL;
+	}
+	(void)jc[0]->close(jc[0]);
+	jc[0] = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
+
+	/*
+	 * --- Bulk put + bulk get: DB_MULTIPLE_KEY put into the btree and
+	 * a DB_MULTIPLE_KEY cursor read back.  Reaches the bulk-buffer /
+	 * DB_MULTIPLE alloc sites.
+	 */
+	if ((bulk = malloc(64 * 1024)) == NULL) {
+		ret = ENOMEM;
+		goto done;
+	}
+	memset(&key, 0, sizeof(key));
+	key.data = bulk; key.ulen = 64 * 1024;
+	key.flags = DB_DBT_USERMEM | DB_DBT_BULK;
+	DB_MULTIPLE_WRITE_INIT(ptr, &key);
+	for (i = 0; i < NBULK; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "mkey-%06d", i);
+		(void)snprintf(vbuf, sizeof(vbuf), "mval-%06d", i);
+		DB_MULTIPLE_KEY_WRITE_NEXT(ptr, &key,
+		    kbuf, strlen(kbuf) + 1, vbuf, strlen(vbuf) + 1);
+		if (ptr == NULL)
+			break;
+	}
+	if ((ret = bt->put(bt, NULL, &key, NULL, DB_MULTIPLE_KEY)) != 0)
+		goto done;
+	/* Bulk get: DB_MULTIPLE_KEY cursor scan of the btree. */
+	if ((ret = bt->cursor(bt, NULL, &dbc, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	data.data = bulk; data.ulen = 64 * 1024;
+	data.flags = DB_DBT_USERMEM;
+	while ((ret = dbc->get(dbc, &key, &data,
+	    DB_NEXT | DB_MULTIPLE_KEY)) == 0) {
+		void *bp, *kp, *dp;
+		u_int32_t klen, dlen;
+		DB_MULTIPLE_INIT(bp, &data);
+		for (;;) {
+			DB_MULTIPLE_KEY_NEXT(bp, &data, kp, klen, dp, dlen);
+			if (kp == NULL)
+				break;
+		}
+	}
+	if (ret == DB_NOTFOUND)
+		ret = 0;
+	{
+		int cret = dbc->close(dbc);
+		dbc = NULL;
+		*heldp = 0;
+		if (ret == 0)
+			ret = cret;
+	}
+	if (ret != 0)
+		goto done;
+
+	/*
+	 * --- In-memory DB (NULL filename): reaches the in-memory-named-DB
+	 * open + mpool-backing alloc sites distinct from on-disk opens.
+	 */
+	if ((ret = db_create(&mem, env, 0)) != 0)
+		goto done;
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	if ((ret = mem->open(mem, txn, NULL, NULL, DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		goto done;
+	for (i = 0; i < 8; i++) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		(void)snprintf(kbuf, sizeof(kbuf), "ikey-%06d", i);
+		(void)snprintf(vbuf, sizeof(vbuf), "ival-%06d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = mem->put(mem, txn, &key, &data, 0)) != 0)
+			goto done;
+	}
+	ret = txn->commit(txn, 0);
+	txn = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
+
+	/*
+	 * --- Subdatabase open: a named DB inside a container file reaches
+	 * the multi-DB / master-DB open alloc sites.
+	 */
+	if ((ret = db_create(&sub, env, 0)) != 0)
+		goto done;
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	if ((ret = sub->open(sub, txn, MULTIFILE, "sub1", DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		goto done;
+	for (i = 0; i < 8; i++) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		(void)snprintf(kbuf, sizeof(kbuf), "skey-%06d", i);
+		(void)snprintf(vbuf, sizeof(vbuf), "sval-%06d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = sub->put(sub, txn, &key, &data, 0)) != 0)
+			goto done;
+	}
+	ret = txn->commit(txn, 0);
+	txn = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
+
+	/*
+	 * --- Compaction: DB->compact on the btree exercises the compact
+	 * alloc sites (compaction working buffers, page fetches).
+	 */
+	memset(&c_data, 0, sizeof(c_data));
+	if ((ret = bt->compact(bt, NULL, NULL, NULL, &c_data,
+	    DB_FREE_SPACE, NULL)) != 0)
+		goto done;
+
+	/*
+	 * --- DB->stat: gather btree statistics (allocates the stat
+	 * struct + walks metadata).
+	 */
+	if ((ret = bt->stat(bt, NULL, &bstat, 0)) != 0)
+		goto done;
+	free(bstat);
+	bstat = NULL;
+
+	/*
+	 * --- 2PC: prepare a transaction, then resolve it.  prepare()
+	 * reaches the log-flush / gid-write / prepare alloc sites that the
+	 * plain commit/abort paths do not.  (txn_recover is a
+	 * separate-process recovery operation; calling it on a still-live
+	 * prepared txn in the same process double-resolves it, so we just
+	 * commit through our own handle here.)
+	 */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		goto done;
+	*heldp = 1;
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "pkey-2pc"; key.size = 9;
+	data.data = "pval-2pc"; data.size = 9;
+	if ((ret = bt->put(bt, txn, &key, &data, 0)) != 0)
+		goto done;
+	memset(gid, 0, sizeof(gid));
+	gid[0] = GID_A;
+	if ((ret = txn->prepare(txn, gid)) != 0)
+		goto done;
+	ret = txn->commit(txn, 0);
+	txn = NULL;
+	*heldp = 0;
+	if (ret != 0)
+		goto done;
 done:
 	/*
 	 * Teardown IS part of the test.  Release anything still held, in
@@ -201,8 +464,27 @@ done:
 	 */
 	if (dbc != NULL)
 		(void)dbc->close(dbc);
+	if (jcur != NULL)
+		(void)jcur->close(jcur);
+	if (jc[0] != NULL)
+		(void)jc[0]->close(jc[0]);
 	if (txn != NULL)
 		(void)txn->abort(txn);
+	free(bulk);
+	free(bstat);
+	if (sub != NULL) {
+		if ((t_ret = sub->close(sub, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
+	if (mem != NULL) {
+		if ((t_ret = mem->close(mem, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
+	if (sec != NULL) {
+		/* Secondary must close before its primary. */
+		if ((t_ret = sec->close(sec, 0)) != 0 && ret == 0)
+			ret = t_ret;
+	}
 	if (h != NULL) {
 		if ((t_ret = h->close(h, 0)) != 0 && ret == 0)
 			ret = t_ret;


### PR DESCRIPTION
## What

Broadens the SQLite-style malloc-failure injection sweep (`test/faultinject/fi_sweep.c`, from PR #49) so its workload reaches substantially more allocation sites, then re-runs the sweep under plain-debug **and** clang ASan.

The old workload (open env + btree + hash, put/get/cursor/txn commit+abort, checkpoint) reached **M = 506** alloc sites. It now also drives the warmer error paths functional tests miss:

- secondary index — `associate` + get-by-secondary + `pget`
- join cursor — `DB->join`
- bulk put/get — `DB_MULTIPLE_KEY` write buffer + `DB_MULTIPLE_KEY` cursor scan
- in-memory DB (NULL filename)
- subdatabase open (named DB in a container file)
- compaction — `DB->compact` with `DB_FREE_SPACE`
- `DB->stat`
- 2PC — `txn->prepare` then resolve

New baseline: **M = 947** (+441 sites, ~87% more failure points swept).

> `txn_recover` was intentionally left out: on a still-live in-process prepared txn it double-resolves and panics the region (`DB_RUNRECOVERY`). It is a separate-process recovery op; `prepare` alone reaches the new 2PC alloc sites.

## Results (deterministic, K = 1..947)

| Metric | old (M=506) | new (M=947) |
|--------|------:|------:|
| Failure points exercised | 506 | 947 |
| Clean error return | 467 | 861 |
| Clean/tolerated | 31 | 81 |
| **CRASH** | (4 root causes, since fixed) | **5** |
| HANG | 0 | 0 |
| DIRTY | 0 | 0 |

Plain-debug sweep: ~46s. ASan full one-shot sweep: ~2min. The four original bugs (PR #52) no longer reproduce on the current tree.

## New OOM bugs found — report only, NOT fixed here (per harness policy)

**Bug A — crash, K = 490, 491, 492, 493, 497** (plain-debug + ASan SEGV). NULL-deref on the hash-abort *undo* path, same stack for all five:
```
#0 __os_atomic_read (p=0xa4)            src/os/os_atomic.c:174
#1 __db_cursor  (MULTIVERSION check)    src/db/db_iface.c:370
#2 __ham_insdel_recover                 src/hash/hash_rec.c:84
#3 __txn_dispatch_undo / __txn_undo     src/txn/txn.c:1942,2036
#5 __txn_abort                          src/txn/txn.c:1242
#6 __txn_env_refresh                    src/txn/txn_region.c:252
#7 __env_refresh (at env close)         src/env/env_open.c:774
```
The wider workload leaves an aborted-hash txn to undo at env teardown; when an alloc on the undo path fails, `__ham_insdel_recover` opens a cursor on a dbp whose backing was never allocated. Repro: `DB_FI_FAIL_AT=490 ./libtool --mode=execute ./fi_sweep --one`.

**Bug B — ASan leak** (`__db_create_internal` OOM teardown). `src/db/db_method.c:206` frees only `dbp` + `dbp->mpf`, never `dbp->bt_internal` / `q_internal` (the access-method private struct from `__bam_db_create`/`__qam_db_create`), and sets `*dbpp = NULL` so the caller can't free it either. Repro: `DB_FI_FAIL_AT=503 ./.libs/fi_sweep --one`.

**Bug C — ASan leak** (`__db_join`, `src/db/db_join.c:93`). Allocates the join cursor, then leaks it when a later alloc in the join wiring fails. Repro: `DB_FI_FAIL_AT=641 ./.libs/fi_sweep --one`.

Bug A is caught by both the forking sweep (CRASH) and ASan (SEGV); Bugs B/C are leaks only ASan sees (advisory). Full detail + fix shapes in `test/faultinject/README.md`.

## CI

The full plain-debug sweep stays the gate; the ASan one-shot pass should sweep the full K = 1..M range (not stop at 260) so it reaches the new region past K = 480. That workflow update needs `workflow` token scope (agent pushes lack it), so it is staged as `test/faultinject/faultinject.yml.workflow` for a maintainer to sync into `.github/workflows/faultinject.yml`; the installed workflow file is left unchanged in this PR. Both jobs remain advisory (`continue-on-error`).

## Validation

Built + run in the nix dev shell (`--enable-debug --enable-faultinject`, plain and `CC=clang -fsanitize=address`). No engine code changed.