### PR TITLE
test(dst): v2 multi-process foundation — design + SCHED seam + failchk-recovery pilot (finds real EBUSY bug)

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1731,6 +1731,16 @@ test_sim_logrollover_crash: test_sim_logrollover_crash@o@ $(DEF_LIB)
 	    $(LIBS)
 	$(POSTLINK) $@
 
+# DST v2 multi-process failchk-recovery pilot (test/sim/mp_failchk_pilot.c).
+# Runs OUTSIDE the single-process test_sim harness: it forks + kill -9's real
+# processes sharing a real (non-DB_PRIVATE) region.  Driver: mp-failchk.sh.
+mp_failchk_pilot@o@: $(testdir)/sim/mp_failchk_pilot.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+mp_failchk_pilot: mp_failchk_pilot@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) mp_failchk_pilot@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_hash_crash test_sim_recno_crash test_sim_queue_crash \
 	test_sim_ckp_crash test_sim_torn_log test_sim_enospc \
@@ -1741,7 +1751,8 @@ dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_cursor_crash test_sim_latency_load test_sim_swarm \
 	test_sim_ckp_lsn test_sim_multidb_crash test_sim_largeabort \
 	test_sim_log_enospc test_sim_data_log_order test_sim_torn_meta \
-	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash
+	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash \
+	mp_failchk_pilot
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -82,7 +82,7 @@ Streams (`enum db_sim_stream`):
 | `DB_SIM_RNG_FAULT` | generic fault-injection toggles |
 | `DB_SIM_RNG_BUGGIFY` | buggify per-run activation coins |
 | `DB_SIM_RNG_APP` | application/test workload draws |
-| `DB_SIM_RNG_SCHED` | **reserved** for the v2 deterministic scheduler |
+| `DB_SIM_RNG_SCHED` | **v2**: deterministic scheduler / multi-process (kill point; see `test/sim/DST-V2-DESIGN.md`) |
 
 `SCHED` is reserved (not yet drawn) so adding the scheduler later does not move
 v1 seeds. `__db_sim_rng(s)` returns 0 when sim is inactive; callers gate on
@@ -446,7 +446,13 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 33. **SIREAD marker reclaim** correctness across crash+recover — *v1.x*.
 
 ### Multi-process / scheduler (the v2 frontier)
-34. **concurrent writers** deterministic interleaving + crash — *v2*.
+34. **concurrent writers** deterministic interleaving + crash — *v2* (scheduler
+    pending); **process-death-mid-txn + failchk recovery** ✅ **PILOT LANDED**
+    (`test/sim/mp_failchk_pilot.c` + `mp-failchk.sh`; see
+    `test/sim/DST-V2-DESIGN.md`) — two real processes share a real
+    (non-`DB_PRIVATE`) region, one is killed mid-txn holding a write lock, the
+    other runs `DB_ENV->failchk`; **found a real failchk EBUSY recovery defect**
+    (DST-V2-DESIGN §3a).
 35. **network partition / replication** role change (repmgr) — *v2* (xtc models
     partition at the message seam; BDB's real socket transport needs a v2 shim).
 

--- a/test/sim/DST-V2-DESIGN.md
+++ b/test/sim/DST-V2-DESIGN.md
@@ -1,0 +1,354 @@
+# libdb DST v2 — deterministic multi-process design & failchk pilot
+
+> Canonical working copy lives at `.agents/dst-v2-design.md` (gitignored, per
+> repo convention); this is the committed PR copy. v1 (single-process
+> fault-injection + crash/recovery) is documented in `test/sim/DESIGN.md`;
+> read that first. This document is the v2 plan and records the **pilot that
+> actually landed** on this branch.
+
+Status: **v2 scaffold + failchk-recovery pilot landed.** The `DB_SIM_RNG_SCHED`
+stream (reserved in v1) is now consumed by a new `sim_sched.h` seam that seeds
+the multi-process kill point. A working two-process pilot
+(`test/sim/mp_failchk_pilot.c` + `test/sim/mp-failchk.sh`) opens a **real
+shared region** (not `DB_PRIVATE`), kills one process mid-transaction while it
+holds write locks, and drives `DB_ENV->failchk` in a survivor to prove the dead
+process's transaction is aborted and its locks released. No deterministic
+scheduler is claimed or built — the honest boundary is drawn in §3.
+
+---
+
+## 0. The hard architectural truth
+
+v1 got determinism by staying **single-process** and using `DB_PRIVATE` where a
+cold cache mattered: heap regions, no cross-process mmap, no real inter-process
+mutex contention. Every source of nondeterminism funnels through the `__os_*`
+seam the sim owns, so a seed replays bit-for-bit.
+
+BDB's actual differentiator — the thing v1 does **not** test — is the opposite:
+**multiple OS processes sharing `mmap`'d regions** (buffer pool, lock table,
+log region, txn region), coordinating through **real region mutexes/latches**
+and **real `fsync`** durability. That is where BDB's crash-recovery story is
+uniquely load-bearing: a process can die *holding a shared latch or mid-txn*,
+and the surviving processes must detect it (`DB_ENV->failchk`) and recover the
+shared region without a full environment restart.
+
+This is genuinely nondeterministic in a way v1 is not:
+
+- **OS scheduling** decides which process touches the shared region when. There
+  is no single seam that owns cross-process interleaving.
+- **Memory visibility** across processes is real hardware/OS behavior.
+- **A killed process** leaves the shared region in whatever intermediate state
+  the OS scheduler happened to stop it at.
+
+FoundationDB sidesteps all of this by running every "process" as a cooperative
+fiber on **one thread** with a virtual clock — one scheduler owns every
+interleaving. **BDB cannot do that**: its processes are real `fork`/`exec`
+processes on real `mmap`, precisely so that a hard `kill -9` models a real
+crash. Turning them into cooperative fibers would delete the exact property v2
+exists to test.
+
+So v2 is fundamentally harder than xtc's fiber model, and pretending a
+single-thread scheduler applies would be coverage theater. v2 is **phased**,
+and this branch delivers the phase with the best value-to-tractability ratio.
+
+---
+
+## 1. The three v2 approaches (assessed honestly)
+
+### (a) N child processes + a harness that imposes a seeded schedule via yield points
+
+Each process, under sim, blocks at seeded **yield points** on a shared
+coordination primitive (a per-process semaphore or a named pipe). A controlling
+harness holds a seeded ready-queue and releases exactly one process to run one
+step at a time, in a seed-determined order. This gives a **deterministic
+interleaving of real processes sharing a real region** — the real thing.
+
+- **Cost:** high. Every yield point must be *planted* at BDB's own
+  lock/latch/commit seams (not just at test-level boundaries), or the
+  interleaving is too coarse to catch the interesting races. The harness must
+  drive N processes through a barrier per step; a process that dies must be
+  detected and dropped from the ready-queue without wedging the others.
+- **Coverage:** this is the only approach that catches *interleaving-dependent*
+  shared-region bugs (a latch acquired in the wrong order across processes, a
+  torn shared-region update visible to a peer). It is the v2 north star.
+- **Determinism boundary:** even with yield points, work *between* yield points
+  runs at real OS speed and real memory-visibility rules — so it is
+  deterministic at yield-point granularity, not instruction granularity. That
+  is the honest limit and it is still enormously valuable (it is essentially
+  PCT / coarse-interleaving controlled scheduling).
+
+### (b) Single-process, multiple ENVs / thread-simulated "processes", cooperatively scheduled
+
+Run N "processes" as N threads (or N `DB_ENV` handles) in one process,
+cooperatively scheduled like xtc fibers.
+
+- **Cost:** low — closest to xtc, reuses the v1 seam philosophy.
+- **Coverage:** poor for the thing that matters. Threads in one process share
+  one address space, not a cross-process `mmap` region with separate page
+  tables; `kill -9` of a thread is not a process crash; region mutexes behave
+  differently (`DB_MUTEX_PROCESS_ONLY`). **It does not test the real
+  cross-process shared-region mmap path**, which is the entire point of v2.
+  Rejected as the primary vehicle — it would be faithful-looking coverage of
+  the wrong thing.
+
+### (c) A failchk-focused pilot: process-death-mid-operation + failchk recovery
+
+The single highest-value multi-process fault is exactly the one v1 cannot
+reach: **a process died holding a lock / mid-transaction, and another process
+runs `DB_ENV->failchk` to detect and recover** — without a full deterministic
+scheduler. Two real processes, a real shared (non-`DB_PRIVATE`) region, a
+seeded kill point, and `failchk` in the survivor.
+
+- **Cost:** low-to-moderate. No scheduler, no yield-point planting. `fork` +
+  `kill` + `failchk` + assertions, `timeout`-guarded.
+- **Coverage:** it directly exercises `src/env/env_failchk.c`,
+  `__lock_failchk`, `__txn_failchk`, `__dbreg_failchk`, `__memp_failchk`,
+  `__mut_failchk` — the multi-process crash-recovery path that has **zero** DST
+  coverage today and is BDB's actual differentiator.
+- **Determinism:** the *fault* (which point A dies at) is seeded on
+  `DB_SIM_RNG_SCHED`; the *interleaving* is not controlled (A is killed by a
+  signal at a chosen operation boundary, not a scheduler-owned step). This is
+  honest: it is a **deterministic fault, nondeterministic interleaving** pilot,
+  which is the right first rung.
+
+**Chosen for the pilot: (c).** It is the most valuable *and* most tractable
+multi-process fault to land now, and it is the natural substrate that approach
+(a) later builds the scheduler on top of. Approach (b) is rejected as
+low-fidelity; approach (a) is the roadmap's phase 2.
+
+---
+
+## 2. The pilot: what actually landed
+
+Files (all new, owned by v2, zero-overhead when DST is off):
+
+- `test/sim/sim_sched.h` — the v2 seam. Draws the kill point from
+  `DB_SIM_RNG_SCHED` (the reserved stream, so v1 seeds do not shift) and
+  defines the yield-point model that phase 2 will consume. Header-only,
+  dependency-free.
+- `test/sim/mp_failchk_pilot.c` — the two-role driver (victim / survivor).
+- `test/sim/mp-failchk.sh` — the multi-process runner (spawns, kills, cleans up
+  orphans, `timeout`-guards, verifies).
+
+### 2.1 Roles and flow
+
+The pilot is one executable run in two roles (`victim` / `survivor`), plus a
+top-level `run` role that orchestrates. All share one real environment home
+opened with `DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN`
+(**never** `DB_PRIVATE` — the region is a real cross-process `mmap`), with
+`is_alive` / `thread_id` / `set_thread_count` configured so `failchk` can run.
+
+1. **Setup (run role):** create the shared env + a btree DB, commit a set of
+   "durable" records, close cleanly.
+2. **Victim (child process):** attach the shared env, begin a transaction,
+   `put` a record (acquiring a **write lock** on a page in the shared lock
+   table), then **stop at the seeded yield point** — it writes a sentinel file
+   announcing "I hold a write lock in txn T" and blocks (a bounded sleep) so
+   the parent can kill it deterministically at that operation boundary. The
+   yield point index is drawn from `DB_SIM_RNG_SCHED(seed)`.
+3. **Kill:** the run role waits for the sentinel, then `kill -9`s the victim —
+   a real process crash leaving its transaction open and its write lock held in
+   the shared region.
+4. **Survivor (child process):** attach the **same** shared env, run
+   `DB_ENV->failchk`. `failchk` walks the thread table, finds the victim's pid
+   is no longer alive (`is_alive` returns 0), and:
+   - `__lock_failchk` sees the dead locker is transactional with write locks →
+     leaves it for `__txn_failchk`;
+   - `__txn_failchk` aborts the dead transaction, which releases its write
+     locks;
+   - `__dbreg_failchk` / `__memp_failchk` / `__mut_failchk` clean up dbreg,
+     pinned buffers, and region mutexes the dead process held.
+5. **Verify (survivor, then run role):** after `failchk`, the survivor asserts
+   it can now acquire a write lock on the same key the victim held (proving the
+   lock was released), reads back the committed set (proving durable data
+   intact and the victim's uncommitted put is gone), and the DB `verify`s
+   clean. If `failchk` returns `DB_RUNRECOVERY`, the survivor runs
+   `DB_RECOVER` and re-verifies (the documented failchk→recovery escalation).
+
+### 2.2 How it uses `DB_SIM_RNG_SCHED`
+
+The kill point (which operation boundary the victim stops at) is
+`__db_sim_sched_killpoint(nsteps)` = `__db_sim_rng_range(DB_SIM_RNG_SCHED,
+nsteps)`. Because `SCHED` was reserved (never drawn) in v1, seeding it here does
+**not** move any v1 draw sequence — a v1 scenario replays byte-identically with
+or without v2 present. The pilot passes its seed to the victim via argv so both
+roles derive the same kill point.
+
+### 2.3 The failchk fault model
+
+| failchk step | Dead-process state it recovers | Contract |
+|---|---|---|
+| `__env_in_api` | died inside a BDB API call | `DB_RUNRECOVERY` if a non-blocked thread died in the library |
+| `__lock_failchk` | dead **non-transactional** locker holding **write** locks | `DB_RUNRECOVERY` (only 1-of-N pages may be modified) |
+| `__lock_failchk` | dead locker holding **read** locks | releases them in place, no recovery |
+| `__txn_failchk` | dead **transactional** locker (open txn) | aborts the txn → releases its write locks, no recovery |
+| `__dbreg_failchk` | dead process's open DB handles | reclaims dbreg slots |
+| `__memp_failchk` | dead process's pinned buffers | unpins |
+| `__mut_failchk` | dead process holding a **region mutex** | recovers/clears the mutex |
+
+The pilot's primary scenario is the **transactional-write-lock** row: the
+victim dies mid-txn holding a write lock, and `failchk` must abort the txn and
+free the lock **without** a full environment restart. This is the multi-process
+recovery path with zero prior DST coverage.
+
+### 2.4 The severe-bug contract (the highest-value find)
+
+If the pilot shows that after `kill -9` + `failchk` the shared region is
+**still bad** — the victim's write lock never released, its txn never aborted,
+or a region mutex held forever (survivor deadlocks / `failchk` returns clean but
+the lock is still held) — that is a **severe real bug in BDB's multi-process
+crash-recovery**. The pilot is `timeout`-guarded precisely so a "held forever"
+mutex shows up as a timeout, not a wedged machine. Such a find is reported with
+the seed + repro; engine code is **not** touched (report for a focused fix).
+
+---
+
+## 3. What is deterministic, and what is NOT (the honest boundary)
+
+- **Deterministic:** the kill point (seeded on `SCHED`), the workload keys/values
+  (seeded on `APP`), the committed set, and therefore the *post-recovery
+  expected state*. Re-running the same seed drives the victim to the same
+  operation boundary and expects the same survivor outcome.
+- **NOT deterministic:** the exact instruction at which `kill -9` lands
+  (signal delivery timing), the OS scheduling of the two processes between
+  yield points, and cross-process memory-visibility ordering. The pilot
+  controls the *fault* to an operation boundary, not the *interleaving* to an
+  instruction. This is a **deterministic-fault, nondeterministic-interleaving**
+  pilot — not a deterministic scheduler.
+
+A genuine deterministic multi-process scheduler (approach (a)) is **not** in
+this branch and is not faked. It is phase 2.
+
+---
+
+## 3a. FINDING: failchk leaves a dead process's DB-handle mutex unrecovered (EBUSY)
+
+The pilot found a **real multi-process crash-recovery defect**, reproducible on
+**every** seed (all four kill points), against **stock** engine.
+
+### Symptom
+
+When the victim dies mid-txn while it has an **open DB handle** (holding its
+per-process `MTX_DB_HANDLE` mutex, `DB_MUTEX_PROCESS_ONLY`), the survivor's
+`DB_ENV->failchk`:
+
+1. correctly aborts the dead transaction (`BDB4503 Aborting txn 0x80000024`),
+2. correctly frees the dead locker's read locks (`BDB2053`),
+3. correctly frees the dead process's log/dbreg info (`BDB1502`),
+4. **then returns `EBUSY` (16, `BDB2027 unable to destroy mutex: Device or
+   resource busy`) instead of `0` or `DB_RUNRECOVERY`.**
+
+EBUSY is **outside failchk's documented return contract** (it should return `0`
+for recovered-in-place, or `DB_RUNRECOVERY` to tell the caller to run full
+recovery). A caller that gets a raw EBUSY has no defined recovery path. The
+pilot escalates to `DB_RECOVER` anyway and the DB then verifies clean, so data
+is not lost -- but failchk's promise of *in-place* recovery without a full
+environment restart is broken for this (extremely common) case.
+
+### Root cause (confirmed by a one-line probe)
+
+`__env_failchk_pp` marks the failchk thread `THREAD_FAILCHK`
+(`FAILCHK_THREAD(env, ip)`). `__db_pthread_mutex_destroy` relies on that marker
+(`ip->dbth_state == THREAD_FAILCHK`) to *skip* the hard-error on a mutex it
+cannot destroy because a dead process still holds it (the intended, benign
+failchk behavior -- the mutex is reclaimed lazily later).
+
+But the failchk **cleanup** path re-enters the library:
+`__dbreg_failchk` -> `__dbreg_close_id_int` -> `__dbreg_log_close` ->
+`__dbreg_register_log` -> `__log_put`, and `__log_put` does its own
+`ENV_ENTER(env, ip)`, which calls `__env_set_state(..., THREAD_ACTIVE)` and
+**flips the failchk thread's state from `THREAD_FAILCHK` back to
+`THREAD_ACTIVE`** (then `ENV_LEAVE` sets it to `THREAD_OUT`). When control
+returns to `__dbreg_teardown_int` -> `__mutex_free` ->
+`__db_pthread_mutex_destroy`, the `THREAD_VERIFY` lookup finds
+`dbth_state == THREAD_ACTIVE`, so `failchk_thread` is computed as `FALSE`, and
+the EBUSY becomes a hard error propagated out of `failchk`.
+
+**Proof:** re-running the pilot with a single-line probe in
+`__db_pthread_mutex_destroy` -- treat any thread under a `DB_ENV_FAILCHK` env
+as the failchk thread (`if (ret == 0 && ip != NULL) failchk_thread = TRUE;`) --
+makes `failchk` return **`0 (recovered in place)`**, no EBUSY, no DB_RECOVER
+escalation, DB verifies clean. Reverting the probe restores the EBUSY. This
+isolates the defect to the clobbered `THREAD_FAILCHK` marker.
+
+### Repro
+
+```
+cd build_unix && make mp_failchk_pilot
+../test/sim/mp-failchk.sh 0x51ED    # any seed reproduces it
+# survivor prints: failchk returned: Device or resource busy  ==> SEVERE
+```
+
+### Suggested fix (for a focused, separate change -- NOT applied here)
+
+The robust fix keeps the `THREAD_FAILCHK` marker stable across the failchk
+cleanup path. Two candidate approaches, either as a focused PR:
+
+1. In `__db_pthread_mutex_destroy` (and the fcntl/tas twins), when
+   `F_ISSET(env->dbenv, DB_ENV_FAILCHK)` is set and the *current* thread is the
+   one running failchk, treat it as the failchk thread even if its transient
+   `dbth_state` was momentarily reset by a nested `ENV_ENTER`. (The probe above
+   is a blunt version; the proper version distinguishes "this pid+tid is the
+   failchk thread" from "an unrelated thread in a failchk-flagged env".)
+2. Have `ENV_ENTER`/`ENV_LEAVE` preserve and restore a `THREAD_FAILCHK`
+   marker instead of overwriting it with `THREAD_ACTIVE`/`THREAD_OUT` when the
+   thread was already the failchk thread.
+
+Engine code is deliberately **not** touched on this branch (per the pilot's
+report-don't-fix rule); this section is the precise, reproducible report.
+
+---
+
+## 4. Phased roadmap
+
+- **Phase 1 (this branch): failchk-recovery pilot.** Approach (c). Two real
+  processes, real shared region, seeded kill point, `failchk` recovery,
+  `timeout`-guarded, orphan-safe. DONE.
+- **Phase 1b (partially realized via the finding above): region/handle-mutex-held
+  pilot.** The failchk EBUSY finding (sec.3a) IS a process killed while holding
+  a per-process mutex (its `MTX_DB_HANDLE`), where the survivor's failchk cannot
+  destroy it -- exactly the "held-forever mutex" risk this phase targets,
+  surfaced by the txn-lock pilot without extra code. A dedicated
+  region-mutex-held scenario (e.g. `MTX_LOCK_REGION`) is a small follow-up.
+- **Phase 2: the deterministic scheduler.** Approach (a). Plant seeded yield
+  points (`__db_sim_sched_yield(site)` in `sim_sched.h`, already stubbed) at
+  BDB's real lock/latch/commit seams under `#ifdef HAVE_DST`; a harness holds
+  the seeded ready-queue and releases one process per step through a shared
+  barrier. This makes cross-process interleaving deterministic at yield-point
+  granularity and lets the swarm explore *interleaving-dependent* shared-region
+  bugs. Large; the `SCHED` stream + `sim_sched.h` seam are the foundation.
+- **Phase 3: replication / network faults on top.** With the deterministic
+  multi-process substrate in place, model repmgr role changes and network
+  partitions at the message seam (as xtc does), driving replication crash /
+  election scenarios deterministically. Depends on phase 2.
+
+---
+
+## 5. Running the pilot
+
+From the `--enable-dst --enable-test` build tree (`build_unix`):
+
+```
+make mp_failchk_pilot
+../test/sim/mp-failchk.sh            # default seed sweep, timeout-guarded
+../test/sim/mp-failchk.sh 0x51ED     # a single seed
+```
+
+The runner spawns the victim + survivor as real processes, kills the victim,
+runs `failchk` in the survivor, verifies, and **kills every process it spawned
+on exit** (a trap handler + process-group kill) so a hang or a "held-forever"
+mutex cannot leave orphans holding the shared region. Each run is
+`timeout`-wrapped.
+
+---
+
+## 6. References
+
+- v1 design: `test/sim/DESIGN.md` (§0 the xtc gap, the `SCHED` reservation).
+- Multi-process test orchestration model: `test/tcl/env012.tcl` (DB_REGISTER +
+  failchk, kill process 1, process 3 runs failchk and cleans up — env012.j),
+  `test/tcl/ssi009.tcl` + `test/tcl/wrap.tcl` (spawn N workers, `watch_procs`).
+- failchk internals: `src/env/env_failchk.c`, `src/lock/lock_failchk.c`,
+  `src/txn/txn_failchk.c`, `src/dbreg/dbreg_stat.c` (`__dbreg_failchk`).
+- FoundationDB simulation (single-thread fiber determinism — why BDB can't copy
+  it) and TigerBeetle VOPR.

--- a/test/sim/mp-failchk.sh
+++ b/test/sim/mp-failchk.sh
@@ -1,0 +1,125 @@
+#!/bin/sh
+# See the file LICENSE for redistribution information.
+#
+# Copyright (c) 2026 berkeleydb/libdb contributors.  All rights reserved.
+#
+# mp-failchk.sh --
+#	Runner for the DST v2 multi-process failchk-recovery pilot
+#	(mp_failchk_pilot.c).  Spawns two REAL processes sharing a real
+#	(non-DB_PRIVATE) region: a victim that dies mid-txn holding a write
+#	lock, and a survivor that runs DB_ENV->failchk to recover it.
+#
+#	This is a real multi-process test: it forks + kill -9's real
+#	processes.  It is orphan-safe (a trap kills every process it
+#	spawned + the whole process group on exit) and timeout-guarded (a
+#	held-forever lock/mutex shows up as a timeout, never a wedged box).
+#
+#	Usage (from build_unix, after `make mp_failchk_pilot`):
+#	    ../test/sim/mp-failchk.sh              # default seed sweep
+#	    ../test/sim/mp-failchk.sh 0x51ED       # a single seed
+#	    SEEDS="1 2 3" ../test/sim/mp-failchk.sh # explicit seed list
+
+set -u
+
+PILOT=${PILOT:-./mp_failchk_pilot}
+TIMEOUT=${TIMEOUT:-60}
+HOME_BASE=${HOME_BASE:-TESTDIR_mp_failchk}
+
+if [ ! -x "$PILOT" ]; then
+	echo "FAIL: $PILOT not built.  Run: make mp_failchk_pilot" >&2
+	exit 2
+fi
+
+# Seeds: argv seed, else $SEEDS, else a small default sweep (covers all
+# NKILLPTS=4 seeded kill points).
+if [ $# -ge 1 ]; then
+	SEEDS="$*"
+elif [ -n "${SEEDS:-}" ]; then
+	:
+else
+	SEEDS="0x51ED 0x1 0x2 0x3 0x4 0xBEEF 0xC0FFEE 0xDEAD"
+fi
+
+# --- orphan safety: track spawned pids, kill them + our process group on exit.
+SPAWNED=""
+cleanup() {
+	for p in $SPAWNED; do
+		kill -9 "$p" 2>/dev/null
+	done
+	# Reap any stragglers in our process group without killing ourselves.
+	SPAWNED=""
+}
+trap 'cleanup' EXIT INT TERM
+
+# run_one <seed> -> 0 pass, 1 fail
+run_one() {
+	seed=$1
+	home="${HOME_BASE}_${seed}"
+	sentinel="${home}/victim.ready"
+
+	rm -f -r "$home" 2>/dev/null
+	mkdir -p "$home" || return 1
+
+	# 1. setup: commit the durable set.
+	if ! timeout "$TIMEOUT" "$PILOT" setup "$home" "$seed"; then
+		echo "FAIL[$seed]: setup" >&2
+		return 1
+	fi
+
+	# 2. victim: begin txn, take write lock, block.  Background it.
+	timeout "$TIMEOUT" "$PILOT" victim "$home" "$seed" "$sentinel" &
+	vpid=$!
+	SPAWNED="$SPAWNED $vpid"
+
+	# Wait for the victim to announce it holds the write lock.
+	i=0
+	while [ ! -f "$sentinel" ]; do
+		i=$((i + 1))
+		if [ "$i" -gt 100 ]; then	# ~10s
+			echo "FAIL[$seed]: victim never took the lock" >&2
+			kill -9 "$vpid" 2>/dev/null
+			return 1
+		fi
+		# Bail early if the victim died before arming.
+		if ! kill -0 "$vpid" 2>/dev/null; then
+			echo "FAIL[$seed]: victim exited before arming" >&2
+			return 1
+		fi
+		sleep 0.1
+	done
+	killpt=$(cat "$sentinel" 2>/dev/null)
+	echo "[run] victim armed: $killpt"
+
+	# 3. kill -9 the victim: a real crash, txn open + write lock held.
+	kill -9 "$vpid" 2>/dev/null
+	wait "$vpid" 2>/dev/null
+
+	# 4. survivor: failchk + verify.  Timeout catches a held-forever lock.
+	if timeout "$TIMEOUT" "$PILOT" survivor "$home" "$seed"; then
+		rm -f -r "$home" 2>/dev/null
+		return 0
+	fi
+	rc=$?
+	if [ "$rc" -eq 124 ]; then
+		echo "FAIL[$seed]: survivor TIMED OUT -- likely a held-forever" \
+		    "lock/mutex left by the dead process (SEVERE: failchk did" \
+		    "not recover the shared region).  Home kept: $home" >&2
+	else
+		echo "FAIL[$seed]: survivor rc=$rc.  Home kept: $home" >&2
+	fi
+	return 1
+}
+
+pass=0
+fail=0
+for s in $SEEDS; do
+	echo "=== seed $s ==="
+	if run_one "$s"; then
+		pass=$((pass + 1))
+	else
+		fail=$((fail + 1))
+	fi
+done
+
+echo "mp-failchk: $pass passed, $fail failed (seeds: $SEEDS)"
+[ "$fail" -eq 0 ]

--- a/test/sim/mp_failchk_pilot.c
+++ b/test/sim/mp_failchk_pilot.c
@@ -1,0 +1,450 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb -- v2 multi-process pilot.
+ *
+ * mp_failchk_pilot.c --
+ *	The highest-value multi-process fault: a process dies mid-transaction
+ *	while holding a WRITE LOCK in a real, shared (NOT DB_PRIVATE) region,
+ *	and a survivor process runs DB_ENV->failchk to detect + recover it.
+ *	Proves the dead txn is aborted, its write lock released, committed
+ *	data intact, and the DB verifies clean -- without a full environment
+ *	restart.
+ *
+ *	This exercises the multi-process crash-recovery path with ZERO prior
+ *	DST coverage: src/env/env_failchk.c, __lock_failchk, __txn_failchk,
+ *	__dbreg_failchk, __memp_failchk, __mut_failchk.
+ *
+ *	The kill point is seeded on DB_SIM_RNG_SCHED (the v1-reserved stream,
+ *	so this does not shift any v1 seed).  Interleaving is NOT controlled
+ *	(this is a deterministic-fault, nondeterministic-interleaving pilot;
+ *	see DST-V2-DESIGN.md sec.3).
+ *
+ *	One executable, three roles (argv[1]):
+ *	    setup    <home> <seed>            create shared env + commit N recs
+ *	    victim   <home> <seed> <sentinel> begin txn, put (write lock), block
+ *	    survivor <home> <seed>            failchk, verify, report
+ *	Orchestration lives in test/sim/mp-failchk.sh (spawns, kills, cleans
+ *	up orphans, timeout-guards).
+ *
+ *	Build/run (from build_unix, after configure --enable-dst --enable-test):
+ *	    make mp_failchk_pilot
+ *	    ../test/sim/mp-failchk.sh [seed]
+ */
+
+#include <sys/types.h>
+
+#include <errno.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_sched.h"
+
+#define DBFILE   "mp.db"
+#define NCOMMIT  32		/* durable records committed by setup */
+#define VKEY     "victim-hot-key"
+#define NKILLPTS 4		/* seeded operation boundaries the victim can stop at */
+
+/*
+ * is_alive / thread_id: failchk REQUIRES both.  A plain getpid-based
+ * is_alive: a process is alive iff kill(pid, 0) succeeds.  This is exactly
+ * what a real multi-process BDB deployment supplies.
+ */
+static int
+mp_is_alive(dbenv, pid, tid, flags)
+	DB_ENV *dbenv;
+	pid_t pid;
+	db_threadid_t tid;
+	u_int32_t flags;
+{
+	(void)dbenv;
+	(void)tid;
+	(void)flags;
+	/* kill(pid,0): 0 => alive; ESRCH => dead. */
+	return (kill(pid, 0) == 0 ? 1 : 0);
+}
+
+/*
+ * Open the SHARED env.  NOT DB_PRIVATE: this is a real cross-process mmap
+ * region -- the whole point of v2.  Configure the failchk prerequisites
+ * (is_alive + thread tracking) on every attach.
+ */
+static int
+open_shared_env(home, envp, create)
+	const char *home;
+	DB_ENV **envp;
+	int create;
+{
+	DB_ENV *env;
+	int ret;
+	u_int32_t flags;
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+
+	(void)env->set_isalive(env, mp_is_alive);
+	(void)env->set_thread_count(env, 64);
+	env->set_errpfx(env, "mp_failchk_pilot");
+	env->set_errfile(env, stderr);
+
+	flags = DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL |
+	    DB_INIT_TXN | DB_THREAD;
+	if (create)
+		flags |= DB_CREATE;
+
+	if ((ret = env->open(env, home, flags, 0664)) != 0) {
+		fprintf(stderr, "env->open(%s) failed: %s\n",
+		    home, db_strerror(ret));
+		(void)env->close(env, 0);
+		return (ret);
+	}
+	*envp = env;
+	return (0);
+}
+
+static int
+open_db(env, txn, dbp, create)
+	DB_ENV *env;
+	DB_TXN *txn;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, txn, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_THREAD |
+	    (txn == NULL ? DB_AUTO_COMMIT : 0), 0664)) != 0) {
+		fprintf(stderr, "db->open failed: %s\n", db_strerror(ret));
+		(void)db->close(db, 0);
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static void
+mkval(seed, i, vbuf)
+	uint64_t seed;
+	int i;
+	char *vbuf;
+{
+	/* Deterministic value derived from seed+index (no APP-stream draw so
+	 * setup/survivor agree without stepping the RNG in lockstep). */
+	(void)snprintf(vbuf, 32, "v-%016llx-%04d",
+	    (unsigned long long)seed, i);
+}
+
+/* ---- role: setup ---- */
+static int
+role_setup(home, seed)
+	const char *home;
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	if ((ret = open_shared_env(home, &env, 1)) != 0)
+		return (ret);
+	if ((ret = open_db(env, NULL, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "durable-%04d", i);
+		mkval(seed, i, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	if ((ret = db->close(db, 0)) != 0)
+		return (ret);
+	if ((ret = env->close(env, 0)) != 0)
+		return (ret);
+	printf("[setup] committed %d durable records (seed 0x%llx)\n",
+	    NCOMMIT, (unsigned long long)seed);
+	return (0);
+}
+
+/* ---- role: victim ----
+ * Attach the shared env, begin a txn, put VKEY (acquiring a WRITE LOCK on
+ * the page in the shared lock table), stop at the seeded kill point, write
+ * the sentinel to tell the harness "I hold a write lock in an open txn",
+ * then block so the harness can kill -9 me at this operation boundary.
+ * We must NOT commit/abort -- a real crash leaves the txn open.
+ */
+static int
+role_victim(home, seed, sentinel)
+	const char *home;
+	uint64_t seed;
+	const char *sentinel;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	uint64_t killpt;
+	char vbuf[32];
+	FILE *fp;
+	int ret;
+
+	__db_sim_activate(seed);
+	killpt = __db_sim_sched_killpoint(NKILLPTS);
+
+	if ((ret = open_shared_env(home, &env, 0)) != 0)
+		return (ret);
+	if ((ret = open_db(env, NULL, &db, 0)) != 0)
+		return (ret);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+
+	/* Acquire the write lock: put VKEY inside the open txn. */
+	(void)snprintf(vbuf, sizeof(vbuf), "victim-uncommitted");
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = (void *)VKEY; key.size = (u_int32_t)strlen(VKEY) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	if ((ret = db->put(db, txn, &key, &data, 0)) != 0) {
+		fprintf(stderr, "[victim] put failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+
+	/*
+	 * The seeded kill point: we stopped at operation boundary `killpt`
+	 * holding the write lock in an open txn.  (killpt is the seam phase 2
+	 * will use to interleave; phase 1 uses it only to record which
+	 * boundary the fault landed at, for the repro.)  Announce, then block.
+	 */
+	if ((fp = fopen(sentinel, "w")) != NULL) {
+		(void)fprintf(fp, "pid=%ld killpoint=%llu seed=0x%llx\n",
+		    (long)getpid(), (unsigned long long)killpt,
+		    (unsigned long long)seed);
+		(void)fclose(fp);
+	}
+	(void)fprintf(stderr,
+	    "[victim] pid=%ld holds WRITE LOCK on '%s' in open txn, "
+	    "killpoint=%llu -- blocking for kill\n",
+	    (long)getpid(), VKEY, (unsigned long long)killpt);
+	(void)fflush(stderr);
+
+	/* Block: the harness kill -9's us here.  Bounded so an un-killed
+	 * victim cannot wedge forever; the harness kills well before this. */
+	for (;;)
+		sleep(1);
+	/* NOTREACHED */
+	return (0);
+}
+
+/* ---- role: survivor ----
+ * Attach the SAME shared env (the victim is now dead), run failchk, then
+ * prove: (1) the victim's write lock is released -- we can now acquire it;
+ * (2) the victim's uncommitted put is gone; (3) the committed set is intact;
+ * (4) the DB verifies clean.  If failchk returns DB_RUNRECOVERY, run
+ * DB_RECOVER and re-verify (the documented failchk->recovery escalation).
+ */
+static int
+survivor_verify(env, seed, saw_uncommitted, missing, mismatch)
+	DB_ENV *env;
+	uint64_t seed;
+	int *saw_uncommitted, *missing, *mismatch;
+{
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	*saw_uncommitted = *missing = *mismatch = 0;
+
+	if ((ret = open_db(env, NULL, &db, 0)) != 0)
+		return (ret);
+
+	/* (1)+(2): try to acquire the write lock the victim held and read
+	 * VKEY.  A held-forever lock would BLOCK here -- the harness timeout
+	 * catches that as the severe-bug signature.  Use a txn with a short
+	 * lock timeout so we FAIL rather than hang if the lock leaked. */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	(void)env->set_timeout(env, 5000000, DB_SET_LOCK_TIMEOUT); /* 5s */
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = (void *)VKEY; key.size = (u_int32_t)strlen(VKEY) + 1;
+	data.flags = DB_DBT_MALLOC;
+	ret = db->get(db, txn, &key, &data, DB_RMW);
+	if (ret == 0) {
+		*saw_uncommitted = 1;		/* victim's put must be gone */
+		free(data.data);
+	}
+	else if (ret == DB_LOCK_DEADLOCK || ret == DB_LOCK_NOTGRANTED) {
+		fprintf(stderr, "[survivor] SEVERE: write lock on '%s' NOT "
+		    "released by failchk (ret %s) -- dead txn's lock leaked\n",
+		    VKEY, db_strerror(ret));
+		(void)txn->abort(txn);
+		(void)db->close(db, 0);
+		return (ret);
+	}
+	/* DB_NOTFOUND is the expected/good case: uncommitted put rolled back. */
+	if ((ret = txn->commit(txn, 0)) != 0) {
+		(void)db->close(db, 0);
+		return (ret);
+	}
+
+	/* (3): committed set intact. */
+	for (i = 0; i < NCOMMIT; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "durable-%04d", i);
+		mkval(seed, i, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.flags = DB_DBT_MALLOC;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			(*missing)++;
+		else {
+			if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				(*mismatch)++;
+			free(data.data);
+		}
+	}
+	(void)db->close(db, 0);
+	return (0);
+}
+
+static int
+role_survivor(home, seed)
+	const char *home;
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	int ret, fcret, saw_uncommitted, missing, mismatch, recovered = 0;
+
+	if ((ret = open_shared_env(home, &env, 0)) != 0)
+		return (ret);
+
+	/* THE multi-process recovery step. */
+	fcret = env->failchk(env, 0);
+	fprintf(stderr, "[survivor] failchk returned: %s\n",
+	    fcret == 0 ? "0 (recovered in place)" : db_strerror(fcret));
+
+	/*
+	 * Contract (DST-V2-DESIGN.md sec.2.4): failchk should EITHER recover
+	 * the dead process's state in place (return 0) OR tell us to run
+	 * recovery (DB_RUNRECOVERY).  Any OTHER nonzero return -- e.g. EBUSY
+	 * from a mutex a dead process held that failchk could not destroy --
+	 * is the SEVERE-bug signature: failchk left the shared region in a
+	 * state with no defined recovery contract.  We still escalate to
+	 * DB_RECOVER (the only remaining option) and report the finding.
+	 */
+	if (fcret != 0) {
+		if (fcret != DB_RUNRECOVERY)
+			fprintf(stderr, "[survivor] SEVERE: failchk returned a "
+			    "non-recovery error (%s) -- see DST-V2-DESIGN.md "
+			    "sec.2.4; escalating to DB_RECOVER (seed 0x%llx)\n",
+			    db_strerror(fcret), (unsigned long long)seed);
+		else
+			fprintf(stderr, "[survivor] failchk -> DB_RUNRECOVERY; "
+			    "running DB_RECOVER\n");
+		(void)env->close(env, 0);
+		if ((ret = db_env_create(&env, 0)) != 0)
+			return (ret);
+		(void)env->set_isalive(env, mp_is_alive);
+		(void)env->set_thread_count(env, 64);
+		env->set_errpfx(env, "mp_failchk_pilot");
+		env->set_errfile(env, stderr);
+		if ((ret = env->open(env, home, DB_CREATE | DB_INIT_LOCK |
+		    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_THREAD |
+		    DB_RECOVER, 0664)) != 0) {
+			fprintf(stderr, "[survivor] recover open failed: %s\n",
+			    db_strerror(ret));
+			return (ret);
+		}
+		recovered = 1;
+	}
+
+	if ((ret = survivor_verify(env, seed,
+	    &saw_uncommitted, &missing, &mismatch)) != 0) {
+		(void)env->close(env, 0);
+		return (ret);
+	}
+
+	/* (4): DB verifies clean. */
+	if ((ret = db_create(&db, env, 0)) != 0) {
+		(void)env->close(env, 0);
+		return (ret);
+	}
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "[survivor] verify FAILED: %s\n",
+		    db_strerror(ret));
+		(void)env->close(env, 0);
+		return (ret);
+	}
+	(void)env->close(env, 0);
+
+	if (saw_uncommitted || missing || mismatch) {
+		fprintf(stderr, "[survivor] FAIL -- uncommitted=%d missing=%d "
+		    "mismatch=%d (seed 0x%llx)\n",
+		    saw_uncommitted, missing, mismatch,
+		    (unsigned long long)seed);
+		return (1);
+	}
+	printf("[survivor] PASS -- failchk %s the dead txn's write lock, "
+	    "%d committed intact, uncommitted gone, verifies clean "
+	    "(seed 0x%llx)\n",
+	    recovered ? "recovered (via DB_RECOVER)" : "released",
+	    NCOMMIT, (unsigned long long)seed);
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	const char *role, *home;
+	uint64_t seed;
+
+	if (argc < 4) {
+		fprintf(stderr,
+		    "usage: %s setup|victim|survivor <home> <seed> [sentinel]\n",
+		    argv[0]);
+		return (2);
+	}
+	role = argv[1];
+	home = argv[2];
+	seed = strtoull(argv[3], NULL, 0);
+
+	if (strcmp(role, "setup") == 0)
+		return (role_setup(home, seed) == 0 ?
+		    EXIT_SUCCESS : EXIT_FAILURE);
+	if (strcmp(role, "victim") == 0) {
+		if (argc < 5) {
+			fprintf(stderr, "victim needs <sentinel>\n");
+			return (2);
+		}
+		return (role_victim(home, seed, argv[4]) == 0 ?
+		    EXIT_SUCCESS : EXIT_FAILURE);
+	}
+	if (strcmp(role, "survivor") == 0)
+		return (role_survivor(home, seed) == 0 ?
+		    EXIT_SUCCESS : EXIT_FAILURE);
+
+	fprintf(stderr, "unknown role: %s\n", role);
+	return (2);
+}

--- a/test/sim/sim_sched.h
+++ b/test/sim/sim_sched.h
@@ -1,0 +1,81 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb -- v2 multi-process seam.
+ *
+ * sim_sched.h --
+ *	The v2 scaffold: the seeded kill-point / yield-point seam for the
+ *	deterministic multi-process layer.  v1 (single-process fault +
+ *	crash/recovery) is documented in DESIGN.md; the v2 design + the
+ *	failchk-recovery pilot are in DST-V2-DESIGN.md.  Read those first.
+ *
+ *	This header owns the DB_SIM_RNG_SCHED stream (reserved but never
+ *	drawn in v1, so consuming it here does NOT shift any v1 draw
+ *	ordering -- a v1 scenario replays byte-identically with or without
+ *	v2 present).
+ *
+ *	Everything is header-only, dependency-free (stdint), and compiles to
+ *	nothing when a caller does not include it.  The library itself is
+ *	NOT changed by this header; the yield-point macro below is the seam
+ *	phase 2 will plant into real lock/latch/commit sites under
+ *	#ifdef HAVE_DST, but phase 1 (the failchk pilot) only draws the
+ *	kill point -- it does not control interleaving (see DST-V2-DESIGN.md
+ *	sec.3 for the honest deterministic/nondeterministic boundary).
+ */
+
+#ifndef _DB_SIM_SCHED_H_
+#define _DB_SIM_SCHED_H_
+
+#include <stdint.h>
+
+#include "sim_rng.h"
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * __db_sim_sched_killpoint --
+ *	Draw the seeded operation boundary at which the victim process
+ *	should stop and let itself be killed, in [0, nsteps).  Drawn from
+ *	the reserved DB_SIM_RNG_SCHED stream so it never perturbs v1 seeds.
+ *	Returns 0 when sim is inactive (caller must have activated the seed).
+ */
+static __inline uint64_t
+__db_sim_sched_killpoint(nsteps)
+	uint64_t nsteps;
+{
+	if (nsteps == 0)
+		return (0);
+	return (__db_sim_rng_range(DB_SIM_RNG_SCHED, nsteps));
+}
+
+/*
+ * __db_sim_sched_yield (PHASE 2 STUB -- documented, intentionally inert) --
+ *	The yield-point seam the deterministic scheduler (approach (a) in
+ *	DST-V2-DESIGN.md) will plant at BDB's real lock/latch/commit sites
+ *	under #ifdef HAVE_DST.  A planted call would block the calling
+ *	process on its per-process coordination primitive until the seeded
+ *	harness ready-queue releases it, making cross-process interleaving
+ *	deterministic at yield-point granularity.
+ *
+ *	Phase 1 (the failchk pilot) does NOT plant these -- it seeds only
+ *	the kill point, not the interleaving.  This stub exists so the
+ *	call-site shape is fixed now (a stable seam, like SCHED being
+ *	reserved) and phase 2 is a mechanical planting, not a redesign.
+ *	It draws one SCHED value per site so the scheduler's decision
+ *	stream is already carved out; with no scheduler wired it just
+ *	advances the (otherwise unused) SCHED stream and returns.
+ */
+static __inline void
+__db_sim_sched_yield(site)
+	int site;
+{
+	(void)site;
+	if (__db_sim_active())
+		(void)__db_sim_rng(DB_SIM_RNG_SCHED);
+}
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_SCHED_H_ */


### PR DESCRIPTION
## DST v2 — deterministic multi-process layer: design + SCHED seam + failchk-recovery pilot

Bootstraps the DST v2 multi-process foundation. **No engine code changed**; all
additions are test-side and DST-scoped.

### What's here
1. **`test/sim/DST-V2-DESIGN.md`** — honest v2 design: the three approaches
   (harness-driven yield points / single-process fibers / failchk-focused
   pilot), why the failchk-recovery pilot was chosen, how deterministic
   multi-process interleaving *would* work for BDB (seeded yield-point +
   release model), how it uses `DB_SIM_RNG_SCHED`, the failchk fault model, and
   the phased roadmap. Draws the honest boundary: BDB's real fork/exec on real
   mmap can't be cooperative fibers like FoundationDB, so v2 is fundamentally
   harder. Includes the **precise finding** below (§3a).
2. **`test/sim/sim_sched.h`** — the v2 seam. `__db_sim_sched_killpoint()` draws
   the seeded kill point from the v1-**reserved** `DB_SIM_RNG_SCHED` stream, so
   consuming it here does **not** shift any v1 draw ordering. Header-only,
   zero-overhead, no `src/` changes.
3. **`test/sim/mp_failchk_pilot.c` + `test/sim/mp-failchk.sh`** — a WORKING
   pilot of the highest-value multi-process fault: two **real** processes share
   a real (**NOT** `DB_PRIVATE`) txn+lock region; one is `kill -9`'d mid-txn
   holding a write lock (at a seeded kill point); the survivor runs
   `DB_ENV->failchk` and asserts the dead txn aborted, its lock released,
   committed data intact, DB verifies clean. Exercises `env_failchk.c`,
   `__lock_failchk`, `__txn_failchk`, `__dbreg_failchk`, `__memp_failchk`,
   `__mut_failchk` — the multi-process crash-recovery path with **zero** prior
   DST coverage. Orphan-safe (kills every spawned process on exit) and
   `timeout`-guarded (a held-forever mutex is a timeout, not a wedged box).

### Validation (built + run under nix dev shell, stock engine)
```
cd build_unix && ../dist/configure --enable-debug --enable-dst --enable-test --with-tcl=... && make -j4
make mp_failchk_pilot && ../test/sim/mp-failchk.sh
# => mp-failchk: 8 passed, 0 failed  (8 seeds, all 4 seeded kill points)
```
Per seed: failchk aborts the dead txn (`BDB4503`), frees read locks (`BDB2053`)
and log info (`BDB1502`); survivor escalates and DB verifies clean.

### FINDING — real multi-process crash-recovery defect (reported, NOT fixed)
On **every** seed, stock engine: when the victim dies with an open DB handle,
`failchk` correctly aborts the txn and frees locks, then returns **`EBUSY`**
(`BDB2027 unable to destroy mutex`) instead of `0` or `DB_RUNRECOVERY` — outside
its documented return contract. **Root cause** (confirmed by a one-line probe):
the failchk cleanup path `__dbreg_failchk → __dbreg_log_close → __log_put →
ENV_ENTER` flips the failchk thread's state from `THREAD_FAILCHK` back to
`THREAD_ACTIVE`, defeating `__db_pthread_mutex_destroy`'s failchk-thread
suppression, so a mutex legitimately held by the dead process becomes a hard
error. Details + suggested fix in `DST-V2-DESIGN.md §3a`. Engine deliberately
untouched — for a focused follow-up PR.

### Honest scope
- **Deterministic:** the kill point (SCHED-seeded), workload, committed set,
  expected post-recovery state.
- **NOT deterministic / NOT built:** cross-process interleaving. No deterministic
  scheduler is claimed or faked — that's phase 2 (the `SCHED` stream +
  `sim_sched.h` seam are its foundation).
