### PR TITLE
fix(db): parenthesize HPAGE_PTYPE(p) macro arg — hash OOB read (found by CBMC)

### DIFF
--- a/src/dbinc/db_page.h
+++ b/src/dbinc/db_page.h
@@ -580,7 +580,7 @@ typedef struct _qpage {
  * field, it requires no alignment, and it's in the same location in all three
  * structures, there's a pair of macros.
  */
-#define	HPAGE_PTYPE(p)		(*(u_int8_t *)p)
+#define	HPAGE_PTYPE(p)		(*(u_int8_t *)(p))
 #define	HPAGE_TYPE(dbp, pg, indx)	(*P_ENTRY(dbp, pg, indx))
 
 /*


### PR DESCRIPTION
**Found by CBMC formal verification** of `__db_ret_okitem` (`test/cbmc/harness_okitem.c`) — a bug a fuzzer might take ages to hit, proved deterministically on the actual C.

`HPAGE_PTYPE(p)` was `(*(u_int8_t *)p)` — **no parens around `p`**. The two `__db_ret_okitem` call sites (`db_ret.c:102,106`) pass a compound arg:
```
HPAGE_PTYPE((u_int8_t *)h + off)
```
which expands to `*(u_int8_t *)h + off` = **`page[0] + off`** (read byte 0, add offset) instead of the intended **`page[off]`** (the item's type byte).

**Consequence:** on a hash page, `okitem` misreads the item type → can fail to recognize an `H_OFFPAGE` item → **skips the check that the item's `HOFFPAGE` header fits on the page** → returns "safe" for an item whose header runs past the page end = **OOB read** (the hash counterpart of #67; the very guard the fuzzer-hardening added, defeated by its own macro use).

**Fix:** `(*(u_int8_t *)(p))`. Corrects both okitem sites; the third caller (`db_ret.c:178`, bare pointer) was unaffected.

## Proof
With page-type byte 8 at offset 0 and an `H_OFFPAGE` item at off=58: old macro → `8+58=66` (misses OFFPAGE → OOB); fixed → `page[58]=3=H_OFFPAGE` (detects → bounds-checks). Build clean; `hash test001/025` + `btree test001` pass; all 4 fuzz reproducers pass.

Depends on / found by #101 (CBMC harnesses).