### PR TITLE
test(pbt): convert toothless hegel_assume assertions to PBT_CHECK (64 across 9 files)

### DIFF
--- a/test/pbt/README.md
+++ b/test/pbt/README.md
@@ -187,11 +187,11 @@ fail**; violating inputs are silently skipped. Reserve `hegel_assume()` for
 genuine domain constraints (e.g. `hegel_assume(malloc_result != NULL)`), and
 assert real properties with `PBT_CHECK`.
 
-> Known debt: the nine *pre-existing* `pbt_*.c` files (log_compare, byteswap,
-> defcmp, put_get, hash_model, hash_func, compint, compress, recno) express
-> their properties with `hegel_assume`, so those assertions currently skip
-> rather than fail. They should be converted to `PBT_CHECK` in a follow-up.
-> The four files added here (getlong, defpfx, lsn, chksum) use `PBT_CHECK`.
+> All nine originally-`hegel_assume` property files (log_compare, byteswap,
+> defcmp, put_get, hash_model, hash_func, compint, compress, recno) now
+> assert with `PBT_CHECK`; only genuine domain/setup guards (draw/malloc/open
+> `!= NULL`) remain as `hegel_assume`.  The four files added in #97 (getlong,
+> defpfx, lsn, chksum) already use `PBT_CHECK`.
 
 ## Building and running
 

--- a/test/pbt/pbt_byteswap.c
+++ b/test/pbt/pbt_byteswap.c
@@ -40,7 +40,7 @@ prop_swap16_involution(hegel_test_case *tc, void *u)
 	v = orig = (u_int16_t)hegel_draw_int(tc, hegel_integers(0, 0xFFFF));
 	M_16_SWAP(v);
 	M_16_SWAP(v);
-	hegel_assume(v == orig);
+	PBT_CHECK(v == orig, "M_16_SWAP is not an involution");
 }
 
 /* P2: M_32_SWAP is an involution. */
@@ -52,7 +52,7 @@ prop_swap32_involution(hegel_test_case *tc, void *u)
 	v = orig = (u_int32_t)hegel_draw_int(tc, hegel_integers(0, 0xFFFFFFFFLL));
 	M_32_SWAP(v);
 	M_32_SWAP(v);
-	hegel_assume(v == orig);
+	PBT_CHECK(v == orig, "M_32_SWAP is not an involution");
 }
 
 /* P3: M_64_SWAP is an involution over the full 64-bit range. */
@@ -64,7 +64,7 @@ prop_swap64_involution(hegel_test_case *tc, void *u)
 	v = orig = (u_int64_t)hegel_draw_int(tc, hegel_integers(INT64_MIN, INT64_MAX));
 	M_64_SWAP(v);
 	M_64_SWAP(v);
-	hegel_assume(v == orig);
+	PBT_CHECK(v == orig, "M_64_SWAP is not an involution");
 }
 
 /* P4: one M_32_SWAP equals the manual reversal of the 4 bytes. */
@@ -78,8 +78,9 @@ prop_swap32_reverses_bytes(hegel_test_case *tc, void *u)
 	memcpy(a, &orig, 4);
 	M_32_SWAP(v);
 	memcpy(b, &v, 4);
-	hegel_assume(a[0] == b[3] && a[1] == b[2] &&
-	    a[2] == b[1] && a[3] == b[0]);
+	PBT_CHECK(a[0] == b[3] && a[1] == b[2] &&
+	    a[2] == b[1] && a[3] == b[0],
+	    "M_32_SWAP does not reverse the 4 bytes");
 }
 
 /*
@@ -103,8 +104,9 @@ prop_copyswap32_unaligned(hegel_test_case *tc, void *u)
 		src[i] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
 
 	P_32_COPYSWAP(src, dst);
-	hegel_assume(dst[0] == src[3] && dst[1] == src[2] &&
-	    dst[2] == src[1] && dst[3] == src[0]);
+	PBT_CHECK(dst[0] == src[3] && dst[1] == src[2] &&
+	    dst[2] == src[1] && dst[3] == src[0],
+	    "P_32_COPYSWAP does not reverse bytes (unaligned)");
 }
 
 /* P6: P_16_COPYSWAP into an unaligned destination reverses the 2 bytes. */
@@ -124,7 +126,8 @@ prop_copyswap16_unaligned(hegel_test_case *tc, void *u)
 	src[1] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
 
 	P_16_COPYSWAP(src, dst);
-	hegel_assume(dst[0] == src[1] && dst[1] == src[0]);
+	PBT_CHECK(dst[0] == src[1] && dst[1] == src[0],
+	    "P_16_COPYSWAP does not reverse bytes (unaligned)");
 }
 
 /*
@@ -146,11 +149,13 @@ prop_swap64_unaligned(hegel_test_case *tc, void *u)
 		p[i] = orig[i] = (u_int8_t)hegel_draw_int(tc, hegel_integers(0, 0xFF));
 
 	P_64_SWAP(p);
-	for (i = 0; i < 8; i++)
-		hegel_assume(p[i] == orig[7 - i]);	/* one swap reverses */
+	for (i = 0; i < 8; i++)				/* one swap reverses */
+		PBT_CHECK(p[i] == orig[7 - i],
+		    "P_64_SWAP does not reverse bytes (unaligned)");
 	P_64_SWAP(p);
-	for (i = 0; i < 8; i++)
-		hegel_assume(p[i] == orig[i]);		/* two swaps restore */
+	for (i = 0; i < 8; i++)				/* two swaps restore */
+		PBT_CHECK(p[i] == orig[i],
+		    "P_64_SWAP twice does not restore (unaligned)");
 }
 
 static const pbt_entry_t tests[] = {

--- a/test/pbt/pbt_compint.c
+++ b/test/pbt/pbt_compint.c
@@ -80,9 +80,10 @@ prop_roundtrip(hegel_test_case *tc, void *u)
 
 	v = draw_u64(tc);
 	n = __db_compress_int(buf, v);
-	hegel_assume(n >= 1 && n <= CMP_MAXLEN);
+	PBT_CHECK(n >= 1 && n <= CMP_MAXLEN,
+	    "__db_compress_int returned out-of-range length");
 	(void)__db_decompress_int(buf, &out);
-	hegel_assume(out == v);
+	PBT_CHECK(out == v, "varint roundtrip: decompress(compress(v)) != v");
 }
 
 /*
@@ -105,9 +106,12 @@ prop_count_agrees(hegel_test_case *tc, void *u)
 	back = __db_decompress_count_int(buf);
 	read_len = __db_decompress_int(buf, &out);
 
-	hegel_assume((u_int32_t)written == predicted);
-	hegel_assume(back == predicted);
-	hegel_assume((u_int32_t)read_len == predicted);
+	PBT_CHECK((u_int32_t)written == predicted,
+	    "__db_compress_int wrote a different byte count than count_int");
+	PBT_CHECK(back == predicted,
+	    "__db_decompress_count_int disagrees with count_int");
+	PBT_CHECK((u_int32_t)read_len == predicted,
+	    "__db_decompress_int length disagrees with count_int");
 }
 
 /*
@@ -136,11 +140,11 @@ prop_order_preserving(hegel_test_case *tc, void *u)
 		cmp = (la > lb) - (la < lb);	/* longer enc => larger value */
 
 	if (a < b)
-		hegel_assume(cmp < 0);
+		PBT_CHECK(cmp < 0, "varint encoding not order-preserving (a<b)");
 	else if (a > b)
-		hegel_assume(cmp > 0);
+		PBT_CHECK(cmp > 0, "varint encoding not order-preserving (a>b)");
 	else
-		hegel_assume(cmp == 0);
+		PBT_CHECK(cmp == 0, "varint encoding not order-preserving (a==b)");
 }
 
 /*
@@ -162,9 +166,12 @@ prop_int32_matches(hegel_test_case *tc, void *u)
 	n32 = __db_decompress_int32(buf, &out32);
 	n64 = __db_decompress_int(buf, &out64);
 
-	hegel_assume((u_int64_t)out32 == out64);
-	hegel_assume(out32 == (u_int32_t)v);
-	hegel_assume(n32 == n64);
+	PBT_CHECK((u_int64_t)out32 == out64,
+	    "int32 decoder value disagrees with 64-bit decoder");
+	PBT_CHECK(out32 == (u_int32_t)v,
+	    "int32 decoder value != original");
+	PBT_CHECK(n32 == n64,
+	    "int32 decoder byte count disagrees with 64-bit decoder");
 }
 
 static const pbt_entry_t tests[] = {

--- a/test/pbt/pbt_compress.c
+++ b/test/pbt/pbt_compress.c
@@ -92,21 +92,24 @@ prop_compress_roundtrip(hegel_test_case *tc, void *u)
 
 	ret = __bam_defcompress(NULL, &prevKey, &prevData, &key, &data, &dest);
 	/* enc[] is generously sized; a full buffer is not the property here. */
-	hegel_assume(ret == 0);
+	PBT_CHECK(ret == 0, "__bam_defcompress failed");
 
 	/* dest.size now holds the encoded length; feed it back to decompress. */
 	set_out(&dkey, outk, sizeof(outk));
 	set_out(&ddata, outd, sizeof(outd));
 	ret = __bam_defdecompress(NULL, &prevKey, &prevData, &dest,
 	    &dkey, &ddata);
-	hegel_assume(ret == 0);
+	PBT_CHECK(ret == 0, "__bam_defdecompress failed");
 
 	/* Round-trip identity for both key and data. */
-	hegel_assume(dkey.size == key.size);
-	hegel_assume(key.size == 0 || memcmp(dkey.data, key.data, key.size) == 0);
-	hegel_assume(ddata.size == data.size);
-	hegel_assume(data.size == 0 ||
-	    memcmp(ddata.data, data.data, data.size) == 0);
+	PBT_CHECK(dkey.size == key.size, "decompressed key size != key size");
+	PBT_CHECK(key.size == 0 || memcmp(dkey.data, key.data, key.size) == 0,
+	    "decompressed key bytes != key bytes");
+	PBT_CHECK(ddata.size == data.size,
+	    "decompressed data size != data size");
+	PBT_CHECK(data.size == 0 ||
+	    memcmp(ddata.data, data.data, data.size) == 0,
+	    "decompressed data bytes != data bytes");
 
 	free(pk);
 	free(pd);

--- a/test/pbt/pbt_defcmp.c
+++ b/test/pbt/pbt_defcmp.c
@@ -69,7 +69,8 @@ prop_reflexive(hegel_test_case *tc, void *u)
 	uint8_t *pa;
 	(void)u;
 	pa = draw_dbt(tc, &a);
-	hegel_assume(__bam_defcmp(NULL, &a, &a) == 0);
+	PBT_CHECK(__bam_defcmp(NULL, &a, &a) == 0,
+	    "__bam_defcmp(a, a) != 0 (not reflexive)");
 	free(pa);
 }
 
@@ -82,8 +83,9 @@ prop_antisymmetric(hegel_test_case *tc, void *u)
 	(void)u;
 	pa = draw_dbt(tc, &a);
 	pb = draw_dbt(tc, &b);
-	hegel_assume(sign(__bam_defcmp(NULL, &a, &b)) ==
-	    -sign(__bam_defcmp(NULL, &b, &a)));
+	PBT_CHECK(sign(__bam_defcmp(NULL, &a, &b)) ==
+	    -sign(__bam_defcmp(NULL, &b, &a)),
+	    "__bam_defcmp not antisymmetric in sign");
 	free(pa);
 	free(pb);
 }
@@ -103,9 +105,9 @@ prop_transitive(hegel_test_case *tc, void *u)
 	bc = sign(__bam_defcmp(NULL, &b, &c));
 	ac = sign(__bam_defcmp(NULL, &a, &c));
 	if (ab <= 0 && bc <= 0)
-		hegel_assume(ac <= 0);
+		PBT_CHECK(ac <= 0, "__bam_defcmp not transitive (a<=b<=c)");
 	if (ab >= 0 && bc >= 0)
-		hegel_assume(ac >= 0);
+		PBT_CHECK(ac >= 0, "__bam_defcmp not transitive (a>=b>=c)");
 	free(pa);
 	free(pb);
 	free(pc);
@@ -120,7 +122,8 @@ prop_matches_oracle(hegel_test_case *tc, void *u)
 	(void)u;
 	pa = draw_dbt(tc, &a);
 	pb = draw_dbt(tc, &b);
-	hegel_assume(sign(__bam_defcmp(NULL, &a, &b)) == oracle_cmp(&a, &b));
+	PBT_CHECK(sign(__bam_defcmp(NULL, &a, &b)) == oracle_cmp(&a, &b),
+	    "__bam_defcmp disagrees in sign with memcmp oracle");
 	free(pa);
 	free(pb);
 }

--- a/test/pbt/pbt_hash_func.c
+++ b/test/pbt/pbt_hash_func.c
@@ -66,8 +66,9 @@ prop_determinism(hegel_test_case *tc, void *u)
 
 	k = draw_key(tc, &len);
 	for (i = 0; i < NFUNCS; i++)
-		hegel_assume(FUNCS[i](NULL, k, (u_int32_t)len) ==
-		    FUNCS[i](NULL, k, (u_int32_t)len));
+		PBT_CHECK(FUNCS[i](NULL, k, (u_int32_t)len) ==
+		    FUNCS[i](NULL, k, (u_int32_t)len),
+		    "hash function is non-deterministic");
 	free(k);
 }
 
@@ -95,9 +96,10 @@ prop_length_honoring(hegel_test_case *tc, void *u)
 		memcpy(joined + plen, suffix, slen);
 
 	for (i = 0; i < NFUNCS; i++)
-		hegel_assume(
+		PBT_CHECK(
 		    FUNCS[i](NULL, prefix, (u_int32_t)plen) ==
-		    FUNCS[i](NULL, joined, (u_int32_t)plen));
+		    FUNCS[i](NULL, joined, (u_int32_t)plen),
+		    "hash depends on bytes past len (not length-honoring)");
 
 	free(prefix);
 	free(suffix);
@@ -118,7 +120,8 @@ prop_func5_is_fnv(hegel_test_case *tc, void *u)
 		h *= 16777619U;
 		h ^= k[i];
 	}
-	hegel_assume(__ham_func5(NULL, k, (u_int32_t)len) == h);
+	PBT_CHECK(__ham_func5(NULL, k, (u_int32_t)len) == h,
+	    "__ham_func5 != FNV-1 recurrence");
 	free(k);
 }
 

--- a/test/pbt/pbt_hash_model.c
+++ b/test/pbt/pbt_hash_model.c
@@ -121,31 +121,36 @@ prop_hash_matches_model(hegel_test_case *tc, void *u)
 			memset(&v, 0, sizeof(v));
 			v.data = vbuf;
 			v.size = (u_int32_t)vlen;
-			hegel_assume(dbp->put(dbp, NULL, &k, &v, 0) == 0);
+			PBT_CHECK(dbp->put(dbp, NULL, &k, &v, 0) == 0,
+			    "put into DB_HASH failed");
 			model[ki].present = 1;
 			model[ki].vlen = vlen;
 			if (vlen != 0)
 				memcpy(model[ki].val, vbuf, vlen);
 		} else if (op == 1) {		/* del */
 			int ret = dbp->del(dbp, NULL, &k, 0);
-			hegel_assume(ret == 0 || ret == DB_NOTFOUND);
+			PBT_CHECK(ret == 0 || ret == DB_NOTFOUND,
+			    "del returned an unexpected code");
 			/* del must succeed iff key was present. */
 			if (model[ki].present)
-				hegel_assume(ret == 0);
+				PBT_CHECK(ret == 0,
+				    "del of a present key did not succeed");
 			else
-				hegel_assume(ret == DB_NOTFOUND);
+				PBT_CHECK(ret == DB_NOTFOUND,
+				    "del of an absent key was not DB_NOTFOUND");
 			model[ki].present = 0;
 			model[ki].vlen = 0;
 		}
 		/* op == 2 (get) is covered by the check below. */
 
 		ok = check_key(dbp, &model[ki], ki);
-		hegel_assume(ok);
+		PBT_CHECK(ok, "DB_HASH disagrees with model after operation");
 	}
 
 	/* Final full agreement over the whole pool. */
 	for (ki = 0; ki < POOL_KEYS; ki++)
-		hegel_assume(check_key(dbp, &model[ki], ki));
+		PBT_CHECK(check_key(dbp, &model[ki], ki),
+		    "DB_HASH disagrees with model at end");
 
 	(void)dbp->close(dbp, 0);
 }

--- a/test/pbt/pbt_log_compare.c
+++ b/test/pbt/pbt_log_compare.c
@@ -40,7 +40,8 @@ prop_result_in_range(hegel_test_case *tc, void *u)
 	a = draw_lsn(tc);
 	b = draw_lsn(tc);
 	r = log_compare(&a, &b);
-	hegel_assume(r == -1 || r == 0 || r == 1);
+	PBT_CHECK(r == -1 || r == 0 || r == 1,
+	    "log_compare result not in {-1,0,1}");
 }
 
 /* P2: reflexivity -- log_compare(a, a) == 0. */
@@ -50,7 +51,8 @@ prop_reflexive(hegel_test_case *tc, void *u)
 	DB_LSN a;
 	(void)u;
 	a = draw_lsn(tc);
-	hegel_assume(log_compare(&a, &a) == 0);
+	PBT_CHECK(log_compare(&a, &a) == 0,
+	    "log_compare(a, a) != 0 (not reflexive)");
 }
 
 /* P3: antisymmetry -- log_compare(a, b) == -log_compare(b, a). */
@@ -61,7 +63,8 @@ prop_antisymmetric(hegel_test_case *tc, void *u)
 	(void)u;
 	a = draw_lsn(tc);
 	b = draw_lsn(tc);
-	hegel_assume(log_compare(&a, &b) == -log_compare(&b, &a));
+	PBT_CHECK(log_compare(&a, &b) == -log_compare(&b, &a),
+	    "log_compare not antisymmetric");
 }
 
 /* P4: transitivity -- a<=b and b<=c imply a<=c (and the strict/equal
@@ -80,13 +83,13 @@ prop_transitive(hegel_test_case *tc, void *u)
 	ac = log_compare(&a, &c);
 	/* If a<=b and b<=c then a<=c. */
 	if (ab <= 0 && bc <= 0)
-		hegel_assume(ac <= 0);
+		PBT_CHECK(ac <= 0, "log_compare not transitive (a<=b<=c)");
 	/* If a>=b and b>=c then a>=c. */
 	if (ab >= 0 && bc >= 0)
-		hegel_assume(ac >= 0);
+		PBT_CHECK(ac >= 0, "log_compare not transitive (a>=b>=c)");
 	/* If a==b and b==c then a==c. */
 	if (ab == 0 && bc == 0)
-		hegel_assume(ac == 0);
+		PBT_CHECK(ac == 0, "log_compare not transitive (a==b==c)");
 }
 
 static const pbt_entry_t tests[] = {

--- a/test/pbt/pbt_put_get.c
+++ b/test/pbt/pbt_put_get.c
@@ -61,14 +61,15 @@ prop_put_get_roundtrip(hegel_test_case *tc, void *u)
 	val.size = (u_int32_t)vlen;
 
 	ret = dbp->put(dbp, NULL, &key, &val, DB_NOOVERWRITE);
-	hegel_assume(ret == 0);
+	PBT_CHECK(ret == 0, "put(NOOVERWRITE) of a fresh key failed");
 
 	ret = dbp->get(dbp, NULL, &key, &out, 0);
-	hegel_assume(ret == 0);
+	PBT_CHECK(ret == 0, "get of a just-put key failed");
 
 	/* Round-trip identity: same length and same bytes. */
-	hegel_assume(out.size == val.size);
-	hegel_assume(val.size == 0 || memcmp(out.data, val.data, val.size) == 0);
+	PBT_CHECK(out.size == val.size, "get returned wrong value size");
+	PBT_CHECK(val.size == 0 || memcmp(out.data, val.data, val.size) == 0,
+	    "get returned wrong value bytes");
 
 	(void)dbp->close(dbp, 0);
 	free(kbuf);
@@ -98,7 +99,7 @@ prop_get_missing_notfound(hegel_test_case *tc, void *u)
 	key.size = (u_int32_t)klen;
 
 	ret = dbp->get(dbp, NULL, &key, &out, 0);
-	hegel_assume(ret == DB_NOTFOUND);
+	PBT_CHECK(ret == DB_NOTFOUND, "get of an absent key did not return DB_NOTFOUND");
 
 	(void)dbp->close(dbp, 0);
 	free(kbuf);

--- a/test/pbt/pbt_recno.c
+++ b/test/pbt/pbt_recno.c
@@ -94,16 +94,17 @@ prop_put_get_roundtrip(hegel_test_case *tc, void *u)
 	hegel_assume(dbp != NULL);
 
 	rec = recno_append(dbp, vbuf, vlen);
-	hegel_assume(rec != 0);
+	PBT_CHECK(rec != 0, "DB_APPEND did not assign a record number");
 
 	memset(&key, 0, sizeof(key));
 	memset(&out, 0, sizeof(out));
 	key.data = &rec;
 	key.size = sizeof(rec);
 	ret = dbp->get(dbp, NULL, &key, &out, 0);
-	hegel_assume(ret == 0);
-	hegel_assume(out.size == (u_int32_t)vlen);
-	hegel_assume(memcmp(out.data, vbuf, vlen) == 0);
+	PBT_CHECK(ret == 0, "get of appended record failed");
+	PBT_CHECK(out.size == (u_int32_t)vlen, "appended record read back wrong size");
+	PBT_CHECK(memcmp(out.data, vbuf, vlen) == 0,
+	    "appended record read back wrong bytes");
 
 	(void)dbp->close(dbp, 0);
 	free(vbuf);
@@ -132,7 +133,8 @@ prop_renumber_contiguous(hegel_test_case *tc, void *u)
 	/* Append n records (1..n). */
 	n = (int)hegel_draw_int(tc, hegel_integers(1, 30));
 	for (i = 0; i < n; i++)
-		hegel_assume(recno_append(dbp, payload, sizeof(payload)) != 0);
+		PBT_CHECK(recno_append(dbp, payload, sizeof(payload)) != 0,
+		    "append during renumber setup failed");
 	live = n;
 
 	/* Delete ndel records, each at a currently-valid position. */
@@ -144,12 +146,12 @@ prop_renumber_contiguous(hegel_test_case *tc, void *u)
 		key.data = &rec;
 		key.size = sizeof(rec);
 		ret = dbp->del(dbp, NULL, &key, 0);
-		hegel_assume(ret == 0);
+		PBT_CHECK(ret == 0, "del of an in-range record failed");
 		live--;
 	}
 
 	/* Walk every live record; recnos must be 1, 2, 3, ... contiguously. */
-	hegel_assume(dbp->cursor(dbp, NULL, &dbc, 0) == 0);
+	PBT_CHECK(dbp->cursor(dbp, NULL, &dbc, 0) == 0, "cursor open failed");
 	expected = 1;
 	for (;;) {
 		memset(&key, 0, sizeof(key));
@@ -157,14 +159,15 @@ prop_renumber_contiguous(hegel_test_case *tc, void *u)
 		ret = dbc->get(dbc, &key, &data, DB_NEXT);
 		if (ret == DB_NOTFOUND)
 			break;
-		hegel_assume(ret == 0);
-		hegel_assume(key.size == sizeof(walk));
+		PBT_CHECK(ret == 0, "cursor DB_NEXT failed");
+		PBT_CHECK(key.size == sizeof(walk), "cursor recno key wrong size");
 		memcpy(&walk, key.data, sizeof(walk));
-		hegel_assume(walk == expected);	/* no gaps, in order */
+		PBT_CHECK(walk == expected, "renumber left a gap or wrong order");
 		expected++;
 	}
 	/* Exactly `live` records survived, numbered 1..live. */
-	hegel_assume((int)(expected - 1) == live);
+	PBT_CHECK((int)(expected - 1) == live,
+	    "surviving record count != N - deletes");
 
 	(void)dbc->close(dbc);
 	(void)dbp->close(dbp, 0);


### PR DESCRIPTION
**Test-validity fix.** The 9 pre-#97 PBT files used \`hegel_assume\` (a skip-*filter*) for their property **assertions** — so those assertions silently SKIPPED instead of FAILING and **could never catch a bug** (false confidence, worse than no test).

Converted **64 real assertions → \`PBT_CHECK\`** (→ \`hegel_fail\`) across the 9 files, keeping only the 10 legitimate NULL-guard/domain filters as \`hegel_assume\`.

## Teeth-proof (same broken condition, two ways — then reverted)
| probe | with PBT_CHECK | with hegel_assume |
|-------|:--:|:--:|
| compint `out==v && v!=0` | **FAIL at v=0** | `OK (800 valid)` — false green |
| log_compare `==0 && offset!=0` | **FAIL at offset=0** | `OK (72 valid)` — false green |
| byteswap `v==orig+1` | **FAIL** | rejected-all |

The identical broken condition is caught by PBT_CHECK but silently passed by hegel_assume — the toothless-test bug, demonstrated.

## Result
All 9 files **pass on correct code**; stub mode still compiles+links+SKIPs. **No real engine bug** was hiding behind the toothless tests. The PBT tier now genuinely has teeth.