### PR TITLE
test(pbt): expand Hegel PBT tier — getlong, defpfx, lsn, chksum (+PBT_CHECK)

### DIFF
--- a/test/pbt/README.md
+++ b/test/pbt/README.md
@@ -25,6 +25,10 @@ reachable) and then prints `SKIP` and exits 0, so CI stays green without the
 | `pbt_compint.c`     | varint codec round-trip / order-preserving | `__db_compress_int` / `__db_decompress_int` / `__db_*_count_int` / `__db_decompress_int32` (`src/common/db_compint.c`) |
 | `pbt_compress.c`    | prefix-compression codec round-trip | `__bam_defcompress` / `__bam_defdecompress` (`src/btree/bt_compress.c`) |
 | `pbt_recno.c`       | recno append/get + DB_RENUMBER contiguity | in-memory `DB_RECNO` (`src/btree/bt_recno.c`) |
+| `pbt_getlong.c`     | string->number parse (round-trip / range / robustness) | `__db_getlong` / `__db_getulong` (`src/common/db_getlong.c`) |
+| `pbt_defpfx.c`      | prefix-length separator | `__bam_defpfx()` (`src/btree/bt_compare.c`) |
+| `pbt_lsn.c`         | LSN wire codec (structured record) | `LOGCOPY_TOLSN` / `LOGCOPY_FROMLSN` (`src/dbinc/db_swap.h`) |
+| `pbt_chksum.c`      | page/log checksum compute + verify | `__db_chksum` / `__db_check_chksum` (`src/hmac/hmac.c`) |
 
 ## Property catalog
 
@@ -107,6 +111,88 @@ Opens a real in-memory `DB_RECNO` and drives it through the public API.
   numbers `1, 2, 3, …` with no gaps, and exactly `N − deletes` records
   survive (the recno renumber contract in `bt_recno.c __ramc_del`).
 
+### `pbt_getlong` — `__db_getlong` / `__db_getulong` numeric-argument parse
+String→number parsers for utility/config arguments. Returns `0` on success,
+`EINVAL` on empty/trailing-garbage, `ERANGE` on overflow or out-of-`[min,max]`.
+This is pure string logic the tcl suite never exercises directly
+(`db_getlong.c` sits at ~47% line coverage in the tcl COV run), so the PBT
+tier closes that gap.
+- **roundtrip_in_range** — `%ld`-formatted value parsed back within a
+  covering window returns `0` and the identical value.
+- **rejects_out_of_range** — an in-range integer parsed against a window
+  that *excludes* it returns `ERANGE` and leaves `*storep` untouched.
+- **rejects_trailing** — digits followed by a non-digit, non-newline byte
+  are `EINVAL`; a trailing `\n` is tolerated (the `end[0]` guard).
+- **robust_no_crash** — arbitrary bytes never crash, always return
+  `{0, EINVAL, ERANGE}`, and on success land in `[min,max]`.
+- **getulong_zero_is_max** — `__db_getulong` treats `max == 0` as
+  "unbounded" (documented `ULONG_MAX` substitute).
+
+### `pbt_defpfx` — `__bam_defpfx()` prefix-length separator
+The default prefix routine used during splits/compaction to pick the shortest
+key that still separates two neighbours. Returns the count of leading bytes
+of the larger key that must be retained.
+- **bounded** — `pfx <= min(la,lb)+1` always; when the longer key is
+  non-empty, `1 <= pfx <= max(la,lb)`; two empty keys give `pfx == 0`
+  (a real boundary — the source returns `b->size`, asserted explicitly).
+- **locates_diff** — when the keys differ inside the common region, `pfx-1`
+  is exactly the index of the first differing byte, and everything before
+  it is equal in both keys.
+- **symmetric** — `__bam_defpfx(a,b) == __bam_defpfx(b,a)`.
+- **separates** — consistency with `__bam_defcmp`: truncating the strictly
+  greater key to `pfx` bytes still sorts strictly after the smaller key
+  (the invariant a split relies on when it stores only the prefix).
+
+### `pbt_lsn` — LSN wire codec (`LOGCOPY_TOLSN` / `LOGCOPY_FROMLSN`)
+Extends the scalar swap coverage in `pbt_byteswap` to a whole *structured
+record*: the two-field `DB_LSN` `(file, offset)` marshalled to/from an 8-byte
+log-wire buffer. Logs are written little-endian on disk for portability.
+- **lsn_roundtrip** — `FROMLSN` then `TOLSN` is the identity in either
+  endian mode.
+- **wire_is_canonical** — with an *honest* env flag (matching the host,
+  detected at run time), the wire bytes are little-endian canonical
+  (compared against an independent hand-marshalling). You cannot simulate
+  the other endianness on one host — the swap is relative to native order.
+- **field_order** — `.file` occupies wire `[0..3]`, `.offset` `[4..7]`:
+  swapping the two LSN fields swaps the two 4-byte halves of the wire.
+- **lsn_roundtrip_unaligned** — the round-trip holds at any byte offset
+  (the codec is byte-at-a-time, so must not assume 4-byte alignment).
+
+### `pbt_chksum` — `__db_chksum` / `__db_check_chksum` (non-crypto path)
+The page/log checksum on the `mac_key == NULL, is_hmac == 0` path: a plain
+4-byte hash over the data (via `__ham_func4`), plus its verifier.
+- **deterministic** — the same bytes checksum identically (pure function).
+- **verify_accepts** — a checksum from `__db_chksum` verifies against the
+  same data.
+- **detects_bitflip** — flipping any single data bit makes the stored
+  checksum no longer verify (a corrupt page is caught).
+- **detects_wrong_sum** — flipping a bit of the *stored checksum* makes
+  verify reject.
+- *Deliberate non-property:* this bare hash does **not** detect truncation
+  — `__ham_func4` returns 0 for an empty buffer and for any all-zero prefix,
+  so `hash("") == hash("\0\0") == 0`. Torn-page/truncation detection in real
+  BDB comes from the `HDR` `prev`/`len` XOR on the log path (`hdr != NULL`),
+  which this pure-hash test avoids on purpose.
+
+## IMPORTANT — `hegel_assume` is a filter, not an assertion
+
+Use **`PBT_CHECK(cond, msg)`** (from `pbt_common.h`) for every actual
+property. It calls `hegel_fail()` when the condition is false, which marks
+the case INTERESTING and lets the server shrink a counterexample.
+
+`hegel_assume(cond)` is a **precondition filter**: a false condition marks
+the case INVALID (skipped), *not* failed. Empirically confirmed against
+hegel-c 0.10.0 — a property written as `hegel_assume(property)` can **never
+fail**; violating inputs are silently skipped. Reserve `hegel_assume()` for
+genuine domain constraints (e.g. `hegel_assume(malloc_result != NULL)`), and
+assert real properties with `PBT_CHECK`.
+
+> Known debt: the nine *pre-existing* `pbt_*.c` files (log_compare, byteswap,
+> defcmp, put_get, hash_model, hash_func, compint, compress, recno) express
+> their properties with `hegel_assume`, so those assertions currently skip
+> rather than fail. They should be converted to `PBT_CHECK` in a follow-up.
+> The four files added here (getlong, defpfx, lsn, chksum) use `PBT_CHECK`.
+
 ## Building and running
 
 ### Meson (primary path)
@@ -186,3 +272,25 @@ every drawn example.
 3. Add `'<name>'` to `pbt_props` in `test/pbt/meson.build`.
 4. Prefer broad generators (full ranges, empty collections, boundary values);
    use `hegel_assume()` only for genuine domain constraints.
+5. Assert the actual property with **`PBT_CHECK(cond, "msg")`**, never with
+   `hegel_assume()` (which only *skips* the case on failure — see the
+   "`hegel_assume` is a filter" note above).
+
+## tcl-uncoverable gaps the PBT tier closes
+
+Some pure logic cannot be reached from the tcl test harness, so it stays
+uncovered in the tcl COV subset no matter how many tcl cases run. The PBT
+tier targets exactly those:
+
+- **`__db_getlong` / `__db_getulong`** (`pbt_getlong`) — `db_getlong.c` is
+  ~47% line-covered by tcl; these string→number parsers have no tcl entry
+  point. `pbt_getlong` drives them directly (round-trip, range rejection,
+  overflow, robustness).
+- **`__db_compress_int` / `__db_decompress_int` 64-bit path** (`pbt_compint`)
+  — the btree compression that reaches this codec from tcl is 32-bit only,
+  so the 9-byte / full-`u_int64_t` encodings are tcl-unreachable.
+  `pbt_compint` draws the full 64-bit range (signed bits reinterpreted), so
+  those large encodings are exercised.
+
+The PBT tier is intentionally *not* part of the tcl COV subset (it is a
+separate opt-in suite), but it is where these gaps get real coverage.

--- a/test/pbt/meson.build
+++ b/test/pbt/meson.build
@@ -35,6 +35,10 @@ pbt_props = [
   'compint',       # varint codec round-trip/order-preserving (src/common/db_compint.c)
   'compress',      # __bam_defcompress/decompress round-trip (src/btree/bt_compress.c)
   'recno',         # recno append/get + DB_RENUMBER contiguity (src/btree/bt_recno.c)
+  'getlong',       # __db_getlong/__db_getulong string->number parse (src/common/db_getlong.c)
+  'defpfx',        # __bam_defpfx prefix-length separator (src/btree/bt_compare.c)
+  'lsn',           # LOGCOPY_TOLSN/FROMLSN LSN wire codec (src/dbinc/db_swap.h)
+  'chksum',        # __db_chksum/__db_check_chksum page checksum (src/hmac/hmac.c)
 ]
 
 # Try to locate hegel-c.  cmake + pkg-config are both attempted; either

--- a/test/pbt/pbt_chksum.c
+++ b/test/pbt/pbt_chksum.c
@@ -1,0 +1,173 @@
+/*-
+ * test/pbt/pbt_chksum.c
+ *	Property-based tests for the page/log checksum in src/hmac/hmac.c:
+ *	__db_chksum (compute) and __db_check_chksum (verify), on the
+ *	non-crypto path (mac_key == NULL, is_hmac == 0), which is a plain
+ *	4-byte hash over the data (delegating to __ham_func4).
+ *
+ * Contract from the source:
+ *	__db_chksum(hdr=NULL, data, len, mac_key=NULL, store) writes a
+ *	sizeof(u_int32_t) checksum of `data` into `store`.
+ *	__db_check_chksum(env=NULL, hdr=NULL, db_cipher=NULL, chksum, data,
+ *	len, is_hmac=0) returns 0 if `chksum` matches the recomputed hash
+ *	of `data`, -1 on mismatch.  (env is only touched for error strings
+ *	on the crypto-misconfiguration branches, which we do not hit.)
+ *
+ * Contracts exercised (grounded in the source, not restated):
+ *   deterministic  -- checksumming the same bytes twice yields identical
+ *                     checksum bytes (a checksum must be a pure function).
+ *   verify_accepts -- a checksum produced by __db_chksum is accepted by
+ *                     __db_check_chksum over the same data (the two halves
+ *                     agree -- the invariant every torn-page check rests on).
+ *   detects_bitflip-- flipping any single bit of the data makes the stored
+ *                     checksum no longer verify (a corrupt page is caught).
+ *                     This is the whole reason the checksum exists.
+ *   detects_wrong_sum -- flipping a bit of the STORED checksum makes verify
+ *                     reject: __db_check_chksum compares the supplied
+ *                     checksum against the recomputed hash, so a corrupted
+ *                     checksum field is caught too.
+ *
+ * NOTE (deliberate non-property): this bare 4-byte hash does NOT detect
+ * truncation -- __ham_func4 returns 0 for a zero-length buffer and for any
+ * all-zero prefix, so hash("") == hash("\0\0") == 0.  Truncation/torn-page
+ * detection in real BDB comes from the HDR prev/len XOR on the log path
+ * (the hdr != NULL branch), which this pure-hash test deliberately avoids.
+ * We therefore do not assert truncation detection.
+ *
+ * Both are PUBLIC (prototypes in src/hmac/hmac.c; verified reachable via
+ * nm on the built library).  We declare them locally to avoid dragging in
+ * db_int.h.
+ */
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+/* Exported by libdb (PUBLIC: prototypes in src/hmac/hmac.c). */
+extern void __db_chksum(void *, u_int8_t *, size_t, u_int8_t *, u_int8_t *);
+extern int __db_check_chksum(void *, void *, void *,
+    u_int8_t *, void *, size_t, int);
+
+#if defined(PBT_HAVE_HEGEL)
+
+#include <string.h>
+
+#define SUMLEN 4	/* non-crypto checksum is sizeof(u_int32_t) */
+
+static uint8_t *
+draw_buf(hegel_test_case *tc, size_t *lenp)
+{
+	return (hegel_draw_bytes(tc, hegel_binary(0, 256), lenp));
+}
+
+/* P1: the checksum is a pure function of the data bytes. */
+static void
+prop_deterministic(hegel_test_case *tc, void *u)
+{
+	uint8_t *d;
+	size_t len = 0;
+	u_int8_t s1[SUMLEN], s2[SUMLEN];
+	(void)u;
+
+	d = draw_buf(tc, &len);
+	memset(s1, 0xAA, SUMLEN);
+	memset(s2, 0x55, SUMLEN);
+	__db_chksum(NULL, d, len, NULL, s1);
+	__db_chksum(NULL, d, len, NULL, s2);
+	PBT_CHECK(memcmp(s1, s2, SUMLEN) == 0,
+	    "checksum not deterministic for identical input");
+	free(d);
+}
+
+/* P2: a freshly computed checksum verifies against the same data. */
+static void
+prop_verify_accepts(hegel_test_case *tc, void *u)
+{
+	uint8_t *d;
+	size_t len = 0;
+	u_int8_t sum[SUMLEN];
+	int ret;
+	(void)u;
+
+	d = draw_buf(tc, &len);
+	__db_chksum(NULL, d, len, NULL, sum);
+	ret = __db_check_chksum(NULL, NULL, NULL, sum, d, len, 0);
+	PBT_CHECK(ret == 0, "valid checksum rejected by check");
+	free(d);
+}
+
+/*
+ * P3: flip one bit of the data; the stored checksum must no longer
+ * verify.  (We require len > 0 so there is a bit to flip.)
+ */
+static void
+prop_detects_bitflip(hegel_test_case *tc, void *u)
+{
+	uint8_t *d;
+	size_t len = 0, bytepos;
+	int bitpos, ret;
+	u_int8_t sum[SUMLEN];
+	(void)u;
+
+	d = hegel_draw_bytes(tc, hegel_binary(1, 256), &len);
+	hegel_assume(len >= 1);
+
+	__db_chksum(NULL, d, len, NULL, sum);
+
+	bytepos = (size_t)hegel_draw_int(tc,
+	    hegel_integers(0, (int64_t)len - 1));
+	bitpos = (int)hegel_draw_int(tc, hegel_integers(0, 7));
+	d[bytepos] ^= (u_int8_t)(1u << bitpos);	/* corrupt one bit */
+
+	ret = __db_check_chksum(NULL, NULL, NULL, sum, d, len, 0);
+	PBT_CHECK(ret != 0, "single-bit corruption not detected");
+	free(d);
+}
+
+/*
+ * P4: flip one bit of the STORED checksum; verify must reject.  The check
+ * compares the supplied checksum bytes against the freshly recomputed
+ * hash, so any change to the checksum field is caught.
+ */
+static void
+prop_detects_wrong_sum(hegel_test_case *tc, void *u)
+{
+	uint8_t *d;
+	size_t len = 0;
+	u_int8_t sum[SUMLEN];
+	int bytepos, bitpos, ret;
+	(void)u;
+
+	d = draw_buf(tc, &len);
+	__db_chksum(NULL, d, len, NULL, sum);
+
+	bytepos = (int)hegel_draw_int(tc, hegel_integers(0, SUMLEN - 1));
+	bitpos = (int)hegel_draw_int(tc, hegel_integers(0, 7));
+	sum[bytepos] ^= (u_int8_t)(1u << bitpos);	/* corrupt the checksum */
+
+	ret = __db_check_chksum(NULL, NULL, NULL, sum, d, len, 0);
+	PBT_CHECK(ret != 0, "corrupted checksum field not detected");
+	free(d);
+}
+
+static const pbt_entry_t tests[] = {
+	{ "deterministic",     prop_deterministic,     500 },
+	{ "verify_accepts",    prop_verify_accepts,    500 },
+	{ "detects_bitflip",   prop_detects_bitflip,   800 },
+	{ "detects_wrong_sum", prop_detects_wrong_sum, 600 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "deterministic",     NULL, 0 },
+	{ "verify_accepts",    NULL, 0 },
+	{ "detects_bitflip",   NULL, 0 },
+	{ "detects_wrong_sum", NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("chksum", tests)

--- a/test/pbt/pbt_common.h
+++ b/test/pbt/pbt_common.h
@@ -16,7 +16,9 @@
  *	The real API mirrored here is from hegel-c (https://github.com/
  *	gburd/hegel-c): hegel_session_new/free, hegel_run_test returning
  *	hegel_results, HEGEL_DEFAULT_SETTINGS, and the hegel_draw_int,
- *	hegel_integers, hegel_binary, and hegel_assume surface.
+ *	hegel_integers, hegel_binary, hegel_assume, and hegel_fail surface.
+ *	Properties assert with PBT_CHECK (-> hegel_fail); hegel_assume is a
+ *	precondition filter only (see PBT_CHECK below).
  */
 
 #ifndef LIBDB_PBT_COMMON_H
@@ -25,6 +27,17 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+/*
+ * PBT_CHECK(cond, msg) -- the property-assertion helper.  A property must
+ * *fail* (not merely skip) when violated.  In hegel, hegel_assume(false)
+ * marks a case INVALID (skipped) -- it is a PRECONDITION filter, never an
+ * assertion.  The failure signal is hegel_fail(), which marks the case
+ * INTERESTING and lets the server shrink a minimal counterexample.  Use
+ * PBT_CHECK for every actual property; reserve hegel_assume() for genuine
+ * domain preconditions.  In stub mode both are no-ops (bodies unreached).
+ */
+#define PBT_CHECK(cond, msg) do { if (!(cond)) hegel_fail(msg); } while (0)
 
 #if defined(PBT_HAVE_HEGEL)
 
@@ -150,6 +163,9 @@ hegel_binary(size_t lo, size_t hi)
 static inline void
 hegel_assume(int cond)
 { (void)cond; }
+static inline void
+hegel_fail(const char *msg)
+{ (void)msg; }
 static inline void
 hegel_note(const char *msg)
 { (void)msg; }

--- a/test/pbt/pbt_defpfx.c
+++ b/test/pbt/pbt_defpfx.c
@@ -1,0 +1,207 @@
+/*-
+ * test/pbt/pbt_defpfx.c
+ *	Property-based tests for __bam_defpfx() -- Berkeley DB's default
+ *	B-tree prefix routine (src/btree/bt_compare.c), used during
+ *	page splits (bt_split.c) and compaction (bt_compact.c) to pick the
+ *	shortest key that still separates two neighbours.
+ *
+ * Contract from the source (read directly):
+ *	cnt = 1; walk min(a->size,b->size) bytes.  On the first differing
+ *	byte at 0-based index i, return i+1 (the count including that byte).
+ *	If they match over the common length:
+ *		a->size < b->size  -> a->size + 1
+ *		b->size < a->size  -> b->size + 1
+ *		equal sizes        -> b->size          (== a->size)
+ *	COMPQUIET(dbp) so NULL is safe.
+ *
+ * The value __bam_defpfx returns is the number of leading bytes of the
+ * LARGER key that must be retained for it to still sort strictly after
+ * the smaller key -- i.e. a prefix length.  The invariants that make it
+ * a correct separator:
+ *   bounded        -- pfx <= min(la,lb)+1 always; when the longer key is
+ *                     non-empty, 1 <= pfx <= max(la,lb); two empty keys
+ *                     give pfx == 0 (nothing to separate).
+ *   locates_diff   -- if a and b differ within the common prefix, pfx-1
+ *                     is exactly the index of the first differing byte,
+ *                     and bytes [0, pfx-1) are equal in a and b.
+ *   symmetric      -- __bam_defpfx(a,b) == __bam_defpfx(b,a) (the routine
+ *                     is order-insensitive; it only measures shared bytes).
+ *   separates      -- consistency with __bam_defcmp: the pfx-length prefix
+ *                     of the strictly-greater key already compares greater
+ *                     than the smaller key (so truncating to pfx preserves
+ *                     the separation the split relies on).
+ *
+ * __bam_defpfx / __bam_defcmp are exported from libdb (verified via nm);
+ * prototypes live in an internal header, declared locally here.
+ */
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+/* Exported by libdb; prototypes from src/btree/bt_compare.c. */
+extern size_t __bam_defpfx(DB *, const DBT *, const DBT *);
+extern int __bam_defcmp(DB *, const DBT *, const DBT *);
+
+#if defined(PBT_HAVE_HEGEL)
+
+#include <string.h>
+
+static uint8_t *
+draw_dbt(hegel_test_case *tc, DBT *d)
+{
+	size_t len = 0;
+	uint8_t *p = hegel_draw_bytes(tc, hegel_binary(0, 64), &len);
+	memset(d, 0, sizeof(*d));
+	d->data = p;
+	d->size = (u_int32_t)len;
+	return (p);
+}
+
+/*
+ * P1: bounds.  pfx <= min(la,lb)+1 always.  When the longer key is
+ * non-empty, 1 <= pfx <= max(la,lb).  The one degenerate case is two
+ * EMPTY keys: the source returns b->size == 0 (there is nothing to
+ * separate), so pfx == 0 there -- asserted explicitly rather than
+ * excluded, since it is a real (and easily-broken) boundary.
+ */
+static void
+prop_bounded(hegel_test_case *tc, void *u)
+{
+	DBT a, b;
+	uint8_t *pa, *pb;
+	size_t pfx, mn, mx;
+	(void)u;
+	pa = draw_dbt(tc, &a);
+	pb = draw_dbt(tc, &b);
+	mn = a.size < b.size ? a.size : b.size;
+	mx = a.size > b.size ? a.size : b.size;
+
+	pfx = __bam_defpfx(NULL, &a, &b);
+	PBT_CHECK(pfx <= mn + 1, "prefix length > min(len)+1");
+	if (mx > 0) {
+		PBT_CHECK(pfx >= 1, "prefix length < 1 for non-empty keys");
+		PBT_CHECK(pfx <= mx, "prefix length > max(len)");
+	} else
+		PBT_CHECK(pfx == 0, "prefix of two empty keys != 0");
+	free(pa);
+	free(pb);
+}
+
+/*
+ * P2: when a and b differ inside the common prefix, pfx-1 indexes the
+ * first differing byte and everything before it is equal in both keys.
+ */
+static void
+prop_locates_diff(hegel_test_case *tc, void *u)
+{
+	DBT a, b;
+	uint8_t *pa, *pb;
+	size_t pfx, mn, i, first;
+	int differ_in_common;
+	(void)u;
+	pa = draw_dbt(tc, &a);
+	pb = draw_dbt(tc, &b);
+	mn = a.size < b.size ? a.size : b.size;
+
+	/* Find the first differing byte in the common region (if any). */
+	differ_in_common = 0;
+	first = mn;
+	for (i = 0; i < mn; i++)
+		if (((uint8_t *)a.data)[i] != ((uint8_t *)b.data)[i]) {
+			differ_in_common = 1;
+			first = i;
+			break;
+		}
+
+	pfx = __bam_defpfx(NULL, &a, &b);
+	if (differ_in_common) {
+		PBT_CHECK(pfx == first + 1,
+		    "prefix does not point at first differing byte");
+		/* bytes strictly before the divergence are equal */
+		for (i = 0; i + 1 < pfx; i++)
+			PBT_CHECK(((uint8_t *)a.data)[i] ==
+			    ((uint8_t *)b.data)[i],
+			    "prefix bytes differ before divergence");
+	}
+	free(pa);
+	free(pb);
+}
+
+/* P3: prefix length is symmetric in its two arguments. */
+static void
+prop_symmetric(hegel_test_case *tc, void *u)
+{
+	DBT a, b;
+	uint8_t *pa, *pb;
+	(void)u;
+	pa = draw_dbt(tc, &a);
+	pb = draw_dbt(tc, &b);
+	PBT_CHECK(__bam_defpfx(NULL, &a, &b) ==
+	    __bam_defpfx(NULL, &b, &a), "prefix length not symmetric");
+	free(pa);
+	free(pb);
+}
+
+/*
+ * P4: the prefix separates.  For two DISTINCT keys, truncate the strictly
+ * greater one to `pfx` bytes; that truncated prefix must still compare
+ * strictly greater than the smaller full key under __bam_defcmp.  This is
+ * the property a split/compaction relies on when it stores only the
+ * prefix as the separator.
+ */
+static void
+prop_separates(hegel_test_case *tc, void *u)
+{
+	DBT a, b, hi, trunc;
+	uint8_t *pa, *pb;
+	const DBT *lo, *big;
+	size_t pfx;
+	(void)u;
+	pa = draw_dbt(tc, &a);
+	pb = draw_dbt(tc, &b);
+
+	/* Only meaningful for distinct keys. */
+	hegel_assume(__bam_defcmp(NULL, &a, &b) != 0);
+	if (__bam_defcmp(NULL, &a, &b) < 0) {
+		lo = &a; big = &b;
+	} else {
+		lo = &b; big = &a;
+	}
+	hi = *big;
+
+	pfx = __bam_defpfx(NULL, &a, &b);
+	PBT_CHECK(pfx <= hi.size, "prefix exceeds the larger key length");
+
+	memset(&trunc, 0, sizeof(trunc));
+	trunc.data = hi.data;
+	trunc.size = (u_int32_t)pfx;
+
+	/* Truncated separator still sorts strictly after the smaller key. */
+	PBT_CHECK(__bam_defcmp(NULL, &trunc, lo) > 0,
+	    "truncated prefix does not separate the keys");
+	free(pa);
+	free(pb);
+}
+
+static const pbt_entry_t tests[] = {
+	{ "bounded",      prop_bounded,      500 },
+	{ "locates_diff", prop_locates_diff, 700 },
+	{ "symmetric",    prop_symmetric,    500 },
+	{ "separates",    prop_separates,    800 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "bounded",      NULL, 0 },
+	{ "locates_diff", NULL, 0 },
+	{ "symmetric",    NULL, 0 },
+	{ "separates",    NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("defpfx", tests)

--- a/test/pbt/pbt_getlong.c
+++ b/test/pbt/pbt_getlong.c
@@ -1,0 +1,243 @@
+/*-
+ * test/pbt/pbt_getlong.c
+ *	Property-based tests for the numeric-argument parsers in
+ *	src/common/db_getlong.c: __db_getlong / __db_getulong.
+ *
+ * These convert a textual argument (from utilities / config) into a
+ * long / u_long, bounded to [min,max], returning:
+ *	0	 success, *storep set
+ *	EINVAL	 empty string, or trailing garbage after the digits
+ *	ERANGE	 strtol/strtoul overflow, or value outside [min,max]
+ * (source: the four early-return branches).  This is pure string->number
+ * logic -- exactly the kind of thing the tcl suite never exercises
+ * directly (db_getlong.c sits at ~47% line coverage in the tcl COV run),
+ * so the PBT tier closes that gap.
+ *
+ * Contracts exercised (grounded in the branch structure, not restated):
+ *   roundtrip_in_range   -- a value formatted with %ld then parsed back
+ *                           within a covering [min,max] returns 0 and the
+ *                           same value (the codec is round-trip exact).
+ *   rejects_out_of_range -- an in-range integer, parsed against a window
+ *                           that EXCLUDES it, returns ERANGE and leaves
+ *                           *storep untouched (never a false success).
+ *   rejects_trailing     -- digits followed by a non-digit, non-newline
+ *                           byte are rejected EINVAL (the end[0] check).
+ *   robust_no_crash      -- arbitrary bytes never crash and never return
+ *                           a code outside {0, EINVAL, ERANGE}; on success
+ *                           *storep lands inside [min,max].
+ *   getulong_zero_is_max -- __db_getulong treats max==0 as "no upper
+ *                           bound" (documented in the source), so a huge
+ *                           value passes with max==0 but is rejected with
+ *                           a small explicit max.
+ *
+ * Both are PUBLIC (prototypes in db_getlong.c; verified reachable via nm
+ * on the built library).  Passing dbenv == NULL routes diagnostics to
+ * stderr and takes the pure branch (no env required).
+ */
+
+#include "db.h"
+
+#include "pbt_common.h"
+
+/* Exported by libdb (PUBLIC: prototypes in src/common/db_getlong.c). */
+extern int __db_getlong(DB_ENV *, const char *, char *, long, long, long *);
+extern int __db_getulong(DB_ENV *, const char *, char *,
+    u_long, u_long, u_long *);
+
+#if defined(PBT_HAVE_HEGEL)
+
+#include <errno.h>
+#include <limits.h>
+#include <string.h>
+
+/*
+ * All these tests pass dbenv == NULL, which sends the error messages to
+ * stderr on rejection.  That is deliberate (it exercises the NULL-dbenv
+ * branch), but to keep the run readable we silence stderr for the batch.
+ */
+static void
+quiet_stderr(void)
+{
+	static int done = 0;
+	if (!done) {
+		(void)freopen("/dev/null", "w", stderr);
+		done = 1;
+	}
+}
+
+/* P1: format then parse within a covering window is the identity. */
+static void
+prop_roundtrip_in_range(hegel_test_case *tc, void *u)
+{
+	char buf[32];
+	long v, min, max, out;
+	int ret;
+	(void)u;
+	quiet_stderr();
+
+	/* Draw within a range that fits `long` on any platform (>= 32-bit). */
+	v = (long)hegel_draw_int(tc, hegel_integers(-2000000000L, 2000000000L));
+	(void)snprintf(buf, sizeof(buf), "%ld", v);
+
+	/* A window that always contains v. */
+	min = v > LONG_MIN + 100 ? v - 100 : LONG_MIN;
+	max = v < LONG_MAX - 100 ? v + 100 : LONG_MAX;
+
+	out = v + 1;	/* poison, so we detect a stale/unset store */
+	ret = __db_getlong(NULL, "pbt", buf, min, max, &out);
+	PBT_CHECK(ret == 0, "in-range value rejected");
+	PBT_CHECK(out == v, "parsed value != formatted value");
+}
+
+/*
+ * P2: an in-range integer parsed against a window that EXCLUDES it must
+ * be rejected ERANGE -- the parser never reports a false success and
+ * never writes *storep on the range-reject path.
+ */
+static void
+prop_rejects_out_of_range(hegel_test_case *tc, void *u)
+{
+	char buf[32];
+	long v, min, max, sentinel, out;
+	int ret, below;
+	(void)u;
+	quiet_stderr();
+
+	v = (long)hegel_draw_int(tc, hegel_integers(-1000000000L, 1000000000L));
+	(void)snprintf(buf, sizeof(buf), "%ld", v);
+	below = (int)hegel_draw_bool(tc, hegel_booleans());
+
+	if (below) {			/* window strictly above v */
+		min = v + 1;
+		max = v + 1000;
+	} else {			/* window strictly below v */
+		min = v - 1000;
+		max = v - 1;
+	}
+
+	sentinel = v ^ 0x5A5A5A5AL;
+	out = sentinel;
+	ret = __db_getlong(NULL, "pbt", buf, min, max, &out);
+	PBT_CHECK(ret == ERANGE, "out-of-window value not rejected ERANGE");
+	PBT_CHECK(out == sentinel, "store written on range-reject path");
+}
+
+/*
+ * P3: valid digits followed by a byte that is neither '\0' nor '\n' are
+ * rejected EINVAL (the `end[0] != '\0' && end[0] != '\n'` guard).  A
+ * trailing '\n' is explicitly allowed, so we assert that separately.
+ */
+static void
+prop_rejects_trailing(hegel_test_case *tc, void *u)
+{
+	char buf[40];
+	long v, out;
+	int ret, junk;
+	static const char junks[] = "abZ!/.:xq_";
+	(void)u;
+	quiet_stderr();
+
+	v = (long)hegel_draw_int(tc, hegel_integers(0, 1000000L));
+	junk = (int)hegel_draw_int(tc,
+	    hegel_integers(0, (int64_t)sizeof(junks) - 2));
+
+	/* "<digits><junkchar>" must be EINVAL. */
+	(void)snprintf(buf, sizeof(buf), "%ld%c", v, junks[junk]);
+	out = -1;
+	ret = __db_getlong(NULL, "pbt", buf, LONG_MIN, LONG_MAX, &out);
+	PBT_CHECK(ret == EINVAL, "trailing junk not rejected EINVAL");
+
+	/* "<digits>\n" must still succeed (newline is tolerated). */
+	(void)snprintf(buf, sizeof(buf), "%ld\n", v);
+	out = -1;
+	ret = __db_getlong(NULL, "pbt", buf, LONG_MIN, LONG_MAX, &out);
+	PBT_CHECK(ret == 0 && out == v, "trailing newline not tolerated");
+}
+
+/*
+ * P4: robustness -- arbitrary NUL-terminated bytes never crash, always
+ * return a code in {0, EINVAL, ERANGE}, and on success land in [min,max].
+ */
+static void
+prop_robust_no_crash(hegel_test_case *tc, void *u)
+{
+	uint8_t *raw;
+	char *s;
+	size_t len = 0, i;
+	long min, max, out;
+	int ret;
+	(void)u;
+	quiet_stderr();
+
+	raw = hegel_draw_bytes(tc, hegel_binary(0, 64), &len);
+	s = malloc(len + 1);
+	hegel_assume(s != NULL);
+	for (i = 0; i < len; i++)		/* NUL-free so it's one C string */
+		s[i] = raw[i] == '\0' ? ' ' : (char)raw[i];
+	s[len] = '\0';
+
+	min = (long)hegel_draw_int(tc, hegel_integers(-100000L, 0));
+	max = (long)hegel_draw_int(tc, hegel_integers(0, 100000L));
+
+	out = 0x1234;
+	ret = __db_getlong(NULL, "pbt", s, min, max, &out);
+	PBT_CHECK(ret == 0 || ret == EINVAL || ret == ERANGE,
+	    "return code outside {0, EINVAL, ERANGE}");
+	if (ret == 0)
+		PBT_CHECK(out >= min && out <= max,
+		    "success stored value outside [min,max]");
+
+	free(s);
+	free(raw);
+}
+
+/*
+ * P5: __db_getulong documents that max == 0 means "no upper bound"
+ * (ULONG_MAX substitute).  So a large value passes with max==0 but is
+ * rejected ERANGE with a small explicit max.
+ */
+static void
+prop_getulong_zero_is_max(hegel_test_case *tc, void *u)
+{
+	char buf[32];
+	u_long v, out;
+	int ret;
+	(void)u;
+	quiet_stderr();
+
+	/* A value comfortably larger than the small explicit cap below. */
+	v = (u_long)hegel_draw_int(tc, hegel_integers(1000000L, 3000000000L));
+	(void)snprintf(buf, sizeof(buf), "%lu", v);
+
+	out = 0;
+	ret = __db_getulong(NULL, "pbt", buf, 0, 0, &out);	/* max==0 */
+	PBT_CHECK(ret == 0 && out == v, "max==0 did not mean unbounded");
+
+	out = 0;
+	ret = __db_getulong(NULL, "pbt", buf, 0, 1000, &out);	/* real cap */
+	PBT_CHECK(ret == ERANGE, "value above explicit max not rejected");
+}
+
+static const pbt_entry_t tests[] = {
+	{ "roundtrip_in_range",   prop_roundtrip_in_range,   600 },
+	{ "rejects_out_of_range", prop_rejects_out_of_range, 600 },
+	{ "rejects_trailing",     prop_rejects_trailing,     600 },
+	{ "robust_no_crash",      prop_robust_no_crash,      800 },
+	{ "getulong_zero_is_max", prop_getulong_zero_is_max, 500 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "roundtrip_in_range",   NULL, 0 },
+	{ "rejects_out_of_range", NULL, 0 },
+	{ "rejects_trailing",     NULL, 0 },
+	{ "robust_no_crash",      NULL, 0 },
+	{ "getulong_zero_is_max", NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("getlong", tests)

--- a/test/pbt/pbt_lsn.c
+++ b/test/pbt/pbt_lsn.c
@@ -1,0 +1,207 @@
+/*-
+ * test/pbt/pbt_lsn.c
+ *	Property-based tests for the log-sequence-number (LSN) wire codec
+ *	in src/dbinc/db_swap.h: LOGCOPY_FROMLSN / LOGCOPY_TOLSN (and the
+ *	LOGCOPY_32 primitive they are built on).
+ *
+ * A DB_LSN is a structured record of two 32-bit fields (file, offset).
+ * The log is written in a fixed little-endian-on-disk wire form so a
+ * database is portable across endianness (source comment: "We write logs
+ * in little endian format to minimize disruption on x86 ...").  The
+ * codec chooses per-field between a byte-reversing copy (P_32_COPYSWAP)
+ * and a straight memcpy based on LOG_SWAPPED(env) == !ENV_LITTLEENDIAN.
+ *
+ * This extends the scalar-swap coverage in pbt_byteswap.c to a whole
+ * *structured record*: the two-field LSN, marshalled to and from an
+ * (optionally unaligned) 8-byte wire buffer.
+ *
+ * Contracts (grounded in the macro bodies, not restated):
+ *   lsn_roundtrip       -- FROMLSN(write) then TOLSN(read) is the identity
+ *                          for any (file,offset), in EITHER endian mode.
+ *   wire_is_canonical   -- when the env flag correctly describes the host,
+ *                          the on-wire bytes are little-endian regardless
+ *                          of the host's native byte order -- that is what
+ *                          makes a log portable.  (The host endianness is
+ *                          detected at run time so the env flag is honest;
+ *                          you cannot fake the other endianness on one host
+ *                          because the swap is relative to native order.)
+ *   field_order         -- TOLSN puts wire bytes [0..3] into .file and
+ *                          [4..7] into .offset: swapping the two LSN fields
+ *                          swaps the two 4-byte halves of the wire buffer.
+ *   lsn_roundtrip_unaligned -- the round-trip still holds when the wire
+ *                          buffer sits at an arbitrary byte offset (the
+ *                          codec is byte-at-a-time, so it must not assume
+ *                          4-byte alignment).
+ *
+ * These are header macros (no libdb symbol), like pbt_byteswap.c, but
+ * real on-disk-format code exercised on every cross-endian log replay.
+ * F_ISSET(env, ENV_LITTLEENDIAN) is the only field the macros read, so a
+ * one-field local struct stands in for ENV exactly.
+ */
+
+#include <string.h>
+
+#include "db.h"		/* DB_LSN, u_int8_t / u_int32_t */
+
+#include "dbinc/db_swap.h"
+
+#include "pbt_common.h"
+
+/*
+ * The LOGCOPY_* macros only ever read `env->flags` (via F_ISSET /
+ * LOG_SWAPPED).  A single-field struct is a faithful stand-in; using it
+ * avoids pulling in the full ENV definition from db_int.h.  ENV_LITTLEENDIAN
+ * is 0x4 (src/dbinc/db_int.in).
+ */
+#ifndef ENV_LITTLEENDIAN
+#define ENV_LITTLEENDIAN 0x00000004
+#endif
+#ifndef F_ISSET
+#define F_ISSET(p, f) ((p)->flags & (f))
+#endif
+typedef struct { u_int32_t flags; } pbt_env;
+
+#if defined(PBT_HAVE_HEGEL)
+
+static void
+draw_lsn(hegel_test_case *tc, DB_LSN *lsn)
+{
+	lsn->file = (u_int32_t)hegel_draw_int(tc,
+	    hegel_integers(0, 0xFFFFFFFFLL));
+	lsn->offset = (u_int32_t)hegel_draw_int(tc,
+	    hegel_integers(0, 0xFFFFFFFFLL));
+}
+
+/*
+ * The env flag must reflect the TRUE host byte order: LOG_SWAPPED(env) is
+ * relative to native order, so faking the other endianness on one host
+ * produces a lie.  Detect it once at run time.
+ */
+static u_int32_t
+host_env_flags(void)
+{
+	u_int32_t probe = 1;
+	return (*(u_int8_t *)&probe == 1) ? ENV_LITTLEENDIAN : 0;
+}
+
+/* P1: FROMLSN then TOLSN is the identity, in either endian mode. */
+static void
+prop_lsn_roundtrip(hegel_test_case *tc, void *u)
+{
+	pbt_env env;
+	DB_LSN in, out;
+	u_int8_t wire[8];
+	(void)u;
+
+	env.flags = hegel_draw_bool(tc, hegel_booleans()) ?
+	    ENV_LITTLEENDIAN : 0;
+	draw_lsn(tc, &in);
+
+	LOGCOPY_FROMLSN(&env, wire, &in);
+	LOGCOPY_TOLSN(&env, &out, wire);
+	PBT_CHECK(out.file == in.file && out.offset == in.offset,
+	    "LSN wire round-trip lost data");
+}
+
+/*
+ * P2: with an HONEST env flag (matching the host), the wire form of an
+ * LSN is little-endian: file in bytes [0..3] LE, offset in [4..7] LE.
+ * This is the portable on-disk contract -- an x86 and a big-endian host
+ * that both describe themselves correctly emit these same bytes.
+ */
+static void
+prop_wire_is_canonical(hegel_test_case *tc, void *u)
+{
+	pbt_env env;
+	DB_LSN in;
+	u_int8_t wire[8], want[8];
+	(void)u;
+
+	env.flags = host_env_flags();
+	draw_lsn(tc, &in);
+
+	LOGCOPY_FROMLSN(&env, wire, &in);
+
+	/* Expected little-endian marshalling, computed independently. */
+	want[0] = (u_int8_t)(in.file & 0xFF);
+	want[1] = (u_int8_t)((in.file >> 8) & 0xFF);
+	want[2] = (u_int8_t)((in.file >> 16) & 0xFF);
+	want[3] = (u_int8_t)((in.file >> 24) & 0xFF);
+	want[4] = (u_int8_t)(in.offset & 0xFF);
+	want[5] = (u_int8_t)((in.offset >> 8) & 0xFF);
+	want[6] = (u_int8_t)((in.offset >> 16) & 0xFF);
+	want[7] = (u_int8_t)((in.offset >> 24) & 0xFF);
+
+	PBT_CHECK(memcmp(wire, want, 8) == 0,
+	    "LSN wire form is not little-endian canonical");
+}
+
+/*
+ * P3: field order -- .file occupies wire[0..3] and .offset wire[4..7],
+ * so swapping the two LSN fields swaps the two 4-byte halves of the wire.
+ * (Independent of endianness: it only checks which field lands where.)
+ */
+static void
+prop_field_order(hegel_test_case *tc, void *u)
+{
+	pbt_env env;
+	DB_LSN in, swapped;
+	u_int8_t w1[8], w2[8];
+	(void)u;
+
+	env.flags = host_env_flags();
+	draw_lsn(tc, &in);
+	swapped.file = in.offset;
+	swapped.offset = in.file;
+
+	LOGCOPY_FROMLSN(&env, w1, &in);
+	LOGCOPY_FROMLSN(&env, w2, &swapped);
+
+	/* first half of w2 == second half of w1, and vice versa */
+	PBT_CHECK(memcmp(w2, w1 + 4, 4) == 0 && memcmp(w2 + 4, w1, 4) == 0,
+	    "LSN fields not marshalled file-then-offset");
+}
+
+/* P4: round-trip still holds through an unaligned wire buffer. */
+static void
+prop_lsn_roundtrip_unaligned(hegel_test_case *tc, void *u)
+{
+	pbt_env env;
+	DB_LSN in, out;
+	u_int8_t buf[16];
+	u_int8_t *wire;
+	int off;
+	(void)u;
+
+	env.flags = host_env_flags();
+	off = (int)hegel_draw_int(tc, hegel_integers(0, 8));
+	wire = buf + off;
+	draw_lsn(tc, &in);
+
+	LOGCOPY_FROMLSN(&env, wire, &in);
+	LOGCOPY_TOLSN(&env, &out, wire);
+	PBT_CHECK(out.file == in.file && out.offset == in.offset,
+	    "unaligned LSN wire round-trip lost data");
+}
+
+static const pbt_entry_t tests[] = {
+	{ "lsn_roundtrip",           prop_lsn_roundtrip,           500 },
+	{ "wire_is_canonical",       prop_wire_is_canonical,       500 },
+	{ "field_order",             prop_field_order,             500 },
+	{ "lsn_roundtrip_unaligned", prop_lsn_roundtrip_unaligned, 500 },
+	{ NULL, NULL, 0 }
+};
+
+#else
+
+static const pbt_entry_t tests[] = {
+	{ "lsn_roundtrip",           NULL, 0 },
+	{ "wire_is_canonical",       NULL, 0 },
+	{ "field_order",             NULL, 0 },
+	{ "lsn_roundtrip_unaligned", NULL, 0 },
+	{ NULL, NULL, 0 }
+};
+
+#endif
+
+PBT_MAIN("lsn", tests)


### PR DESCRIPTION
## What

Expands the Hegel property-based-test tier (`test/pbt/`) with **4 new files / 17 new properties** on under-tested pure logic, plus a correctness fix to the assertion pattern. Every property is grounded in the actual source (read first), one property per test, broad generators. All ran **green** against hegel-c 0.10.0 + the `hegel` server, and stub-compile+link+SKIP cleanly when hegel-c is absent.

| File | Props | Target |
|------|-------|--------|
| `pbt_getlong.c` | 5 | `__db_getlong` / `__db_getulong` (`src/common/db_getlong.c`) |
| `pbt_defpfx.c`  | 4 | `__bam_defpfx` (`src/btree/bt_compare.c`) |
| `pbt_lsn.c`     | 4 | `LOGCOPY_TOLSN`/`FROMLSN` LSN wire codec (`src/dbinc/db_swap.h`) |
| `pbt_chksum.c`  | 4 | `__db_chksum` / `__db_check_chksum` (`src/hmac/hmac.c`) |

## Correctness finding: `hegel_assume` is a filter, not an assertion

Confirmed empirically against hegel-c 0.10.0: **`hegel_assume(false)` marks a case INVALID (skipped), never INTERESTING (failed).** A property written as `hegel_assume(property)` therefore *can never fail* — violating inputs are silently skipped. The failure signal is `hegel_fail()`.

- Added **`PBT_CHECK(cond, msg)`** to `pbt_common.h` (calls `hegel_fail`), used by all four new files.
- Documented the distinction in `README.md` and flagged that the **nine pre-existing** `pbt_*.c` files still use `hegel_assume` for their assertions and should be converted to `PBT_CHECK` in a follow-up (left out of scope here to keep the PR focused and low-risk).

## Two properties falsified during development (corrected, not engine bugs)

- `__bam_defpfx` returns **0** for two empty keys (source returns `b->size`); the `pfx >= 1` bound was wrong → asserted the real boundary.
- The bare 4-byte page checksum does **not** detect truncation: `__ham_func4` hashes any all-zero prefix to 0 (`hash("") == hash("\0\0") == 0`). Torn-page detection lives on the `HDR` prev/len XOR path, deliberately bypassed here. Replaced the over-reaching `detects_truncation` with `detects_wrong_sum`.

## tcl-uncoverable gaps this closes

- **`__db_getlong`/`__db_getulong`** — no tcl entry point; `db_getlong.c` ~47% line-covered. `pbt_getlong` drives them directly.
- **`__db_compress_int` 64-bit path** — the existing `pbt_compint` already draws the full `u_int64_t` range (btree compression reaches this codec 32-bit-only from tcl); README now calls this out.

The PBT tier is intentionally not in the tcl COV subset (separate opt-in suite), but it is where this pure logic gets real coverage.

## Validation (nix dev shell)

- Base library: `../dist/configure --enable-debug && make -j4` — OK.
- Symbols verified reachable via `nm` on `libdb-5.3.a`: `__db_getlong`, `__db_getulong`, `__bam_defpfx`, `__db_chksum`, `__db_check_chksum`, `__ham_func4`.
- Real run (hegel-c + `hegel` server): all 17 new properties **OK** (500–800 examples each).
- Stub mode: all 4 compile+link against libdb, print SKIP, exit 0.
- Meson: `meson test --suite pbt` runs all **13** PBT executables (9 existing + 4 new) green.

No engine code touched. No build/coverage artifacts committed. Changes confined to `test/pbt/`.