### PR TITLE
build(nix): add CBMC to the dev shell for formal-verification harnesses

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
             pkgs.meson pkgs.ninja pkgs.python3 pkgs.pkg-config
             pkgs.gcc pkgs.clang pkgs.autoconf pkgs.gnumake
             pkgs.tcl   # for the TCL test harness (--enable-test)
+            pkgs.cbmc  # bounded model checker for the formal-verification harnesses (test/cbmc)
           ] ++ pkgs.lib.optionals pkgs.stdenv.isLinux [
             pkgs.liburing  # Linux io_uring AIO backend (HAVE_IO_URING)
           ];


### PR DESCRIPTION
Adds `pkgs.cbmc` to `devShells.default` — a **dev-only** dependency (not a build or runtime input).

CBMC (C Bounded Model Checker) will formally verify — on the **actual C**, not a spec — the self-contained algorithmic functions where latent bugs hide: the varint codec (`__db_compress_int`/`__db_decompress_int`), page checksum (`__db_chksum`), deadlock cycle detection, log-record marshal/unmarshal, and page-item bounds (`__db_ret_okitem`). This is step (2) of the formal-verification plan (executable DST invariants + CBMC on algorithmic cores); the harnesses land in `test/cbmc/` in a follow-up PR.

Verified: `nix develop --command cbmc --version` → 6.9.0 on PATH; flake still evaluates and the default package builds.