### PR TITLE
test(dst): +8 fault scenarios, +3 planted bugs, 32-scenario swarm

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1674,6 +1674,63 @@ test_sim_ckp_lsn: test_sim_ckp_lsn@o@ $(DEF_LIB)
 	    $(LDFLAGS) test_sim_ckp_lsn@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
 	$(POSTLINK) $@
 
+test_sim_multidb_crash@o@: $(testdir)/sim/test_sim_multidb_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_multidb_crash: test_sim_multidb_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_multidb_crash@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_largeabort@o@: $(testdir)/sim/test_sim_largeabort.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_largeabort: test_sim_largeabort@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_largeabort@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_log_enospc@o@: $(testdir)/sim/test_sim_log_enospc.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_log_enospc: test_sim_log_enospc@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_log_enospc@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_data_log_order@o@: $(testdir)/sim/test_sim_data_log_order.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_data_log_order: test_sim_data_log_order@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_data_log_order@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_torn_meta@o@: $(testdir)/sim/test_sim_torn_meta.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_torn_meta: test_sim_torn_meta@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_torn_meta@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_stale_meta@o@: $(testdir)/sim/test_sim_stale_meta.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_stale_meta: test_sim_stale_meta@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_stale_meta@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_compound_fault@o@: $(testdir)/sim/test_sim_compound_fault.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_compound_fault: test_sim_compound_fault@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_compound_fault@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_logrollover_crash@o@: $(testdir)/sim/test_sim_logrollover_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_logrollover_crash: test_sim_logrollover_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_logrollover_crash@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_hash_crash test_sim_recno_crash test_sim_queue_crash \
 	test_sim_ckp_crash test_sim_torn_log test_sim_enospc \
@@ -1682,7 +1739,9 @@ dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_ckp_enospc test_sim_split_torn test_sim_recover_corrupt \
 	test_sim_multi_fault test_sim_secondary_crash test_sim_largetxn_crash \
 	test_sim_cursor_crash test_sim_latency_load test_sim_swarm \
-	test_sim_ckp_lsn
+	test_sim_ckp_lsn test_sim_multidb_crash test_sim_largeabort \
+	test_sim_log_enospc test_sim_data_log_order test_sim_torn_meta \
+	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/src/db/db_rec.c
+++ b/src/db/db_rec.c
@@ -17,6 +17,10 @@
 #include "dbinc/btree.h"
 #include "dbinc/hash.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 static int __db_pg_free_recover_int __P((ENV *, DB_THREAD_INFO *,
     __db_pg_freedata_args *, DB *, DB_LSN *, DB_MPOOLFILE *, db_recops, int));
 static int __db_pg_free_recover_42_int __P((ENV *, DB_THREAD_INFO *,
@@ -81,10 +85,31 @@ __db_addrem_recover(env, dbtp, lsnp, op, info)
 	}
 
 	if (modified) {
+#if defined(HAVE_DST)
+#if DB_DST_BUG(6)
+		/*
+		 * PLANTED BUG REDONOSTAMP (DB_DST_INJECT_BUG=6): apply the
+		 * redo/undo but SKIP stamping the page LSN, so LSN(pagep)
+		 * never advances past this record.  The idempotency guard
+		 * (cmp_p == 0) therefore still holds on a SECOND recovery
+		 * pass, which re-applies the same redo -- recovery is no
+		 * longer idempotent.  test_sim_recover_idempotent's
+		 * "identical state hash across two recoveries" invariant
+		 * fires.  Compiled out of every normal build.
+		 */
+		;
+#else
 		if (DB_REDO(op))
 			LSN(pagep) = *lsnp;
 		else
 			LSN(pagep) = argp->pagelsn;
+#endif
+#else
+		if (DB_REDO(op))
+			LSN(pagep) = *lsnp;
+		else
+			LSN(pagep) = argp->pagelsn;
+#endif
 	}
 
 	if ((ret = __memp_fput(mpf, ip, pagep, dbc->priority)) != 0)

--- a/src/log/log_put.c
+++ b/src/log/log_put.c
@@ -1336,8 +1336,27 @@ __log_write(dblp, addr, len)
 	 * since we last did).
 	 */
 	if ((ret = __os_io(env, DB_IO_WRITE,
-	    dblp->lfhp, 0, 0, lp->w_off, len, addr, &nw)) != 0)
+	    dblp->lfhp, 0, 0, lp->w_off, len, addr, &nw)) != 0) {
+#if defined(HAVE_DST)
+#if DB_DST_BUG(8)
+		/*
+		 * PLANTED BUG LOGWRITEIGNORE (DB_DST_INJECT_BUG=8): swallow
+		 * the log write error (e.g. ENOSPC / EIO) and fall through as
+		 * if the record reached the file, advancing lp->w_off.  A
+		 * commit is then acked whose log bytes never persisted; after
+		 * a crash the record is gone.  test_sim_log_enospc's "an
+		 * acked commit whose log write failed must not silently
+		 * vanish" invariant fires.  Compiled out of every normal
+		 * build.
+		 */
+		ret = 0;
+#else
 		return (ret);
+#endif
+#else
+		return (ret);
+#endif
+	}
 
 	/* Reset the buffer offset and update the seek offset. */
 	lp->w_off += len;

--- a/src/mp/mp_sync.c
+++ b/src/mp/mp_sync.c
@@ -15,6 +15,10 @@
 #include "dbinc/db_page.h"
 #include "dbinc/hash.h"
 
+#ifdef HAVE_DST
+#include "sim_inject.h"			/* DST planted-bug harness. */
+#endif
+
 typedef struct {
 	DB_MPOOL_HASH *track_hp;	/* Hash bucket. */
 
@@ -661,8 +665,29 @@ done:	/*
 	if (ret == 0 && required_write) {
 		if (dbmfp == NULL)
 			ret = __memp_sync_files(env);
+#if defined(HAVE_DST)
+#if DB_DST_BUG(7)
+		/*
+		 * PLANTED BUG SYNCSKIP (DB_DST_INJECT_BUG=7): a single-file
+		 * sync (db->sync / checkpoint of one file) WRITES the dirty
+		 * pages but SKIPS the fsync, then reports success.  The
+		 * pages reached the file via pwrite, but the durable frontier
+		 * never advances, so a power loss (write-back crash) drops
+		 * them.  With no log to redo (a non-txn env), the flushed
+		 * records are gone after the crash; test_sim_ckp_crash's
+		 * "every synced record survives" invariant fires.  Compiled
+		 * out of every normal build.
+		 */
+		else
+			ret = 0;
+#else
 		else
 			ret = __os_fsync(env, dbmfp->fhp);
+#endif
+#else
+		else
+			ret = __os_fsync(env, dbmfp->fhp);
+#endif
 	}
 
 	/* If we've opened files to flush pages, close them. */

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -6,10 +6,10 @@ Status: **v1 foundation landed + v1.x depth grown** (this branch). Seeded
 PRNG tree, determinism
 guard, buggify, simulated-I/O fault knobs, the write-back-cache durable-frontier
 crash model, the `__os_*` I/O hooks, a `--enable-dst` build switch that is
-zero-overhead when off, and a **24-scenario** catalog plus a FoundationDB-style
-**swarm runner** with per-fault activation coverage and **five** planted-bug
-yardsticks. Modeled on FoundationDB / TigerBeetle and the xtc project's
-DST (`/home/gburd/ws/xtc`).
+zero-overhead when off, and a **32-scenario** catalog plus a FoundationDB-style
+**swarm runner** with per-fault activation coverage (now with a hard
+coverage-gap guard) and **eight** planted-bug yardsticks. Modeled on
+FoundationDB / TigerBeetle and the xtc project's DST (`/home/gburd/ws/xtc`).
 
 This document is the PLAN. It records what shipped, the honest architectural
 gap vs xtc, and the full scenario catalog to grow into.
@@ -242,7 +242,7 @@ replay of the same seed would fail.
 
 ## 3. Scenarios (all runnable now, all PASS)
 
-Twenty-four scenarios (plus the swarm runner); the crash/fault ones each pass
+Thirty-two scenarios (plus the swarm runner); the crash/fault ones each pass
 across a multi-seed sweep and replay bit-identically per seed.
 
 | Scenario | Proves | Result |
@@ -271,7 +271,15 @@ across a multi-seed sweep and replay bit-identically per seed.
 | `test_sim_multi_fault` | latency + ENOSPC both active across a crash; committed durable, no corruption | PASS |
 | `test_sim_latency_load` | slow disk makes forward progress; committed set byte-identical to fast disk | PASS (latency fires) |
 | `test_sim_ckp_lsn` | checkpoint LSN is the correct recovery start; pre+post-ckp committed survive | PASS (catches CKPBADLSN) |
-| `test_sim_swarm` | **swarm**: mixed-fault sweep, per-fault activation coverage, replay | PASS (256 seeds, 0 violations) |
+| `test_sim_multidb_crash` | 3 sub-databases in one file+log recover mutually consistent; committed survives, uncommitted gone, each sub-tree verifies | PASS (144 records / 3 sub-dbs) |
+| `test_sim_largeabort` | a 1500-op txn EXPLICITLY aborted leaves no trace, a following committed txn survives, across a crash | PASS (1500 aborted / 300 committed) |
+| `test_sim_log_enospc` | ENOSPC on the LOG write: every ACKED commit is durable, failed commits cleanly absent (catches LOGWRITEIGNORE) | PASS (e.g. 184 acked, 0 lost) |
+| `test_sim_data_log_order` | the durability window: NOSYNC commits made durable ONLY by a checkpoint survive a crash (log durable before data trusted) | PASS (96 NOSYNC commits) |
+| `test_sim_torn_meta` | torn write of the METADATA page during a checkpoint: caught by the checksum (clean error or correct), never silent-bad | PASS |
+| `test_sim_stale_meta` | stale read of a real DB meta page after overwrite: caught by the page LSN+checksum, never silent-bad | PASS (stale reads fired) |
+| `test_sim_compound_fault` | latency + ENOSPC + torn all active at once across a crash: durable prefix intact, tree clean, no silent-bad | PASS (3 faults fire) |
+| `test_sim_logrollover_crash` | crash with the WAL spread over multiple log files: every commit survives across the rollover boundary | PASS (400 commits / 3 log files) |
+| `test_sim_swarm` | **swarm**: mixed-fault sweep, per-fault activation coverage + gap guard, replay | PASS (512 seeds, 0 violations) |
 
 **Recovery-before-verify discipline** (from
 `.agents/concurrent-btree-corruption.md`): a crashed txn env verified *without*
@@ -279,7 +287,7 @@ recovery falsely looks corrupt. `test_sim_crash_recover` **always** runs
 `DB_RECOVER` before `db->verify`.
 
 **Planted-bug harness** (`sim_inject.h`, `DB_DST_INJECT_BUG=<n>`) — the
-FoundationDB-grade "DST finds real bugs" proof, LANDED. **Five** known bugs
+FoundationDB-grade "DST finds real bugs" proof, LANDED. **Eight** known bugs
 planted at real library sites, each caught by a scenario within **K=1**
 seeds (`test/sim/dst-bug-inject.sh` builds a dedicated library per bug and
 asserts the catch, reporting the catch-latency K):
@@ -291,9 +299,12 @@ asserts the catch, reporting the catch-latency K):
 | 3 LOSTUPDATE | `__memp_pgwrite` (mp_bh.c) skips a dirty-page write, reports success | `test_sim_ckp_crash` | flushed records lost after crash (no log to redo) |
 | 4 ABORTNOUNDO | `__txn_abort` (txn.c) skips the `__txn_undo` rollback pass | `test_sim_abort_atomic` | aborted txn's changes left in place; recovery hits a log-sequence error |
 | 5 CKPBADLSN | `__txn_checkpoint` (txn_chkpt.c) writes a checkpoint record with a wrong (too-far-forward) `ckp_lsn` | `test_sim_ckp_lsn` | recovery starts too late; post-checkpoint committed txns lost |
+| 6 REDONOSTAMP | `__db_addrem_recover` (db_rec.c) applies a redo but skips the page-LSN stamp | `test_sim_recover_idempotent` | a second recovery re-applies the same redo -- recovery is not idempotent |
+| 7 SYNCSKIP | `__memp_sync_int` (mp_sync.c) writes a single-file sync's pages but skips the fsync | `test_sim_ckp_crash` | pages written but not durable; write-back crash drops them, flushed records lost |
+| 8 LOGWRITEIGNORE | `__log_write` (log_put.c) ignores an `__os_io` write error and advances `w_off` | `test_sim_log_enospc` | a commit is acked whose log bytes never persisted; lost after crash |
 
-Measured catch-latency (dst-bug-inject.sh, K max 8): **all five caught at K=1**.
-A normal build (`DB_DST_INJECT_BUG` undefined) compiles all five out and every
+Measured catch-latency (dst-bug-inject.sh, K max 8): **all eight caught at K=1**.
+A normal build (`DB_DST_INJECT_BUG` undefined) compiles all eight out and every
 scenario passes; the OFF library has **0** `__db_sim_*` symbols (verified via
 `nm` on a fresh `--enable-debug` build tree).
 
@@ -312,18 +323,20 @@ re-reads versioned, self-checksummed pages and asserts the safety invariants:
   same seed produce identical result + activation counts).
 
 It reports pass/fail, distinct-result count (seed-sensitivity), and **per-fault
-activation** (seeds on which each class actually FIRED, not merely armed).
+activation** (seeds on which each class actually FIRED, not merely armed).  A
+sweep of ≥ 64 seeds fails hard if any fault class NEVER activates (a coverage
+gap that would let a regression silently stop arming a class slip through).
 
-**Measured (2000-seed soak):** 0 invariant violations; fault activation
-`torn=73.8% corrupt=72.9% stale=49.6% enospc=49.5% latency=75.2%
-shorteio=47.1%` — every fault class activates, no coverage gap. (torn/corrupt
+**Measured (512-seed swarm):** 0 invariant violations; fault activation
+`torn=74.0% corrupt=72.7% stale=49.6% enospc=49.4% latency=75.0%
+shorteio=49.4%` — every fault class activates, no coverage gap. (torn/corrupt
 exceed their ~50% armed rate because they share the IO corrupt knob, so arming
 either can fire both on writes and reads.)
 
 `test/sim/dst-swarm.sh` is the aggregate driver: it sweeps the FULL scenario set
 over a seed range (default 30 seeds/scenario) plus the fault-mix swarm, emitting
-one CI-readable summary. Measured: **24 scenarios × 20 seeds = 423 pass, 0
-fail**.
+one CI-readable summary. Measured: **32 scenarios × 10 seeds = 284 pass, 0
+fail** (and every new scenario passes a 20-seed sweep + replays bit-identically).
 
 ---
 
@@ -383,7 +396,7 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 2. **btree split/merge** churn across a crash + recovery — *v1* ✅ `test_sim_split_crash`.
 3. **hash** insert/lookup/delete round-trip under faults — *v1.x* ✅ `test_sim_hash_crash`.
 4. **recno / queue** append + consume across a crash — *v1.x* ✅ `test_sim_recno_crash`, `test_sim_queue_crash`.
-5. **secondary index / join** consistency after recovery — *v1.x* ✅ `test_sim_secondary_crash`.
+5. **secondary index / join** consistency after recovery — *v1.x* ✅ `test_sim_secondary_crash`; multi-file/sub-database recovery ✅ `test_sim_multidb_crash`.
 6. **large / overflow records** torn-write + checksum detection — *v1.x* ✅ `test_sim_overflow_torn`.
 7. **duplicate keys** (sorted/unsorted) survive crash+recover — *v1.x* ✅ `test_sim_dup_crash`.
 
@@ -392,26 +405,28 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 9. **ack-before-fsync bug caught** via the write-back frontier — *v1* ✅ planted bug 1, caught by the capstone.
 10. **torn log write**: recovery stops cleanly at the torn record — *v1.x* ✅ `test_sim_torn_log`.
 11. **log record checksum** mismatch detected on replay — *v1.x* ✅ (partial) `test_sim_recover_corrupt` (corrupt reads during recovery caught, never silent).
-12. **log file rollover** crash at the boundary, clean recovery — *v1.x*.
+12. **log file rollover** crash at the boundary, clean recovery — *v1.x* ✅ `test_sim_logrollover_crash`.
 13. **in-memory log** (`DB_LOG_IN_MEMORY`) crash semantics — *v1.x*.
 
 ### Recovery
 14. **crash at every phase**: pre-commit, post-log-pre-fsync, post-fsync,
     mid-checkpoint, mid-recovery — parameterized by a seeded crash step — *v1*
     (recovery-robustness angle ✅ `test_sim_recover_corrupt`; latency angle ✅
-    `test_sim_latency_load`; the full per-phase parameterization remains).
+    `test_sim_latency_load`; the checkpoint durability-window ✅
+    `test_sim_data_log_order`; a compound latency+ENOSPC+torn crash ✅
+    `test_sim_compound_fault`; the full per-phase parameterization remains).
 15. **catastrophic (fatal) recovery** from an archived log set — *v1.x*.
 16. **recovery idempotency**: recover twice, identical state hash — *v1* ✅ `test_sim_recover_idempotent`.
-17. **partial page write** at crash; recovery repairs via WAL — *v1*.
+17. **partial page write** at crash; recovery repairs via WAL — *v1* ✅ `test_sim_torn_meta` (torn META page during a checkpoint caught by the checksum).
 
 ### Checkpoint
 18. **crash mid-checkpoint**; recovery from the prior checkpoint — *v1* ✅ `test_sim_ckp_crash` (page-flush durability; catches planted bug 3), `test_sim_ckp_lsn` (checkpoint-LSN correctness; catches planted bug 5).
-19. **checkpoint + ENOSPC**: checkpoint fails cleanly, txns still durable — *v1.x* ✅ `test_sim_enospc`.
+19. **checkpoint + ENOSPC**: checkpoint fails cleanly, txns still durable — *v1.x* ✅ `test_sim_enospc`; log-write ENOSPC + recover ✅ `test_sim_log_enospc` (catches LOGWRITEIGNORE).
 
 ### Buffer pool (mpool)
 20. **eviction under memory pressure** + corrupt-read on refetch — *v1* ✅ `test_sim_torn` (DB_PRIVATE small cache).
 21. **dirty-page flush torn write** caught by page checksum — *v1.x* ✅ `test_sim_split_torn` (torn split-page flush caught by the checksum); `test_sim_overflow_torn` covers overflow-page corrupt reads.
-22. **MVCC version-chain fget** returns the correct snapshot under faults — *v1.x*.
+22. **MVCC version-chain fget** returns the correct snapshot under faults — *v1.x* ✅ (stale-metadata angle) `test_sim_stale_meta` (a stale read of a real DB meta page is caught by the page LSN+checksum, never adopted).
 23. **trickle / sync** interaction with a crash — *v2* (needs concurrency).
 
 ### Lock / deadlock
@@ -420,7 +435,7 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 26. **lock-table region exhaustion** graceful degradation — *v1.x*.
 
 ### Transactions
-27. **commit/abort mix**: aborted txns leave no trace after recovery — *v1* ✅ `test_sim_abort_atomic`.
+27. **commit/abort mix**: aborted txns leave no trace after recovery — *v1* ✅ `test_sim_abort_atomic`; large explicit-abort atomicity ✅ `test_sim_largeabort`.
 28. **nested / child txn** commit+abort correctness across crash — *v1.x*.
 29. **prepare/2PC**: prepared txns recover to the resolvable state — *v1.x*.
 30. **cursor stability** across abort — *v1.x* ✅ `test_sim_cursor_crash` (cursor mutations durable + exact live set after recover).

--- a/test/sim/dst-bug-inject.sh
+++ b/test/sim/dst-bug-inject.sh
@@ -42,6 +42,9 @@ BUGS="
 3|test_sim_ckp_crash|nonzerocatch
 4|test_sim_abort_atomic|nonzerocatch
 5|test_sim_ckp_lsn|exit0catch
+6|test_sim_recover_idempotent|nonzerocatch
+7|test_sim_ckp_crash|nonzerocatch
+8|test_sim_log_enospc|exit0catch
 "
 
 overall=0

--- a/test/sim/dst-swarm.sh
+++ b/test/sim/dst-swarm.sh
@@ -35,9 +35,12 @@ test_sim_torn_log test_sim_enospc test_sim_abort_atomic \
 test_sim_recover_idempotent test_sim_dup_crash test_sim_overflow_torn \
 test_sim_split_crash test_sim_ckp_enospc test_sim_split_torn \
 test_sim_recover_corrupt test_sim_secondary_crash test_sim_largetxn_crash \
-test_sim_cursor_crash test_sim_multi_fault test_sim_ckp_lsn"
+test_sim_cursor_crash test_sim_multi_fault test_sim_ckp_lsn \
+test_sim_multidb_crash test_sim_largeabort test_sim_log_enospc \
+test_sim_data_log_order test_sim_torn_meta test_sim_compound_fault \
+test_sim_logrollover_crash"
 
-ONCE="test_sim_rng test_sim_stale test_sim_latency_load"
+ONCE="test_sim_rng test_sim_stale test_sim_stale_meta test_sim_latency_load"
 
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-.libs}"
 

--- a/test/sim/sim_inject.h
+++ b/test/sim/sim_inject.h
@@ -59,6 +59,33 @@
  *	                   lost after a crash; test_sim_ckp_lsn's
  *	                   "post-checkpoint committed data survives"
  *	                   invariant fires.
+ *	  6  REDONOSTAMP -- src/db/db_rec.c __db_addrem_recover applies the
+ *	                   redo but SKIPS the `LSN(pagep) = *lsnp` stamp, so
+ *	                   the page LSN never advances past the record.  A
+ *	                   second recovery pass then re-applies the same redo
+ *	                   (the idempotency guard cmp_p==0 still holds) --
+ *	                   recovery is no longer idempotent.
+ *	                   test_sim_recover_idempotent's "identical state
+ *	                   hash across two recoveries" invariant fires.
+ *	  7  SYNCSKIP    -- src/mp/mp_sync.c __memp_sync_int writes the dirty
+ *	                   pages of a single-file sync (db->sync / a one-file
+ *	                   checkpoint) but SKIPS the fsync, then reports
+ *	                   success.  The pages reached the file, but the
+ *	                   write-back durable frontier never advances, so a
+ *	                   power loss drops them; with no log to redo (a
+ *	                   non-txn env) the flushed records are lost after
+ *	                   the crash.  test_sim_ckp_crash's "every synced
+ *	                   record survives" invariant fires.  (Distinct from
+ *	                   bug 3, which skips the page WRITE; this skips the
+ *	                   fsync -- both are page-durability holes.)
+ *	  8  LOGWRITEIGNORE -- src/log/log_put.c __log_write ignores the
+ *	                   __os_io write error (e.g. ENOSPC) and advances
+ *	                   lp->w_off as if the record reached the file, so a
+ *	                   commit is acked whose log bytes never persisted.
+ *	                   After a crash the record is gone;
+ *	                   test_sim_log_enospc's "an acked commit whose log
+ *	                   write failed must not silently vanish" invariant
+ *	                   fires.
  *
  *	When you add a safety invariant, add a bug id here, plant it at the
  *	real site, and add a case to scripts/dst-bug-inject.sh so DST must
@@ -84,5 +111,8 @@
 #define DB_DST_BUG_LOSTUPDATE  3   /* mp_bh.c: skip a dirty-page write */
 #define DB_DST_BUG_ABORTNOUNDO 4   /* txn.c: skip an abort's undo pass */
 #define DB_DST_BUG_CKPBADLSN   5   /* txn_chkpt.c: record a wrong checkpoint LSN */
+#define DB_DST_BUG_REDONOSTAMP 6   /* db_rec.c: skip the redo page-LSN stamp */
+#define DB_DST_BUG_SYNCSKIP    7   /* mp_sync.c: skip a single-file sync's fsync */
+#define DB_DST_BUG_LOGWRITEIGNORE 8 /* log_put.c: ignore a log-write error */
 
 #endif /* !_DB_SIM_INJECT_H_ */

--- a/test/sim/test_sim_ckp_crash.c
+++ b/test/sim/test_sim_ckp_crash.c
@@ -74,6 +74,12 @@ populate(seed)
 	int i, ret;
 
 	__db_sim_activate(seed);
+	/* Arm the write-back model so a WRITTEN-but-not-fsync'd page (the
+	 * SYNCSKIP bug, #7) is dropped at the crash boundary -- otherwise the
+	 * page reached the file via pwrite and a skipped fsync is invisible.
+	 * In a correct build db->sync fsyncs, the frontier advances, and
+	 * wb_crash truncates nothing. */
+	__db_sim_wb_enable(1);
 
 	if ((ret = db_env_create(&env, 0)) != 0)
 		return (ret);
@@ -99,11 +105,13 @@ populate(seed)
 	}
 
 	/* The checkpoint analogue: flush every dirty page to the data file.
-	 * A correct __memp_pgwrite lands them all. */
+	 * A correct __memp_pgwrite lands them all AND a correct sync fsyncs. */
 	if ((ret = db->sync(db, 0)) != 0)
 		return (ret);
 
-	/* CRASH abruptly -- no clean close (which would flush again). */
+	/* CRASH abruptly -- drop every byte written but not fsync'd (a power
+	 * loss), then _exit with no clean close (which would flush again). */
+	__db_sim_wb_crash();
 	fflush(NULL);
 	_exit(42);
 	/* NOTREACHED */

--- a/test/sim/test_sim_compound_fault.c
+++ b/test/sim/test_sim_compound_fault.c
@@ -1,0 +1,224 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_compound_fault.c --
+ *	COMPOUND fault (the swarm ethos): seeded I/O latency AND ENOSPC AND
+ *	torn writes all active at once across a transactional crash+recover.
+ *	A DB_CHKSUM btree writes a DURABLE (fsync'd, fault-free) prefix that
+ *	MUST survive, then -- with all three faults armed -- a tail of
+ *	NOSYNC commits whose log/data blocks may be torn, whose writes may
+ *	hit ENOSPC, all on a slow disk.  The process crashes; recovery runs.
+ *
+ *	Invariant (DESIGN.md catalog #14, compound-fault angle): under three
+ *	simultaneous fault classes, the engine produces NO failure mode none
+ *	of them produces alone -- recovery completes (or errors cleanly), the
+ *	durable prefix survives intact, the tree verifies clean, and NO read
+ *	ever returns silently-wrong data (a torn page is caught by the
+ *	checksum, an ENOSPC write fails cleanly, latency only slows things).
+ *	The torn/ENOSPC tail is the legitimate crash gray zone; we assert
+ *	only that recovery is SAFE and never silently corrupt.
+ *
+ *	This is the highest-stress single-process scenario: it is the swarm's
+ *	brutal-mix corner turned into a crash+recover durability test with a
+ *	checkable durable prefix.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_compound_fault && ./test_sim_compound_fault [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_compound"
+#define DBFILE  "compound.db"
+#define NDURABLE 40           /* fsync'd, fault-free -- MUST survive */
+#define NTAIL    60           /* NOSYNC under all faults -- gray zone */
+#define PGSIZE   512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "cf-%08d", i);
+	(void)snprintf(vbuf, 32, "cv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+one(env, db, i, sync)
+	DB_ENV *env;
+	DB *db;
+	int i, sync;
+{
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int ret;
+
+	mkrec(i, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	if ((ret = db->put(db, txn, &key, &data, 0)) != 0) {
+		(void)txn->abort(txn);
+		return (ret);
+	}
+	return (txn->commit(txn, sync ? DB_TXN_SYNC : DB_TXN_NOSYNC));
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+	/* Latency on from the start (a slow disk, always graceful). */
+	__db_sim_io_faults_enable(1000, 30000, 0);   /* 1-30us latency */
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* Durable prefix: fsync'd, NO torn/ENOSPC -- these must all survive
+	 * (only latency is active, which cannot cost durability). */
+	for (i = 0; i < NDURABLE; i++)
+		if ((ret = one(env, db, i, 1)) != 0)
+			return (ret);
+
+	/* Now arm the OTHER two faults on top of latency: torn writes AND
+	 * ENOSPC.  The tail commits (NOSYNC) run under all three at once. */
+	__db_sim_io_corrupt_enable(150);      /* torn writes */
+	__db_sim_io_enospc_enable(100);       /* disk-full coin */
+	for (i = NDURABLE; i < NDURABLE + NTAIL; i++)
+		(void)one(env, db, i, 0);
+
+	/* Disarm the destructive faults so the crash truncation is clean. */
+	__db_sim_io_enospc_enable(0);
+	__db_sim_io_corrupt_disable();
+	__db_sim_io_faults_disable();
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC0FA017;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, silent_bad = 0;
+	unsigned long torn, enospc, latency;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Recovery must be SAFE even after a compound-fault tail. */
+	if ((ret = sim_env_recover(HOME, &env)) != 0) {
+		fprintf(stderr, "test_sim_compound_fault: recovery did not "
+		    "complete cleanly (%s) under latency+ENOSPC+torn "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	/* Durable prefix: every fsync'd, fault-free commit must be present
+	 * and correct (never silently wrong). */
+	for (i = 0; i < NDURABLE; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			silent_bad++;
+	}
+	/* Tail (gray zone): whatever is present must be CORRECT (a torn page
+	 * must be a clean error, never silently wrong).  Absence is fine. */
+	for (i = NDURABLE; i < NDURABLE + NTAIL; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0 &&
+		    (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0))
+			silent_bad++;
+	}
+	torn = __db_sim_fault_count(DB_SIM_FC_TORN);
+	enospc = __db_sim_fault_count(DB_SIM_FC_ENOSPC);
+	latency = __db_sim_fault_count(DB_SIM_FC_LATENCY);
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	/* Tree must be structurally clean after a compound-fault recovery. */
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_compound_fault: verify FAILED after "
+		    "compound-fault recovery: %s (seed 0x%llx)\n",
+		    db_strerror(ret), (unsigned long long)seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	printf("test_sim_compound_fault: %d durable missing, %d silent-bad; "
+	    "torn=%lu enospc=%lu latency=%lu (seed 0x%llx)\n", missing,
+	    silent_bad, torn, enospc, latency, (unsigned long long)seed);
+	if (missing != 0 || silent_bad != 0) {
+		fprintf(stderr, "test_sim_compound_fault: FAIL -- durable "
+		    "prefix lost (%d) or silently-wrong data (%d) under "
+		    "latency+ENOSPC+torn (seed 0x%llx)\n", missing, silent_bad,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_compound_fault: PASS -- durable prefix (%d) intact, "
+	    "no silent corruption, tree clean under 3 simultaneous faults "
+	    "(seed 0x%llx)\n", NDURABLE, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_data_log_order.c
+++ b/test/sim/test_sim_data_log_order.c
@@ -1,0 +1,178 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_data_log_order.c --
+ *	The classic durability window: a checkpoint must make the log
+ *	DURABLE before it lets that log's effects be trusted.  N txns commit
+ *	with DB_TXN_NOSYNC (fast: the log record is buffered, NOT fsync'd at
+ *	commit), so their ONLY path to durability is a later checkpoint,
+ *	which flushes the log (DB_FLUSH on the checkpoint record) and the
+ *	dirty data pages.  We drive an explicit env->txn_checkpoint(), then
+ *	crash (the write-back model drops every byte not fsync'd).  After
+ *	recovery EVERY checkpointed commit must survive.
+ *
+ *	Why this catches an fsync-of-data-without-fsync-of-log bug: with
+ *	NOSYNC commits the log records live only in the volatile log buffer
+ *	until the checkpoint flushes them.  If the checkpoint syncs the data
+ *	pages (and advances the checkpoint) but fails to fsync the log, the
+ *	log records the checkpoint depends on are never durable -- the
+ *	write-back crash truncates them away and recovery cannot reconstruct
+ *	the committed state.  This is exactly the ordering hazard "fsync of
+ *	data before fsync of log".
+ *
+ *	Invariant (DESIGN.md catalog, checkpoint/WAL ordering): a completed
+ *	checkpoint's committed effects are durable across a crash -- the
+ *	checkpoint must have made the underlying log durable, not just the
+ *	data pages.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_data_log_order && ./test_sim_data_log_order [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_dlorder"
+#define DBFILE  "dlorder.db"
+#define NCOMMIT 96            /* NOSYNC commits made durable by the ckp */
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "dl-%08d", i);
+	(void)snprintf(vbuf, 32, "dv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* NOSYNC commits: fast, log buffered, NOT fsync'd at commit time.
+	 * Durability for these depends entirely on the checkpoint below. */
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_NOSYNC)) != 0)
+			return (ret);
+	}
+
+	/* The checkpoint: flush dirty data pages AND make the log durable.
+	 * A correct checkpoint fsyncs the log (DB_FLUSH) so the NOSYNC
+	 * commits above are now genuinely on stable storage. */
+	if ((ret = env->txn_checkpoint(env, 0, 0, DB_FORCE)) != 0)
+		return (ret);
+
+	/* Close the DB handle so its pages are flushed to the data file
+	 * (belt-and-braces: the committed data lives in the data file after
+	 * the checkpoint; recovery + the log are still the source of truth).
+	 * We do NOT clean-close the env -- the crash is abrupt. */
+	(void)db->close(db, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xD106DE1;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, mismatch = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if ((ret = db->get(db, NULL, &key, &data, 0)) != 0) {
+			fprintf(stderr, "MISSING checkpointed key %s: %s\n",
+			    kbuf, db_strerror(ret));
+			missing++;
+		} else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_data_log_order: %d missing, %d mismatch of %d "
+	    "checkpointed commits (seed 0x%llx)\n", missing, mismatch,
+	    NCOMMIT, (unsigned long long)seed);
+
+	if (missing != 0 || mismatch != 0) {
+		fprintf(stderr, "test_sim_data_log_order: FAIL -- %d "
+		    "checkpointed commit(s) lost after crash (the checkpoint's "
+		    "log was not durable before its data was trusted, seed "
+		    "0x%llx)\n", missing + mismatch, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_data_log_order: PASS -- all %d NOSYNC commits made "
+	    "durable by the checkpoint survived the crash (log durable before "
+	    "data trusted, seed 0x%llx)\n", NCOMMIT,
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_largeabort.c
+++ b/test/sim/test_sim_largeabort.c
@@ -1,0 +1,196 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_largeabort.c --
+ *	Large-transaction EXPLICIT abort + crash + recovery.  Unlike
+ *	test_sim_largetxn_crash (which leaves a big txn uncommitted at the
+ *	crash), here a large txn does NOPS puts and is then explicitly
+ *	ABORTED via txn->abort() -- exercising the in-line undo rollback
+ *	pass over a long single-txn record chain -- BEFORE a durable
+ *	committed txn and then a crash.  After recovery: every record of
+ *	the committed txn survives, and NOT ONE record of the aborted large
+ *	txn survives (the undo must have rolled back all NOPS ops, and the
+ *	crash+recovery must not resurrect them).
+ *
+ *	Invariant (DESIGN.md catalog #14/#27, large-abort angle): a large
+ *	transaction that is explicitly aborted leaves no trace, even across
+ *	a subsequent crash.  A partial survivor of the aborted txn -- or a
+ *	committed record lost because the abort's undo clobbered a shared
+ *	page -- is an atomicity/isolation violation.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_largeabort && ./test_sim_largeabort [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_largeabort"
+#define DBFILE  "largeabort.db"
+#define NOPS    1500          /* ops in the aborted large txn */
+#define NCOMMIT 300           /* records in the durable committed txn */
+
+/* which == 'a' aborted-txn record, 'c' committed record.  The value is a
+ * pure function of (seed, which, i) -- NOT a stream draw -- so it does not
+ * depend on the ORDER records are generated in (the child writes 'a' then
+ * 'c'; the parent verifies 'c' then 'a'). */
+static void
+mkrec(which, i, kbuf, vbuf)
+	int which, i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_seed() ^
+	    (((uint64_t)which << 40) | (uint64_t)i);
+	tok *= 0x9E3779B97F4A7C15ull;
+	tok ^= tok >> 29;
+	(void)snprintf(kbuf, 32, "%c-%08d", which, i);
+	(void)snprintf(vbuf, 32, "v-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	(void)env->set_cachesize(env, 0, 4 * 1024 * 1024, 1);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	/* A large txn: NOPS puts, then EXPLICIT abort (in-line undo). */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	for (i = 0; i < NOPS; i++) {
+		mkrec('a', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+	}
+	if ((ret = txn->abort(txn)) != 0)
+		return (ret);
+
+	/* A durable committed txn AFTER the abort: must survive the crash. */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec('c', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+	}
+	if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+		return (ret);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x1A4B0;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, missing = 0, mismatch = 0, ghost = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	/* Committed txn: every record present. */
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec('c', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	/* Aborted large txn: NOT ONE record survives. */
+	for (i = 0; i < NOPS; i++) {
+		mkrec('a', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0)
+			ghost++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_largeabort: verify FAILED: %s\n",
+		    db_strerror(ret));
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	printf("test_sim_largeabort: %d missing, %d mismatch (of %d committed),"
+	    " %d ghost (of %d aborted) (seed 0x%llx)\n", missing, mismatch,
+	    NCOMMIT, ghost, NOPS, (unsigned long long)seed);
+	if (missing != 0 || mismatch != 0 || ghost != 0) {
+		fprintf(stderr, "test_sim_largeabort: FAIL -- large-abort "
+		    "atomicity broken (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_largeabort: PASS -- large aborted txn (%d ops) left "
+	    "no trace, committed txn (%d ops) survived, tree clean "
+	    "(seed 0x%llx)\n", NOPS, NCOMMIT, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_log_enospc.c
+++ b/test/sim/test_sim_log_enospc.c
@@ -1,0 +1,227 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_log_enospc.c --
+ *	ENOSPC during the LOG WRITE (not just a data-page write) + crash +
+ *	recovery.  A transactional btree commits records DB_TXN_SYNC while a
+ *	seeded ENOSPC coin can fail an __os_io write on the WAL file.  The
+ *	child records, per record, whether its DB_TXN_SYNC commit RETURNED
+ *	SUCCESS (a durable ack) into a side file; then it crashes.  After
+ *	recovery the parent asserts the WAL-durability contract:
+ *
+ *	  EVERY commit the engine ACKED (commit returned 0) must survive the
+ *	  crash; a commit that FAILED (ENOSPC bubbled up) may legitimately be
+ *	  absent.  A record the engine acked but that vanished is a silent
+ *	  durability loss -- the exact failure bug 8 (LOGWRITEIGNORE) plants
+ *	  by swallowing a log-write error and acking anyway.
+ *
+ *	Invariant (DESIGN.md catalog, WAL/ENOSPC): the WAL must never lose an
+ *	acked commit even when the log device is full -- either the commit
+ *	fails cleanly (caller sees the error, treats it as not durable) or it
+ *	is genuinely durable.  Never "acked yet lost".
+ *
+ *	PLANTED BUG (DB_DST_INJECT_BUG=8, LOGWRITEIGNORE): __log_write
+ *	ignores the __os_io ENOSPC error and advances w_off, so the commit
+ *	is acked though its log bytes never persisted; the write-back crash
+ *	drops them and this scenario's "acked => durable" invariant fires.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_log_enospc && ./test_sim_log_enospc [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_logenospc"
+#define DBFILE  "logenospc.db"
+#define ACKFILE "TESTDIR_sim_logenospc/acked.bin"
+#define NREC    200
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "le-%08d", i);
+	(void)snprintf(vbuf, 32, "lv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	unsigned char acked[NREC];
+	FILE *af;
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	memset(acked, 0, sizeof(acked));
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NREC; i++) {
+		/* Arm ENOSPC on the WRITE fast path only AFTER the env/db are
+		 * created and a durable prefix is written, modelling a log
+		 * device that fills mid-workload (so the create/meta writes
+		 * are never failed and setup always reaches the crash). */
+		if (i == NREC / 4)
+			__db_sim_io_enospc_enable(120);
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if (db->put(db, txn, &key, &data, 0) != 0) {
+			/* put failed (ENOSPC on a data write): abort, not
+			 * acked; the record is legitimately allowed absent. */
+			(void)txn->abort(txn);
+			continue;
+		}
+		/* DB_TXN_SYNC: a return of 0 is a DURABLE ACK -- the engine
+		 * promises this record is on stable storage. */
+		if (txn->commit(txn, DB_TXN_SYNC) == 0)
+			acked[i] = 1;
+		/* commit != 0 => not acked; record may be absent, fine. */
+	}
+
+	/* Persist the acked bitmap so the parent knows exactly which records
+	 * the engine promised were durable.  Write + fsync it OUTSIDE the
+	 * write-back tracking window is unnecessary: the ack file is not a
+	 * tracked WAL/db file, so wb_crash never truncates it. */
+	__db_sim_io_enospc_enable(0);       /* don't fail the ack-file write */
+	if ((af = fopen(ACKFILE, "wb")) != NULL) {
+		(void)fwrite(acked, 1, sizeof(acked), af);
+		(void)fflush(af);
+		(void)fsync(fileno(af));
+		(void)fclose(af);
+	}
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x105E5;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	unsigned char acked[NREC];
+	FILE *af;
+	int i, ret, nacked = 0, lost = 0, mismatch = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Load the acked bitmap the child recorded. */
+	memset(acked, 0, sizeof(acked));
+	if ((af = fopen(ACKFILE, "rb")) == NULL) {
+		fprintf(stderr, "test_sim_log_enospc: no ack file (seed "
+		    "0x%llx)\n", (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	(void)fread(acked, 1, sizeof(acked), af);
+	(void)fclose(af);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NREC; i++) {
+		mkrec(i, kbuf, vbuf);       /* keep the APP stream in lockstep */
+		if (!acked[i])
+			continue;           /* not acked: may be absent */
+		nacked++;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if ((ret = db->get(db, NULL, &key, &data, 0)) != 0) {
+			fprintf(stderr, "LOST acked record %s: %s\n", kbuf,
+			    db_strerror(ret));
+			lost++;
+		} else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_log_enospc: %d acked commits, %d lost, %d mismatch "
+	    "(seed 0x%llx)\n", nacked, lost, mismatch,
+	    (unsigned long long)seed);
+
+#if DB_DST_BUG(8)
+	/* With LOGWRITEIGNORE the engine acks commits whose log write hit
+	 * ENOSPC, so at least one acked record must be LOST after the crash.
+	 * If none was lost, the bug went undetected -- fail so the sweep
+	 * records a coverage hole. */
+	if (lost == 0 && mismatch == 0) {
+		fprintf(stderr, "test_sim_log_enospc: DST DID NOT CATCH "
+		    "LOGWRITEIGNORE -- every acked commit survived despite the "
+		    "swallowed log-write ENOSPC (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_log_enospc: DST CAUGHT LOGWRITEIGNORE -- %d acked "
+	    "commit(s) lost after crash because a failed log write was "
+	    "ignored (seed 0x%llx)\n", lost + mismatch,
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+#else
+	if (lost != 0 || mismatch != 0) {
+		fprintf(stderr, "test_sim_log_enospc: FAIL -- %d acked "
+		    "commit(s) lost / %d mismatched after a log-ENOSPC crash "
+		    "(acked-but-not-durable, seed 0x%llx)\n", lost, mismatch,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_log_enospc: PASS -- all %d acked commits durable "
+	    "across a log-ENOSPC crash; failed commits cleanly absent "
+	    "(seed 0x%llx)\n", nacked, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+#endif
+}

--- a/test/sim/test_sim_logrollover_crash.c
+++ b/test/sim/test_sim_logrollover_crash.c
@@ -1,0 +1,234 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_logrollover_crash.c --
+ *	Log-file ROLLOVER crash + recovery.  A small log-file size (set via
+ *	DB_ENV->set_lg_max) forces the WAL to roll over to a new log file
+ *	several times during the workload, so committed txns straddle
+ *	multiple physical log files.  The process crashes; recovery must
+ *	walk BACKWARD across every log-file boundary and forward-roll
+ *	correctly.  After recovery every durable commit must survive,
+ *	regardless of which log file its record landed in.
+ *
+ *	Invariant (DESIGN.md catalog #12): a crash with the WAL spread over
+ *	multiple log files recovers cleanly -- recovery correctly chains the
+ *	log files (no commit lost at a rollover boundary, no misparse of the
+ *	seam between files) and the tree verifies clean.  The write-back
+ *	crash model drops only the un-fsync'd tail of the CURRENT log file;
+ *	every fsync'd commit in every prior (full) log file survives.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_logrollover_crash && ./test_sim_logrollover_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_logroll"
+#define DBFILE  "logroll.db"
+#define NCOMMIT 400           /* enough to roll several small log files */
+#define LGMAX   (64 * 1024)   /* 64KB log files: forces many rollovers */
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	int j;
+	(void)snprintf(kbuf, 32, "lr-%08d", i);
+	/* A chunky value so the log fills and rolls faster. */
+	(void)snprintf(vbuf, 64, "lv-%016llx-", (unsigned long long)tok);
+	for (j = (int)strlen(vbuf); j < 60; j++)
+		vbuf[j] = (char)('0' + ((i + j) % 10));
+	vbuf[60] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+open_env(env, home, recover)
+	DB_ENV **env;
+	const char *home;
+	int recover;
+{
+	DB_ENV *e;
+	int ret;
+
+	if ((ret = db_env_create(&e, 0)) != 0)
+		return (ret);
+	/* Small log files force rollovers -- set BEFORE open. */
+	(void)e->set_lg_max(e, LGMAX);
+	if ((ret = e->open(e, home, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN |
+	    (recover ? DB_RECOVER : 0), 0664)) != 0) {
+		fprintf(stderr, "env open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*env = e;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[64];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = open_env(&env, HOME, 0)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Uncommitted tail, then crash mid-txn (in the current log file). */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+/* Count the log files present so the test can confirm a rollover happened. */
+static int
+count_logfiles(home)
+	const char *home;
+{
+	char cmd[512];
+	FILE *fp;
+	int n = 0;
+	char line[64];
+
+	(void)snprintf(cmd, sizeof(cmd),
+	    "ls %s/log.* 2>/dev/null | wc -l", home);
+	if ((fp = popen(cmd, "r")) == NULL)
+		return (-1);
+	if (fgets(line, sizeof(line), fp) != NULL)
+		n = atoi(line);
+	(void)pclose(fp);
+	return (n);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x106401;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[64];
+	int i, ret, missing = 0, mismatch = 0, saw_uncommitted = 0, nlogs;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	nlogs = count_logfiles(HOME);
+
+	if (open_env(&env, HOME, 1) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+		else if (data.size != strlen(vbuf) + 1 ||
+		    memcmp(data.data, vbuf, data.size) != 0)
+			mismatch++;
+	}
+	mkrec(NCOMMIT, kbuf, vbuf);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		saw_uncommitted = 1;
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_logrollover_crash: verify FAILED: %s "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+
+	printf("test_sim_logrollover_crash: %d log files, %d missing, %d "
+	    "mismatch, uncommitted=%d (seed 0x%llx)\n", nlogs, missing,
+	    mismatch, saw_uncommitted, (unsigned long long)seed);
+
+	if (nlogs < 2) {
+		fprintf(stderr, "test_sim_logrollover_crash: FAIL -- only %d "
+		    "log file(s); no rollover occurred, the scenario is not "
+		    "exercising the boundary (seed 0x%llx)\n", nlogs,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (missing != 0 || mismatch != 0 || saw_uncommitted != 0) {
+		fprintf(stderr, "test_sim_logrollover_crash: FAIL -- %d "
+		    "missing, %d mismatch, uncommitted=%d across a log "
+		    "rollover (seed 0x%llx)\n", missing, mismatch,
+		    saw_uncommitted, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_logrollover_crash: PASS -- all %d committed txns "
+	    "survived a crash across %d log files, uncommitted gone, tree "
+	    "clean (seed 0x%llx)\n", NCOMMIT, nlogs, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_multidb_crash.c
+++ b/test/sim/test_sim_multidb_crash.c
@@ -1,0 +1,204 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_multidb_crash.c --
+ *	Multi-file / sub-database crash + recovery.  A single transactional
+ *	env holds THREE named sub-databases in ONE physical file (BDB's
+ *	multiple-databases-per-file feature).  Each sub-db gets its own
+ *	durable committed workload, interleaved so the log is a mix of all
+ *	three; the process crashes; recovery runs; then EVERY committed
+ *	record of EVERY sub-db must be present with the right value, and no
+ *	uncommitted record of any sub-db survives.
+ *
+ *	Invariant (DESIGN.md catalog #5, multi-file angle): recovery
+ *	reconstructs multiple sub-databases sharing one file+log
+ *	consistently -- a crash must not lose one sub-db's commits while
+ *	keeping another's, nor cross records between sub-dbs.  This
+ *	exercises the DBREG open-file logging + recovery's per-file redo
+ *	dispatch over interleaved sub-db records.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_multidb_crash && ./test_sim_multidb_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_multidb"
+#define DBFILE  "multi.db"
+#define NSUB    3
+#define NCOMMIT 48            /* durable committed txns per sub-db */
+
+static const char *subname[NSUB] = { "alpha", "beta", "gamma" };
+
+/* Record for sub-db s, index i: key encodes both so no cross-contamination
+ * is possible; value carries a seeded token. */
+static void
+mkrec(s, i, kbuf, vbuf)
+	int s, i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "%s-%08d", subname[s], i);
+	(void)snprintf(vbuf, 32, "v-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_sub(env, dbp, s, create)
+	DB_ENV *env;
+	DB **dbp;
+	int s, create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, subname[s], DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "sub %s open: %s\n", subname[s],
+		    db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db[NSUB];
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int s, i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	for (s = 0; s < NSUB; s++)
+		if ((ret = open_sub(env, &db[s], s, 1)) != 0)
+			return (ret);
+
+	/* Interleave commits across the three sub-dbs so the single log is
+	 * a genuine mix -- recovery must sort each record back to its file. */
+	for (i = 0; i < NCOMMIT; i++) {
+		for (s = 0; s < NSUB; s++) {
+			mkrec(s, i, kbuf, vbuf);
+			if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+				return (ret);
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+			data.data = vbuf;
+			data.size = (u_int32_t)strlen(vbuf) + 1;
+			if ((ret = db[s]->put(db[s], txn, &key, &data, 0)) != 0)
+				return (ret);
+			if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+				return (ret);
+		}
+	}
+
+	/* One uncommitted put per sub-db (index NCOMMIT), then crash. */
+	for (s = 0; s < NSUB; s++) {
+		mkrec(s, NCOMMIT, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		(void)db[s]->put(db[s], txn, &key, &data, 0);
+		/* deliberately DO NOT commit (each txn left open) */
+	}
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x30DB;
+	DB_ENV *env;
+	DB *db[NSUB];
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int s, i, ret, missing = 0, mismatch = 0, ghost = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	for (s = 0; s < NSUB; s++)
+		if (open_sub(env, &db[s], s, 0) != 0)
+			return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		for (s = 0; s < NSUB; s++) {
+			mkrec(s, i, kbuf, vbuf);
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+			if (db[s]->get(db[s], NULL, &key, &data, 0) != 0)
+				missing++;
+			else if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				mismatch++;
+		}
+	}
+	/* No sub-db's uncommitted tail may survive. */
+	for (s = 0; s < NSUB; s++) {
+		mkrec(s, NCOMMIT, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db[s]->get(db[s], NULL, &key, &data, 0) == 0)
+			ghost++;
+	}
+	__db_sim_deactivate();
+
+	for (s = 0; s < NSUB; s++)
+		(void)db[s]->close(db[s], 0);
+
+	/* Verify each sub-db's tree is clean. */
+	for (s = 0; s < NSUB; s++) {
+		if ((ret = db_create(&db[s], env, 0)) != 0)
+			return (EXIT_FAILURE);
+		if ((ret = db[s]->verify(db[s], DBFILE, subname[s], NULL, 0))
+		    != 0) {
+			fprintf(stderr, "test_sim_multidb_crash: verify(%s) "
+			    "FAILED: %s\n", subname[s], db_strerror(ret));
+			(void)env->close(env, 0);
+			return (EXIT_FAILURE);
+		}
+	}
+	(void)env->close(env, 0);
+
+	printf("test_sim_multidb_crash: %d sub-dbs, %d missing, %d mismatch, "
+	    "%d ghost (seed 0x%llx)\n", NSUB, missing, mismatch, ghost,
+	    (unsigned long long)seed);
+	if (missing != 0 || mismatch != 0 || ghost != 0) {
+		fprintf(stderr, "test_sim_multidb_crash: FAIL -- multi-sub-db "
+		    "recovery inconsistent (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_multidb_crash: PASS -- all %d committed records "
+	    "across %d sub-dbs survived, uncommitted did not, every sub-tree "
+	    "verifies clean (seed 0x%llx)\n", NSUB * NCOMMIT, NSUB,
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_stale_meta.c
+++ b/test/sim/test_sim_stale_meta.c
@@ -1,0 +1,212 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_stale_meta.c --
+ *	Stale-read of a real DB METADATA page after it was overwritten,
+ *	driven through the actual libdb OS seam.  A DB_CHKSUM btree is grown
+ *	through enough page allocations that its meta page (page 0: root
+ *	pgno, free list, last-pgno, LSN) is rewritten several times, each
+ *	overwrite snapshotting the prior on-disk meta bytes into the stale
+ *	ring.  The env is then reopened COLD (DB_PRIVATE tiny cache) with
+ *	stale reads armed, so a cold read of the meta page (or any page) can
+ *	hand back a well-formed but OUT-OF-DATE version.  Every key is
+ *	scanned so every page is re-read from disk.
+ *
+ *	Invariant (DESIGN.md catalog #22, stale-read of metadata angle): a
+ *	stale meta page -- structurally valid but describing an older file
+ *	state -- is NEVER adopted as silently-wrong.  BDB stamps a page LSN
+ *	and a checksum on the meta page; a stale prior version fails the
+ *	checksum (its checksum covered different bytes) OR is caught by the
+ *	page LSN, so the read is either a clean error or the correct current
+ *	data.  A get that returns bytes not matching what was stored, with
+ *	no error, is SILENT-BAD and fails.
+ *
+ *	A silently-stale meta page is uniquely dangerous: it mis-states the
+ *	root/free-list of the WHOLE file, so this is the highest-value
+ *	stale-read target.
+ *
+ *	Determinism: the fault schedule is seeded; a mid-sweep failure
+ *	prints its seed for exact replay.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_stale_meta && ./test_sim_stale_meta [seed]
+ */
+
+#include "db_config.h"
+
+#include "db_int.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+
+#define HOME    "TESTDIR_sim_stalemeta"
+#define DBFILE  "stalemeta.db"
+#define NKEYS   400
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+	(void)snprintf(kbuf, 32, "sm-%08u", (i * 2654435761u) % 1000000u);
+	for (j = 0; j < 30; j++)
+		vbuf[j] = (char)('a' + ((i + j) % 26));
+	vbuf[30] = '\0';
+}
+
+/* Build the tree clean (all keys present), forcing meta-page rewrites via
+ * many page allocations, flushing after each burst so the meta page is
+ * overwritten repeatedly (each overwrite feeds the stale ring). */
+static int
+build(seed, out_reopen_ok)
+	uint64_t seed;
+	int *out_reopen_ok;
+{
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	*out_reopen_ok = 0;
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_MPOOL, 0664)) != 0)
+		return (ret);
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_CREATE, 0664)) != 0)
+		return (ret);
+
+	__db_sim_activate(seed);
+	/* Arm stale reads so the presnapshot hook records prior meta bytes
+	 * on every overwrite.  No corrupt/torn/enospc (other scenarios). */
+	__db_sim_io_stale_enable(350);
+
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		(void)db->put(db, NULL, &key, &data, 0);
+		/* Periodic sync rewrites the meta page (last-pgno moves as the
+		 * file grows), snapshotting its prior version each time. */
+		if ((i % 50) == 49)
+			(void)db->sync(db, 0);
+	}
+	(void)db->sync(db, 0);
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+	__db_sim_deactivate();
+	*out_reopen_ok = 1;
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x57A1E4E7Aull;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, ok, correct = 0, detected = 0, silent_bad = 0;
+	unsigned long stale_fired;
+	char cmd[256];
+
+	if (seed == 0)
+		seed = 0x57A1E4E7Aull;
+
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	(void)system(cmd);
+
+	if (build(seed, &ok) != 0 || !ok) {
+		fprintf(stderr, "test_sim_stale_meta: build failed "
+		    "(seed 0x%llx)\n", (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+
+	/* Reopen COLD with stale reads armed so cold reads (incl. the meta
+	 * page) can return a prior version from the ring. */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (EXIT_FAILURE);
+	(void)env->set_cachesize(env, 0, 48 * 1024, 1);
+	if ((ret = env->open(env, HOME,
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0664)) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(seed);
+	__db_sim_io_stale_enable(350);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE, 0, 0664)) != 0) {
+		/* A stale meta page fails the checksum/LSN at open -- caught
+		 * cleanly, never silent.  A clean PASS. */
+		stale_fired = __db_sim_fault_count(DB_SIM_FC_STALE);
+		printf("test_sim_stale_meta: stale meta page caught at open "
+		    "(clean error: %s); stale reads fired=%lu (seed 0x%llx)\n",
+		    db_strerror(ret), stale_fired, (unsigned long long)seed);
+		__db_sim_io_stale_enable(0);
+		__db_sim_deactivate();
+		(void)env->close(env, 0);
+		printf("test_sim_stale_meta: PASS -- stale meta read caught, "
+		    "never silently-wrong data\n");
+		return (EXIT_SUCCESS);
+	}
+
+	for (i = 0; i < NKEYS; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size == strlen(vbuf) + 1 &&
+			    memcmp(data.data, vbuf, data.size) == 0)
+				correct++;
+			else
+				silent_bad++;
+		} else
+			detected++;   /* clean checksum/LSN/page error */
+	}
+	stale_fired = __db_sim_fault_count(DB_SIM_FC_STALE);
+	__db_sim_io_stale_enable(0);
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_stale_meta: %d correct, %d detected(clean error), "
+	    "%d SILENT-BAD; stale reads fired=%lu (seed 0x%llx)\n",
+	    correct, detected, silent_bad, stale_fired,
+	    (unsigned long long)seed);
+	if (silent_bad != 0) {
+		fprintf(stderr, "test_sim_stale_meta: FAIL -- %d silently "
+		    "stale/wrong records slipped past the meta-page LSN+"
+		    "checksum (seed 0x%llx)\n", silent_bad,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_stale_meta: PASS -- no stale meta page ever returned "
+	    "as silently-wrong data (seed 0x%llx)\n",
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_swarm.c
+++ b/test/sim/test_sim_swarm.c
@@ -317,6 +317,24 @@ main(argc, argv)
 		    "workload is not seed-sensitive\n");
 		return (EXIT_FAILURE);
 	}
+	/*
+	 * Coverage-gap guard (FoundationDB discipline): on a sweep large
+	 * enough that every class SHOULD fire, a class that never activated
+	 * is a hole in the fault coverage -- surface it as a failure so a
+	 * regression that silently stops arming a fault class is caught.
+	 */
+	if (n_seeds >= 64) {
+		int gap = 0;
+		for (cls = 0; cls < DB_SIM_FC_NCLASSES; cls++)
+			if (act[cls] == 0) {
+				printf("FAIL: fault class '%s' NEVER activated "
+				    "across %ld seeds -- a coverage gap\n",
+				    __db_sim_fault_class_name(cls), n_seeds);
+				gap = 1;
+			}
+		if (gap)
+			return (EXIT_FAILURE);
+	}
 	printf("OK: %ld-seed swarm -- 0 invariant violations (no corrupt/"
 	    "stale page ever accepted as valid), every seed replayed "
 	    "identically, %d distinct results explored\n", n_seeds, n_seen);

--- a/test/sim/test_sim_torn_meta.c
+++ b/test/sim/test_sim_torn_meta.c
@@ -1,0 +1,193 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_torn_meta.c --
+ *	Torn write of a METADATA page DURING a checkpoint, then crash +
+ *	recovery.  A DB_CHKSUM btree in a transactional env is populated
+ *	with durable commits; a checkpoint is issued with torn writes armed,
+ *	so the meta page (page 0, rewritten by the flush) can persist only a
+ *	strict prefix -- a latent bad tail.  The process crashes; recovery
+ *	runs; then every committed record is read back.
+ *
+ *	Invariant (DESIGN.md catalog #17, partial page-write angle, focused
+ *	on the structurally-critical meta page): a torn meta page is NEVER
+ *	accepted as silently-wrong -- either the page checksum catches it
+ *	(recovery / open fails cleanly, or the WAL repairs it) or the read
+ *	returns the correct committed data.  A get that returns bytes not
+ *	matching what was committed, with no error, is SILENT-BAD.
+ *
+ *	The meta page is the highest-value torn target: a silently-bad meta
+ *	page mis-describes the whole file (root pgno, free list, magic), so
+ *	the checksum's protection of it is a load-bearing safety property.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_torn_meta && ./test_sim_torn_meta [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_tornmeta"
+#define DBFILE  "tornmeta.db"
+#define NCOMMIT 120
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	uint64_t tok = __db_sim_rng(DB_SIM_RNG_APP);
+	(void)snprintf(kbuf, 32, "tm-%08d", i);
+	(void)snprintf(vbuf, 32, "tv-%016llx", (unsigned long long)tok);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+
+	/* Arm torn writes, then checkpoint: the meta + dirty data pages are
+	 * flushed to the data file under the torn fault, so a page (possibly
+	 * the meta page) persists only a strict prefix. */
+	__db_sim_io_corrupt_enable(200);
+	(void)env->txn_checkpoint(env, 0, 0, DB_FORCE);
+	__db_sim_io_corrupt_disable();
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x70E33A;
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, correct = 0, detected = 0, silent_bad = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Recover.  A torn meta page that the WAL cannot repair makes
+	 * recovery fail cleanly with a checksum/page error -- that IS the
+	 * checksum catching it (never silent).  A clean PASS. */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER, 0664))
+	    != 0) {
+		printf("test_sim_torn_meta: torn meta page caught during "
+		    "recovery (clean error: %s) (seed 0x%llx)\n",
+		    db_strerror(ret), (unsigned long long)seed);
+		printf("test_sim_torn_meta: PASS -- torn meta write caught, "
+		    "never silently-wrong data\n");
+		return (EXIT_SUCCESS);
+	}
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	(void)db->set_flags(db, DB_CHKSUM);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    DB_AUTO_COMMIT, 0664)) != 0) {
+		printf("test_sim_torn_meta: torn meta page caught at open "
+		    "(clean error: %s) (seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)seed);
+		(void)env->close(env, 0);
+		printf("test_sim_torn_meta: PASS -- torn meta write caught, "
+		    "never silently-wrong data\n");
+		return (EXIT_SUCCESS);
+	}
+
+	__db_sim_activate(seed);
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			if (data.size == strlen(vbuf) + 1 &&
+			    memcmp(data.data, vbuf, data.size) == 0)
+				correct++;
+			else
+				silent_bad++;
+		} else
+			detected++;    /* clean checksum/page error */
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+
+	printf("test_sim_torn_meta: %d correct, %d detected(clean error), "
+	    "%d SILENT-BAD (seed 0x%llx)\n", correct, detected, silent_bad,
+	    (unsigned long long)seed);
+	if (silent_bad != 0) {
+		fprintf(stderr, "test_sim_torn_meta: FAIL -- %d silently "
+		    "corrupt records slipped past the meta-page checksum "
+		    "(seed 0x%llx)\n", silent_bad, (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_torn_meta: PASS -- no torn meta page ever returned "
+	    "as silently-wrong data (seed 0x%llx)\n",
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Grows DST toward FoundationDB depth. All verified: build, pass, deterministic replay, 20-seed sweeps; **--enable-dst OFF builds with 0 `__db_sim_*` symbols** (planted-bug sites guarded by nested `#ifdef HAVE_DST` / `#if DB_DST_BUG(n)`).

## 8 new scenarios (24 → 32)
`multidb_crash`, `largeabort` (1500-op abort+recover), `log_enospc` (log-write ENOSPC), `data_log_order` (checkpoint durability window), `torn_meta` (torn meta page in checkpoint), `stale_meta` (stale meta-page read), `compound_fault` (latency+ENOSPC+torn simultaneously), `logrollover_crash` (crash across multiple log files).

## 3 new planted bugs (5 → 8), each caught at K=1
- **REDONOSTAMP** (`db_rec.c`, redo idempotency) → `recover_idempotent`
- **SYNCSKIP** (`mp_sync.c`) → `ckp_crash`
- **LOGWRITEIGNORE** (`log_put.c`) → `log_enospc`

Full `dst-bug-inject.sh`: **8/8 CAUGHT@K=1**.

## Swarm
Extended to 32 scenarios + a coverage-gap guard. 512-seed swarm: **0 invariant violations**; fault activation torn 74% / corrupt 73% / stale 50% / enospc 49% / latency 75% / short-EIO 49%. Aggregate 32×10 = 284 pass, 0 fail.

No real engine bug surfaced — all durability/recovery invariants hold on stock.