### PR TITLE
fix(db): free handle/join-cursor state on create-time OOM error paths

### DIFF
--- a/src/db/db_join.c
+++ b/src/db/db_join.c
@@ -227,6 +227,15 @@ err:	if (jc != NULL) {
 			__os_free(env, jc->j_fdupcurs);
 		if (jc->j_exhausted != NULL)
 			__os_free(env, jc->j_exhausted);
+		/*
+		 * j_key.data (malloc'd above) and j_rdata.data (DB_DBT_REALLOC)
+		 * are freed on the normal close path; free them here too or an
+		 * allocation failure after j_key.data was set leaks them.
+		 */
+		if (jc->j_key.data != NULL)
+			__os_free(env, jc->j_key.data);
+		if (jc->j_rdata.data != NULL)
+			__os_ufree(env, jc->j_rdata.data);
 		__os_free(env, jc);
 	}
 	if (dbc != NULL)

--- a/src/db/db_method.c
+++ b/src/db/db_method.c
@@ -204,6 +204,19 @@ __db_create_internal(dbpp, env, flags)
 	return (0);
 
 err:	if (dbp != NULL) {
+		/*
+		 * Free the access-method-specific handle state (bt_internal,
+		 * h_internal, q_internal, ...) that the __{bam,ham,heap,qam}_
+		 * db_create calls above may already have allocated before a later
+		 * failure on this path.  The close routines are NULL-safe (they
+		 * no-op when their *_internal is unset), so this is safe whether
+		 * or not each was reached.  Without this the handle's AM state
+		 * leaks -- *dbpp is left NULL, so the caller cannot free it either.
+		 */
+		(void)__bam_db_close(dbp);
+		(void)__ham_db_close(dbp);
+		(void)__heap_db_close(dbp);
+		(void)__qam_db_close(dbp, 0);
 		if (dbp->mpf != NULL)
 			(void)__memp_fclose(dbp->mpf, 0);
 		__os_free(env, dbp);


### PR DESCRIPTION
Two OOM memory leaks found by the extended malloc-fault injection sweep (#90):

- **`__db_create_internal`** (db_method.c): the `err:` path freed `dbp`+`mpf` but not the access-method state (`bt_internal`/`h_internal`/`q_internal`) already allocated by `__{bam,ham,heap,qam}_db_create`. `*dbpp` is left NULL so the caller can't free it either → leak on any create-time alloc failure. **Fix:** call the NULL-safe `__*_db_close` routines on `err:`.
- **`__db_join`** (db_join.c): `err:` freed the join cursor's sub-arrays + cursor but not `jc->j_key.data` (malloc'd) or `jc->j_rdata.data` (DB_DBT_REALLOC), both freed on normal close. **Fix:** free them on `err:` too.

## Verified
ASan malloc-injection sweep no longer reports either leak; `jointest` + `test001 btree/hash` pass.

## Deferred (documented, not in this PR)
The sweep also found **Bug A** — a deeper OOM crash: `__ham_insdel_recover` uses a half-rebuilt DB handle (invalid `mpf`) during txn-undo-at-env-close, crashing in `__memp_fget`. That's a recovery/`__dbreg_do_open`-under-OOM root cause; symptom-patching the derefs just moves the crash. Documented in `.agents/oom-recovery-bug-A.md` for a focused follow-up (make `__dbreg_id_to_db` return the OOM error instead of a garbage handle).