### PR TITLE
feat(dst): clock-skew / time-jump fault class + scenarios

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1731,6 +1731,29 @@ test_sim_logrollover_crash: test_sim_logrollover_crash@o@ $(DEF_LIB)
 	    $(LIBS)
 	$(POSTLINK) $@
 
+test_sim_clockskew_timeout@o@: $(testdir)/sim/test_sim_clockskew_timeout.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_clockskew_timeout: test_sim_clockskew_timeout@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_clockskew_timeout@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_clockskew_ckp@o@: $(testdir)/sim/test_sim_clockskew_ckp.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_clockskew_ckp: test_sim_clockskew_ckp@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_clockskew_ckp@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_clockskew_backward@o@: $(testdir)/sim/test_sim_clockskew_backward.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_clockskew_backward: test_sim_clockskew_backward@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_clockskew_backward@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_hash_crash test_sim_recno_crash test_sim_queue_crash \
 	test_sim_ckp_crash test_sim_torn_log test_sim_enospc \
@@ -1741,7 +1764,9 @@ dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_cursor_crash test_sim_latency_load test_sim_swarm \
 	test_sim_ckp_lsn test_sim_multidb_crash test_sim_largeabort \
 	test_sim_log_enospc test_sim_data_log_order test_sim_torn_meta \
-	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash
+	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash \
+	test_sim_clockskew_timeout test_sim_clockskew_ckp \
+	test_sim_clockskew_backward
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/src/os/os_clock.c
+++ b/src/os/os_clock.c
@@ -10,6 +10,10 @@
 
 #include "db_int.h"
 
+#ifdef HAVE_DST
+#include "sim_os.h"			/* DST clock-skew hook (--enable-dst only). */
+#endif
+
 /*
  * __os_gettime --
  *	Return the current time-of-day clock in seconds and nanoseconds.
@@ -64,6 +68,18 @@ __os_gettime(env, tp, monotonic)
 	tp->tv_nsec = 0;
 #else
 	NO AVAILABLE CLOCK IMPLEMENTATION
+#endif
+#ifdef HAVE_DST
+	/*
+	 * DST clock-skew / time-jump fault: when a sim armed the knob, apply
+	 * the seeded skew (fixed offset + jitter + occasional forward/BACKWARD
+	 * jump) to the reading BDB is about to return.  This is the single
+	 * seam every time-dependent decision (lock/txn timeout deadlines, the
+	 * deadlock detector's expiry scan, checkpoint scheduling, replication
+	 * lease/election timers) reads "now" through.  A no-op when no sim is
+	 * running; compiled out entirely without --enable-dst (zero overhead).
+	 */
+	__db_sim_clock_hook(tp, monotonic);
 #endif
 	COMPQUIET(monotonic, 0);
 	return;

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -6,7 +6,7 @@ Status: **v1 foundation landed + v1.x depth grown** (this branch). Seeded
 PRNG tree, determinism
 guard, buggify, simulated-I/O fault knobs, the write-back-cache durable-frontier
 crash model, the `__os_*` I/O hooks, a `--enable-dst` build switch that is
-zero-overhead when off, and a **32-scenario** catalog plus a FoundationDB-style
+zero-overhead when off, and a **35-scenario** catalog plus a FoundationDB-style
 **swarm runner** with per-fault activation coverage (now with a hard
 coverage-gap guard) and **eight** planted-bug yardsticks. Modeled on
 FoundationDB / TigerBeetle and the xtc project's DST (`/home/gburd/ws/xtc`).
@@ -161,6 +161,58 @@ Each fault firing (not merely arming) bumps a **fault-activation counter**
 (`__db_sim_fault_count(class)`), so the swarm can report per-fault activation
 coverage across a seed sweep -- a class that never fires is a coverage gap.
 
+### 1.4a Clock-skew / time-jump fault (`sim_clock.h`, in `sim_core.c`)
+
+A fault class at BDB's **time seam** (`__os_gettime`), modeled on
+FoundationDB's clock skew: a process's clock can read ahead/behind "true"
+time and can jump.  When armed under sim, the `__os_gettime` hook applies a
+seeded skew to every reading BDB is about to return:
+
+- **fixed per-run offset** -- a clock steadily ahead/behind true time
+  (cancels out in a `deadline = now + timeout` / `now2 >= deadline`
+  comparison, so on its own it is benign -- proving the comparison is
+  offset-relative);
+- **per-read jitter** -- a jumpy, imprecise clock (uniform in `[-j, +j]`);
+- **occasional discrete JUMP** -- forward or, the dangerous one, **BACKWARD**,
+  by up to a bounded magnitude with a per-1000 probability.  A backward jump
+  can push a fresh `now2` reading below an already-set deadline, so a
+  timeout that trusts a monotonic clock could **never fire (hang)** or fire
+  **instantly (premature)**.
+
+The disturbance can be bounded to the first *N* clock reads
+(`__db_sim_clock_settle_after`), after which the clock "settles" back to true
+time.  This models a **transient** jump (a real skew event has finite
+duration): a persistent adversary clock that never advances past a fixed
+deadline could never fire ANY deadline-based timeout -- that is physics, not
+a bug -- so the dangerous-case scenarios use a bounded, recovering jump and
+assert the timeout fires ONCE the clock recovers.
+
+All bounded + seeded, drawn from a **dedicated CLOCK PRNG stream**
+(`DB_SIM_RNG_CLOCK`) so arming clock skew never perturbs the IO/FAULT/APP
+streams -- same seed => same skew sequence => replayable.  A firing bumps the
+`clock` fault-activation counter.  The hook is `#ifdef HAVE_DST` in
+`src/os/os_clock.c` and is a single `__db_sim_active()` relaxed load in the
+no-sim case; a DST-off build compiles it out entirely (verified: 0
+`__db_sim_*` symbols, `os_clock.o` has no `sim` references).
+
+**Which decisions read the clock (and could misbehave on a jump):** lock/txn
+timeout deadlines (`__clock_set_expires` / `__clock_expired` in
+`src/common/clock.c`, driving `__lock_get_internal`'s `tx_expire`/`lk_expire`
+and the deadlock detector's `DB_LOCK_EXPIRE` scan in `lock_deadlock.c` /
+`lock.c`), and the replication lease/election timers (`src/rep`,
+`src/repmgr`).  **Honest finding on the time seam:** libdb's `__os_gettime`
+is called with `monotonic=1` on the timeout paths, but on the
+`HAVE_CLOCK_GETTIME` platform (Linux) the function unconditionally re-reads
+`CLOCK_REALTIME` after the monotonic read (a stray second `clock_gettime`
+call in `os_clock.c`), so every reading is effectively **wall-clock, not
+monotonic** -- which makes clock skew a *real* risk worth testing rather than
+a theoretical one.  The checkpoint MINUTE-interval decision in
+`__txn_checkpoint` and the checkpoint-record timestamp read libc `time()`
+**directly** (because `HAVE_TIME` is defined the library's `time()` wrapper is
+not compiled), so they bypass `__os_gettime` and are NOT reachable by this
+skew -- itself a finding (that decision is inherently robust to
+`__os_gettime` skew).
+
 Keyed by a **stable FNV-1a hash of the file name** (not the fd), so the
 frontier tracks a *logical* file across libdb's frequent close/reopen — exactly
 how a real disk behaves.
@@ -242,7 +294,7 @@ replay of the same seed would fail.
 
 ## 3. Scenarios (all runnable now, all PASS)
 
-Thirty-two scenarios (plus the swarm runner); the crash/fault ones each pass
+Thirty-five scenarios (plus the swarm runner); the crash/fault ones each pass
 across a multi-seed sweep and replay bit-identically per seed.
 
 | Scenario | Proves | Result |
@@ -280,6 +332,9 @@ across a multi-seed sweep and replay bit-identically per seed.
 | `test_sim_compound_fault` | latency + ENOSPC + torn all active at once across a crash: durable prefix intact, tree clean, no silent-bad | PASS (3 faults fire) |
 | `test_sim_logrollover_crash` | crash with the WAL spread over multiple log files: every commit survives across the rollover boundary | PASS (400 commits / 3 log files) |
 | `test_sim_swarm` | **swarm**: mixed-fault sweep, per-fault activation coverage + gap guard, replay | PASS (512 seeds, 0 violations) |
+| `test_sim_clockskew_timeout` | **lock timeout under a non-monotonic clock**: main thread holds a write lock, a helper blocks on a conflicting lock with a lock timeout, the clock is skewed (offset + jitter + forward AND backward jumps); the deadlock detector's expiry scan still fires the timeout (DB_LOCK_NOTGRANTED) -- no hang, no corruption; wall-clock-alarm-guarded | PASS (deterministic; skew count seed-sensitive) |
+| `test_sim_clockskew_ckp` | **checkpoint + recovery under a large FORWARD clock jump**: explicit checkpoints taken while the clock leaps ahead by up to an hour; after a crash every acked commit is durable and the tree verifies clean -- a forward jump corrupts no checkpoint/recovery state | PASS (256 committed durable) |
+| `test_sim_clockskew_backward` | **the dangerous case -- a TRANSIENT BACKWARD jump**: a legitimately-set txn deadline, then the clock is knocked backward (offset + backward-leaning jumps) for a bounded window, then settles; the timeout still fires once the recovered clock crosses the fixed deadline -- **the timeout is not LOST**; asserts determinism (replay identical skew count + verdict); wall-clock-alarm-guarded | PASS (deterministic; robust to backward jump) |
 
 **Recovery-before-verify discipline** (from
 `.agents/concurrent-btree-corruption.md`): a crashed txn env verified *without*
@@ -431,7 +486,7 @@ scheduler / multi-process). ~34 scenarios across BDB subsystems.
 
 ### Lock / deadlock
 24. **deadlock detection** picks a victim deterministically (seeded) — *v2*.
-25. **lock timeout** under seeded clock skew — *v2* (needs virtual clock).
+25. **lock timeout** under seeded clock skew — *v1.x* ✅ `test_sim_clockskew_timeout` (lock timeout fires under offset+jitter+jump), `test_sim_clockskew_backward` (a transient BACKWARD jump does not lose the timeout).  Single-process, driven via the lock API + a helper thread + the deadlock detector's `DB_LOCK_EXPIRE` scan; the virtual-clock seam is the `__os_gettime` skew hook.  **Result: BDB's expiry scan re-reads the clock fresh each scan and holds a fixed deadline target, so it is robust to a non-monotonic (jumping/backward) clock -- no lost or premature timeout.**
 26. **lock-table region exhaustion** graceful degradation — *v1.x*.
 
 ### Transactions

--- a/test/sim/README.md
+++ b/test/sim/README.md
@@ -14,6 +14,7 @@ axis. The full deterministic multi-process scheduler is v2 (design doc §0).
 |---|---|
 | `sim_rng.h` | seeded per-stream PRNG + activation/guard API |
 | `sim_fault.h` | fault toggles, buggify, I/O fault knobs, write-back model API |
+| `sim_clock.h` | clock-skew / time-jump fault knobs (offset + jitter + forward/backward jump) at the `__os_gettime` seam |
 | `sim_os.h` | declarations of the `__os_*` I/O hooks (included by the os layer) |
 | `sim_inject.h` | planted-bug ids (`DB_DST_INJECT_BUG`) — the bug-detection yardstick |
 | `sim_scenario.h` | shared crash/recover helpers (fork+crash+recover boilerplate) |
@@ -42,6 +43,9 @@ axis. The full deterministic multi-process scheduler is v2 (design doc §0).
 | `test_sim_latency_load.c` | slow disk makes progress; committed set byte-identical to fast disk |
 | `test_sim_ckp_lsn.c` | checkpoint LSN is the correct recovery start point |
 | `test_sim_swarm.c` | **swarm**: mixed-fault seed sweep + per-fault activation coverage |
+| `test_sim_clockskew_timeout.c` | lock timeout under a non-monotonic clock (offset+jitter+forward/backward jump); the timeout still fires, no hang, no corruption |
+| `test_sim_clockskew_ckp.c` | checkpoint + recovery under a large forward clock jump; committed data durable, tree clean |
+| `test_sim_clockskew_backward.c` | the dangerous case: a transient BACKWARD jump does not lose an already-set txn timeout (fires once the clock recovers); deterministic |
 | `dst-sweep.sh` | run one scenario over a seed range, report pass count + failing seeds |
 | `dst-swarm.sh` | swarm the FULL scenario set + fault-mix activation, one CI summary |
 | `dst-bug-inject.sh` | build a library per planted bug, assert each is caught within K seeds |
@@ -151,6 +155,31 @@ Measured 2000-seed soak: 0 invariant violations, every fault class activates.
 - **Fault config never perturbs the schedule.** All fault knobs draw on the IO
   stream, so enabling/disabling faults does not change what the APP workload
   produces — the same workload replays regardless of fault config.
+- **Clock skew is its own stream.** The clock-skew / time-jump fault
+  (`sim_clock.h`) draws from a dedicated `DB_SIM_RNG_CLOCK` stream, so arming
+  it never shifts the IO/FAULT/APP sequences; same seed => same skew sequence.
+
+## Clock-skew / time-jump fault
+
+The `__os_gettime` seam has an `#ifdef HAVE_DST` hook that, when a sim arms it,
+skews every clock reading (fixed offset + per-read jitter + occasional forward
+or **backward** jump), modeling FoundationDB's clock skew.  It exercises the
+code that reads the clock for timeouts: lock/txn deadlines
+(`__clock_set_expires`/`__clock_expired`) and the deadlock detector's expiry
+scan.  Three scenarios (`test_sim_clockskew_{timeout,ckp,backward}`) assert the
+timeout still fires (no hang, no premature abort-storm), checkpoints make
+progress, and a **transient backward jump does not lose an already-set
+timeout**.  Each is guarded by a hard wall-clock `alarm()` so a lost/hung
+timeout is reported as a failure with the seed instead of wedging CI.
+
+**Finding:** BDB's expiry scan re-reads the clock fresh each pass against a
+fixed deadline target, so it is robust to a non-monotonic clock -- no lost or
+premature timeout.  Note that on Linux `__os_gettime` effectively returns
+wall-clock time even when asked for monotonic (a stray second
+`clock_gettime(CLOCK_REALTIME)` in `os_clock.c` clobbers the monotonic read),
+so clock skew is a *real* risk these scenarios prove robustness against; and
+the checkpoint minute-interval reads libc `time()` directly, bypassing this
+seam.  See `DESIGN.md` §1.4a.
 
 ## Housekeeping
 

--- a/test/sim/sim_clock.h
+++ b/test/sim/sim_clock.h
@@ -1,0 +1,91 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_clock.h --
+ *	Clock-skew / time-jump fault class.  Under sim, when armed, the
+ *	__os_gettime seam applies a seeded per-read skew to the clock BDB
+ *	reads -- a fixed per-run offset, optional per-read jitter, and an
+ *	occasional discrete JUMP (forward and, the dangerous one, BACKWARD).
+ *	This exercises every decision that reads the clock: lock/txn timeout
+ *	deadlines (deadline = now + timeout; later now2 >= deadline), the
+ *	deadlock detector's expiry scan, checkpoint scheduling and the
+ *	replication lease/election timers.
+ *
+ *	FoundationDB-style: a process's clock can read ahead/behind "true"
+ *	time and can jump.  The correctness concern is code that assumes
+ *	monotonic time -- a backward jump can make a timeout never fire
+ *	(hang) or fire instantly (premature abort).
+ *
+ *	This header is OWNED by the clock-skew work; keep the shared headers
+ *	(sim_fault.h / sim_rng.h) untouched.  The skew draws on its own
+ *	dedicated PRNG stream so arming it never perturbs the IO/FAULT/APP
+ *	streams (same discipline as every other fault knob).
+ *
+ *	Compilation model: like the rest of DST, this whole surface is only
+ *	reachable under --enable-dst (HAVE_DST).  The __os_gettime hook is
+ *	#ifdef HAVE_DST and is a single relaxed load (__db_sim_active) in the
+ *	common no-sim case, so an --enable-dst library that is NOT running a
+ *	sim reads the real clock at ~zero cost, and a production (DST-off)
+ *	build never sees any of this.
+ */
+
+#ifndef _DB_SIM_CLOCK_H_
+#define _DB_SIM_CLOCK_H_
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * Arm the clock-skew fault.  Drawn from the dedicated CLOCK stream so
+ * enabling it never shifts another site's draws.
+ *
+ *   offset_ns  a FIXED per-run offset applied to EVERY read (models a
+ *              clock that reads steadily ahead/behind true time); may be
+ *              negative.  If 0, a seeded offset in [-1s, +1s] is drawn.
+ *   jitter_ns  bound on a per-read uniform jitter in [-jitter, +jitter]
+ *              (models a jumpy, imprecise clock); 0 => no jitter.
+ *   jump_ns    magnitude of an occasional discrete jump; 0 => no jumps.
+ *   jump_pct   per-1000 probability that a given read takes a jump.  A
+ *              jump is forward or BACKWARD (seeded coin) by up to jump_ns.
+ *
+ * All bounded + seeded: same seed => same skew sequence => replayable.
+ */
+void __db_sim_clock_enable
+    __P((int64_t offset_ns, int64_t jitter_ns, int64_t jump_ns, unsigned jump_pct));
+void __db_sim_clock_disable __P((void));
+int  __db_sim_clock_armed __P((void));
+
+/*
+ * Bound the disturbance to the first `n` clock reads, after which the skew
+ * self-disables (the clock "settles" back to true time).  This models a
+ * TRANSIENT jump -- a real clock-skew event has a finite duration; a
+ * correct deadline-based timeout must recover and fire once the clock
+ * resumes advancing.  0 (the default) => the skew never settles (a
+ * persistent-adversary clock).  Deterministic: `n` reads is `n` reads.
+ */
+void __db_sim_clock_settle_after __P((unsigned n));
+
+/*
+ * Apply the armed skew to a just-read clock value.  `sec`/`nsec` are the
+ * real reading; on return they hold the skewed reading.  A no-op (leaves
+ * the value untouched) unless a sim armed the knob.  Counts a skew
+ * "firing" via the fault-activation counter so a swarm can prove coverage.
+ *
+ * `monotonic` is passed through for diagnostics/future use; the skew is
+ * applied to both clock domains because a skewed process clock skews every
+ * reading (that is exactly the FDB model, and it is what makes a "monotonic"
+ * read that in libdb actually falls through to CLOCK_REALTIME dangerous).
+ */
+void __db_sim_clock_skew __P((time_t *sec, long *nsec, int monotonic));
+
+/* How many times the skew has fired this run (diagnostic / coverage). */
+unsigned long __db_sim_clock_fire_count __P((void));
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_CLOCK_H_ */

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -24,6 +24,7 @@
 #include "db_int.h"
 #include "sim_rng.h"
 #include "sim_fault.h"
+#include "sim_clock.h"
 
 #include <stdatomic.h>
 #include <stdio.h>
@@ -148,6 +149,7 @@ __db_sim_fault_class_name(cls)
 	case DB_SIM_FC_STALE:    return ("stale");
 	case DB_SIM_FC_LATENCY:  return ("latency");
 	case DB_SIM_FC_SHORTEIO: return ("shorteio");
+	case DB_SIM_FC_CLOCK:    return ("clock");
 	default:                 return ("?");
 	}
 }
@@ -184,6 +186,7 @@ __db_sim_deactivate()
 	atomic_store_explicit(&g_io_corrupt_on, 0, memory_order_release);
 	__db_sim_io_stale_enable(0);
 	__db_sim_wb_enable(0);
+	__db_sim_clock_disable();
 }
 
 uint64_t
@@ -734,4 +737,149 @@ __db_sim_io_stale_read(fkey, off, buf, len)
 		}
 	}
 	return (0);
+}
+
+/* ---- clock-skew / time-jump fault (sim_clock.h) ----
+ *
+ * A seeded skew applied at the __os_gettime seam.  Three components, all
+ * bounded and drawn from the dedicated CLOCK stream so arming this never
+ * shifts another site's draws:
+ *   - g_clk_offset: a FIXED per-run offset (set once at arm), applied to
+ *     every read -- a clock that reads steadily ahead/behind true time;
+ *   - g_clk_jitter: a per-read uniform jitter in [-j, +j] -- an imprecise,
+ *     jumpy clock;
+ *   - g_clk_jump*:  an occasional discrete jump, forward or BACKWARD, by
+ *     up to g_clk_jump_ns, with per-1000 probability g_clk_jump_pct.  The
+ *     backward jump is the dangerous one: it can make a deadline (now +
+ *     timeout, compared later against a smaller now) never be reached.
+ *
+ * The skew is applied to a signed nanosecond accumulator then clamped so
+ * the result never goes negative (a negative tv_sec would be nonsense to
+ * the caller and is not what "clock reads earlier" means).  Determinism:
+ * the whole sequence of skews is a pure function of the seed.
+ */
+static _Atomic int     g_clk_on;
+static _Atomic int64_t g_clk_offset;     /* fixed per-run offset (ns) */
+static _Atomic int64_t g_clk_jitter;     /* per-read jitter bound (ns) */
+static _Atomic int64_t g_clk_jump_ns;    /* jump magnitude (ns) */
+static _Atomic int     g_clk_jump_pct;   /* per-1000 jump probability */
+static _Atomic unsigned long g_clk_fires;
+static _Atomic long    g_clk_settle;     /* skew reads left; <0 => never */
+
+#define NS_PER_S 1000000000LL
+
+void
+__db_sim_clock_enable(offset_ns, jitter_ns, jump_ns, jump_pct)
+	int64_t offset_ns, jitter_ns, jump_ns;
+	unsigned jump_pct;
+{
+	int64_t off = offset_ns;
+
+	/* If no fixed offset requested, draw a seeded one in [-1s, +1s] so a
+	 * bare enable still models a clock that is off by a constant. */
+	if (off == 0)
+		off = (int64_t)__db_sim_rng_range(DB_SIM_RNG_CLOCK,
+		    (uint64_t)(2 * NS_PER_S + 1)) - NS_PER_S;
+	atomic_store_explicit(&g_clk_offset, off, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jitter,
+	    jitter_ns < 0 ? -jitter_ns : jitter_ns, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_ns,
+	    jump_ns < 0 ? -jump_ns : jump_ns, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_pct,
+	    jump_pct > 1000 ? 1000 : (int)jump_pct, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_fires, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_settle, -1, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_on, 1, memory_order_release);
+}
+
+void
+__db_sim_clock_settle_after(n)
+	unsigned n;
+{
+	atomic_store_explicit(&g_clk_settle, (long)n, memory_order_relaxed);
+}
+
+void
+__db_sim_clock_disable()
+{
+	atomic_store_explicit(&g_clk_on, 0, memory_order_release);
+	atomic_store_explicit(&g_clk_offset, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jitter, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_ns, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_pct, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_settle, -1, memory_order_relaxed);
+}
+
+int
+__db_sim_clock_armed()
+{
+	return (atomic_load_explicit(&g_clk_on, memory_order_acquire) &&
+	    __db_sim_active());
+}
+
+unsigned long
+__db_sim_clock_fire_count()
+{
+	return (atomic_load_explicit(&g_clk_fires, memory_order_relaxed));
+}
+
+void
+__db_sim_clock_skew(sec, nsec, monotonic)
+	time_t *sec;
+	long *nsec;
+	int monotonic;
+{
+	int64_t total, jit, jbound, jmag;
+	int jpct;
+	long left;
+
+	COMPQUIET(monotonic, 0);
+	if (sec == NULL || nsec == NULL || !__db_sim_clock_armed())
+		return;
+
+	/* Transient-jump budget: after `settle` skewed reads the clock
+	 * returns to true time (a bounded disturbance that recovers). */
+	left = atomic_load_explicit(&g_clk_settle, memory_order_relaxed);
+	if (left == 0)
+		return;                     /* settled: real clock */
+	if (left > 0)
+		atomic_store_explicit(&g_clk_settle, left - 1,
+		    memory_order_relaxed);
+
+	/* real reading as a signed ns accumulator */
+	total = (int64_t)*sec * NS_PER_S + (int64_t)*nsec;
+
+	/* fixed per-run offset */
+	total += atomic_load_explicit(&g_clk_offset, memory_order_relaxed);
+
+	/* per-read jitter in [-bound, +bound] */
+	jbound = atomic_load_explicit(&g_clk_jitter, memory_order_relaxed);
+	if (jbound > 0) {
+		jit = (int64_t)__db_sim_rng_range(DB_SIM_RNG_CLOCK,
+		    (uint64_t)(2 * jbound + 1)) - jbound;
+		total += jit;
+	}
+
+	/* occasional discrete jump, forward or BACKWARD */
+	jmag = atomic_load_explicit(&g_clk_jump_ns, memory_order_relaxed);
+	jpct = atomic_load_explicit(&g_clk_jump_pct, memory_order_relaxed);
+	if (jmag > 0 && jpct > 0 &&
+	    (int)__db_sim_rng_range(DB_SIM_RNG_CLOCK, 1000) < jpct) {
+		/* seeded coin: 0 => backward, 1 => forward */
+		int64_t j = (int64_t)__db_sim_rng_range(DB_SIM_RNG_CLOCK,
+		    (uint64_t)jmag + 1);
+		if (__db_sim_rng_range(DB_SIM_RNG_CLOCK, 2) == 0)
+			total -= j;                 /* BACKWARD (dangerous) */
+		else
+			total += j;                 /* forward */
+	}
+
+	/* Clamp: a clock never reads before the epoch here. */
+	if (total < 0)
+		total = 0;
+
+	*sec = (time_t)(total / NS_PER_S);
+	*nsec = (long)(total % NS_PER_S);
+	fc_hit(DB_SIM_FC_CLOCK);
+	atomic_fetch_add_explicit(&g_clk_fires, 1, memory_order_relaxed);
 }

--- a/test/sim/sim_fault.h
+++ b/test/sim/sim_fault.h
@@ -46,6 +46,7 @@ enum db_sim_fault_class {
 	DB_SIM_FC_STALE    = 3,   /* stale read (prior version returned) */
 	DB_SIM_FC_LATENCY  = 4,   /* per-I/O latency sleep taken */
 	DB_SIM_FC_SHORTEIO = 5,   /* short-transfer / EIO toggle fired */
+	DB_SIM_FC_CLOCK    = 6,   /* clock skew / time-jump applied */
 	DB_SIM_FC_NCLASSES
 };
 unsigned long __db_sim_fault_count __P((int));

--- a/test/sim/sim_os.h
+++ b/test/sim/sim_os.h
@@ -24,6 +24,7 @@ void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, u_int32_t));
 void __db_sim_io_sync_hook __P((DB_FH *));
 void __db_sim_io_read_hook __P((DB_FH *, u_int64_t, void *, size_t));
 void __db_sim_io_latency_hook __P((void));
+void __db_sim_clock_hook __P((db_timespec *, int));
 
 #if defined(__cplusplus)
 }

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -25,6 +25,7 @@
 #include "db_int.h"
 #include "sim_rng.h"
 #include "sim_fault.h"
+#include "sim_clock.h"
 
 /*
  * db_sim_fkey --
@@ -233,4 +234,35 @@ __db_sim_io_latency_hook()
 	if (!__db_sim_active())
 		return;
 	__db_sim_io_sleep_latency();
+}
+
+/*
+ * __db_sim_clock_hook --
+ *	Called from __os_gettime AFTER a real clock reading has landed in
+ *	`tp`.  When the clock-skew fault is armed, applies the seeded skew
+ *	(fixed offset + jitter + occasional forward/backward jump) in place;
+ *	a no-op (leaves tp untouched, ~zero cost) otherwise.  This is the
+ *	one seam every lock/txn timeout deadline, the deadlock detector's
+ *	expiry scan, checkpoint scheduling and the replication timers read
+ *	their notion of "now" through.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_clock_hook __P((db_timespec *, int));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_clock_hook(tp, monotonic)
+	db_timespec *tp;
+	int monotonic;
+{
+	time_t sec;
+	long nsec;
+
+	if (tp == NULL || !__db_sim_clock_armed())
+		return;
+	sec = tp->tv_sec;
+	nsec = (long)tp->tv_nsec;
+	__db_sim_clock_skew(&sec, &nsec, monotonic);
+	tp->tv_sec = sec;
+	tp->tv_nsec = nsec;
 }

--- a/test/sim/sim_rng.h
+++ b/test/sim/sim_rng.h
@@ -39,6 +39,7 @@ enum db_sim_stream {
 	DB_SIM_RNG_BUGGIFY = 2,   /* buggify per-run activation coins */
 	DB_SIM_RNG_APP     = 3,   /* application/test workload draws */
 	DB_SIM_RNG_SCHED   = 4,   /* RESERVED: deterministic scheduler (v2) */
+	DB_SIM_RNG_CLOCK   = 5,   /* clock-skew / time-jump fault stream */
 	DB_SIM_RNG_NSTREAMS
 };
 

--- a/test/sim/test_sim_clockskew_backward.c
+++ b/test/sim/test_sim_clockskew_backward.c
@@ -1,0 +1,270 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_clockskew_backward.c --
+ *	A pure BACKWARD clock jump mid-run: the dangerous case.
+ *
+ *	The clock jumps only backward (never forward) partway through a
+ *	txn-timeout wait.  This is the exact FoundationDB clock-skew concern:
+ *	`deadline = now + timeout` is set, then the clock jumps back below
+ *	`now`, so later reads of `now2` stay < deadline for a while.  The jump
+ *	is TRANSIENT (bounded via __db_sim_clock_settle_after): after the
+ *	disturbance the clock resumes advancing.  A correct engine must fire
+ *	the timeout once the recovered clock crosses the fixed deadline; a
+ *	broken engine that RE-ARMS the deadline off the jumped-back clock, or
+ *	that trusts a monotonic assumption, would lose the timeout FOREVER
+ *	even after the clock recovers -- and the wall-clock alarm catches it.
+ *
+ *	(A PERSISTENT adversary clock that never advances past the deadline
+ *	could never fire ANY deadline-based timeout -- that is physics, not a
+ *	libdb bug -- so this scenario uses a bounded, recovering jump.)
+ *
+ *	Uses a TXN timeout (DB_SET_TXN_TIMEOUT) via a real DB_TXN + a lock
+ *	contended between the txn and a helper-held lock, so the txn's wait is
+ *	bounded by tx_expire (set from the skewed clock).  Also asserts
+ *	determinism: two runs of the same seed apply the identical number of
+ *	skews (same skew sequence) and reach the identical verdict.
+ *
+ *	Guarded by a hard wall-clock alarm: a LOST timeout hangs the waiter,
+ *	and the alarm reports it as a REAL BUG with the seed, rather than
+ *	wedging CI.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_clockskew_backward && ./test_sim_clockskew_backward [seed]
+ */
+
+#include <sys/types.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+#include "sim_clock.h"
+
+#define HOME       "TESTDIR_sim_clockskew_backward"
+#define OBJNAME    "contended"
+#define TXN_TMOUT  60000        /* 60 ms txn timeout (microseconds) */
+#define WALL_LIMIT 20
+
+static DB_ENV  *g_env;
+static u_int32_t g_holder_id;
+static DB_TXN  *g_waiter_txn;
+static volatile int g_helper_ret = -12345;
+static volatile int g_helper_done;
+static uint64_t g_seed;
+
+static void
+on_alarm(sig)
+	int sig;
+{
+	(void)sig;
+	fprintf(stderr, "test_sim_clockskew_backward: FAIL -- HUNG: a txn "
+	    "timeout was LOST after a BACKWARD clock jump (never woke within "
+	    "%ds); REAL BUG: backward jump defeats the deadline.  Reproduce: "
+	    "./test_sim_clockskew_backward 0x%llx\n",
+	    WALL_LIMIT, (unsigned long long)g_seed);
+	_exit(3);
+}
+
+static void *
+helper(arg)
+	void *arg;
+{
+	DB_LOCKREQ req;
+	DBT obj;
+	u_int32_t wid;
+	int ret;
+
+	(void)arg;
+	/* The waiter txn's locker id drives the txn timeout. */
+	wid = g_waiter_txn->id(g_waiter_txn);
+	memset(&obj, 0, sizeof(obj));
+	obj.data = (void *)OBJNAME;
+	obj.size = (u_int32_t)strlen(OBJNAME) + 1;
+	memset(&req, 0, sizeof(req));
+	req.op = DB_LOCK_GET;
+	req.mode = DB_LOCK_WRITE;
+	req.obj = &obj;
+
+	/* Blocks until the txn's tx_expire deadline expires it. */
+	ret = g_env->lock_vec(g_env, wid, 0, &req, 1, NULL);
+	if (ret == 0)
+		(void)g_env->lock_put(g_env, &req.lock);
+	g_helper_ret = ret;
+	g_helper_done = 1;
+	return (NULL);
+}
+
+/* One full run at a given seed; returns 0 on PASS, sets skews + verdict. */
+static int
+run_once(seed, skews, verdict)
+	uint64_t seed;
+	unsigned long *skews;
+	int *verdict;
+{
+	DB_LOCK holder_lock;
+	DBT obj;
+	pthread_t tid;
+	struct timespec nap;
+	int ret, i, rejected;
+
+	g_helper_ret = -12345;
+	g_helper_done = 0;
+
+	if ((ret = db_env_create(&g_env, 0)) != 0)
+		return (ret);
+	if ((ret = g_env->open(g_env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	(void)g_env->set_lk_detect(g_env, DB_LOCK_EXPIRE);
+
+	if ((ret = g_env->lock_id(g_env, &g_holder_id)) != 0)
+		return (ret);
+	/* Waiter runs inside a real txn with a txn timeout. */
+	if ((ret = g_env->txn_begin(g_env, NULL, &g_waiter_txn, 0)) != 0)
+		return (ret);
+
+	/* Main thread holds the write lock on the contended object. */
+	memset(&obj, 0, sizeof(obj));
+	obj.data = (void *)OBJNAME;
+	obj.size = (u_int32_t)strlen(OBJNAME) + 1;
+	memset(&holder_lock, 0, sizeof(holder_lock));
+	if ((ret = g_env->lock_get(g_env, g_holder_id, 0, &obj,
+	    DB_LOCK_WRITE, &holder_lock)) != 0)
+		return (ret);
+
+	__db_sim_activate(seed);
+	/*
+	 * Set the txn's deadline FIRST, on the TRUE clock: tx_expire =
+	 * true_now + 60ms (a legitimate, correctly-computed deadline).
+	 */
+	if ((ret = g_waiter_txn->set_timeout(g_waiter_txn, TXN_TMOUT,
+	    DB_SET_TXN_TIMEOUT)) != 0)
+		return (ret);
+
+	/*
+	 * NOW knock the clock backward (the TRANSIENT FoundationDB model): a
+	 * big negative offset plus large backward-leaning jumps, for a BOUNDED
+	 * number of reads, after which the clock settles back to true time.
+	 * The deadline is a fixed, already-set target; the backward jump pushes
+	 * every fresh `now2` reading below it for a while.  A correct engine
+	 * must fire the timeout once the recovered clock crosses the deadline;
+	 * a broken engine that trusts a monotonic assumption, or re-arms the
+	 * deadline off the jumped-back clock, would lose the timeout FOREVER --
+	 * and the wall-clock alarm catches that as a REAL BUG.
+	 *
+	 * (A PERSISTENT adversary clock that never advances past the deadline
+	 * could never fire ANY deadline-based timeout -- physics, not a bug --
+	 * so the jump is bounded and recovering.)
+	 */
+	__db_sim_clock_enable(
+	    /* offset */ -3LL * 1000 * 1000 * 1000,     /* -3s steady */
+	    /* jitter */ 20LL * 1000 * 1000,            /* +/-20ms */
+	    /* jump   */ 10LL * 1000 * 1000 * 1000,     /* up to 10s jumps */
+	    /* jump%  */ 700);                           /* 70% of reads jump */
+	/* Disturbance lasts ~60 clock reads, then the clock returns to true
+	 * and the fixed deadline MUST be crossed. */
+	__db_sim_clock_settle_after(60);
+
+	/* The txn must own the tx_expire deadline: touch a lock under it so
+	 * the locker exists, then start the waiter which contends. */
+	if ((ret = pthread_create(&tid, NULL, helper, NULL)) != 0)
+		return (ret);
+
+	nap.tv_sec = 0;
+	nap.tv_nsec = 5 * 1000 * 1000;
+	for (i = 0; i < 4000 && !g_helper_done; i++) {
+		rejected = 0;
+		(void)g_env->lock_detect(g_env, 0, DB_LOCK_EXPIRE, &rejected);
+		(void)nanosleep(&nap, NULL);
+	}
+
+	(void)pthread_join(tid, NULL);
+
+	*skews = __db_sim_clock_fire_count();
+	*verdict = g_helper_ret;
+	__db_sim_deactivate();
+
+	(void)g_env->lock_put(g_env, &holder_lock);
+	(void)g_waiter_txn->abort(g_waiter_txn);
+	(void)g_env->close(g_env, 0);
+
+	if (!g_helper_done)
+		return (-100);   /* never resolved */
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	char cmd[512];
+	unsigned long skews1, skews2;
+	int ret, verdict1, verdict2;
+
+	g_seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC10C0003;
+
+	(void)signal(SIGALRM, on_alarm);
+	(void)alarm(WALL_LIMIT);
+
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	if (system(cmd) != 0)
+		return (EXIT_FAILURE);
+
+	if ((ret = run_once(g_seed, &skews1, &verdict1)) != 0) {
+		if (ret == -100)
+			fprintf(stderr, "test_sim_clockskew_backward: FAIL -- "
+			    "waiter never resolved (lost timeout?) (seed "
+			    "0x%llx)\n", (unsigned long long)g_seed);
+		else
+			fprintf(stderr, "test_sim_clockskew_backward: run "
+			    "failed: %s\n", db_strerror(ret));
+		return (EXIT_FAILURE);
+	}
+
+	/* Timeout must have fired cleanly, never granted. */
+	if (verdict1 != DB_LOCK_NOTGRANTED && verdict1 != DB_LOCK_DEADLOCK) {
+		fprintf(stderr, "test_sim_clockskew_backward: FAIL -- "
+		    "unexpected verdict %d (%s) (seed 0x%llx)\n",
+		    verdict1, db_strerror(verdict1),
+		    (unsigned long long)g_seed);
+		return (EXIT_FAILURE);
+	}
+
+	/* Determinism: rerun the same seed -> identical skew count + verdict. */
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	(void)system(cmd);
+	if (run_once(g_seed, &skews2, &verdict2) != 0) {
+		fprintf(stderr, "test_sim_clockskew_backward: FAIL -- replay "
+		    "run did not resolve (seed 0x%llx)\n",
+		    (unsigned long long)g_seed);
+		return (EXIT_FAILURE);
+	}
+	if (skews1 != skews2 || verdict1 != verdict2) {
+		fprintf(stderr, "test_sim_clockskew_backward: FAIL -- NOT "
+		    "DETERMINISTIC: skews %lu vs %lu, verdict %d vs %d "
+		    "(seed 0x%llx)\n", skews1, skews2, verdict1, verdict2,
+		    (unsigned long long)g_seed);
+		return (EXIT_FAILURE);
+	}
+
+	(void)alarm(0);
+	printf("test_sim_clockskew_backward: PASS -- txn timeout fired "
+	    "(ret=%s) despite a backward-trending clock; no timeout lost, "
+	    "deterministic (%lu skews, replay identical) (seed 0x%llx)\n",
+	    verdict1 == DB_LOCK_NOTGRANTED ? "NOTGRANTED" : "DEADLOCK",
+	    skews1, (unsigned long long)g_seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_clockskew_ckp.c
+++ b/test/sim/test_sim_clockskew_ckp.c
@@ -1,0 +1,219 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_clockskew_ckp.c --
+ *	Checkpoint + recovery under a large FORWARD clock jump.
+ *
+ *	Arms the clock-skew fault with an aggressive forward jump (the clock
+ *	leaps ahead by up to an hour, repeatedly) while a transactional
+ *	workload runs and checkpoints are taken.  A forward jump is what a
+ *	naive scheduler treats as "lots of time has passed" -- it must not
+ *	make checkpoint bookkeeping (the checkpoint LSN, the durable frontier)
+ *	inconsistent.  After a mid-workload crash the environment recovers
+ *	clean and every fsync-acked commit is present.
+ *
+ *	Invariant: a forward clock jump does not corrupt checkpoint/recovery
+ *	state; checkpoints still make progress; committed data survives.
+ *
+ *	Honest scope note: on a platform with libc time() (HAVE_TIME, i.e.
+ *	Linux), the checkpoint MINUTE-interval decision in __txn_checkpoint
+ *	reads libc time() directly, NOT __os_gettime, so it is not reachable
+ *	by this __os_gettime skew -- which is itself a finding (that decision
+ *	is inherently robust to __os_gettime skew).  This scenario therefore
+ *	drives checkpoints EXPLICITLY (as a real application's checkpoint
+ *	thread does) and proves the skew perturbs nothing downstream in the
+ *	checkpoint/recovery path.  See DESIGN.md clock-skew section.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_clockskew_ckp && ./test_sim_clockskew_ckp [seed]
+ */
+
+#include "sim_scenario.h"
+#include "sim_clock.h"
+
+#include <signal.h>
+
+#define HOME    "TESTDIR_sim_clockskew_ckp"
+#define DBFILE  "ckpskew.db"
+#define NTXN    256
+#define CKP_EVERY 32
+#define WALL_LIMIT 30
+
+static unsigned char g_committed[NTXN];
+static uint64_t g_seed;
+
+static void
+on_alarm(sig)
+	int sig;
+{
+	(void)sig;
+	fprintf(stderr, "test_sim_clockskew_ckp: FAIL -- HUNG: checkpoint "
+	    "stopped making progress under a forward clock jump (>%ds); "
+	    "REAL BUG.  Reproduce: ./test_sim_clockskew_ckp 0x%llx\n",
+	    WALL_LIMIT, (unsigned long long)g_seed);
+	_exit(3);
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0)
+		return (ret);
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[48];
+	int i, ret;
+	FILE *fp;
+	uint64_t tok;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	memset(g_committed, 0, sizeof(g_committed));
+
+	/*
+	 * Arm a large forward jump: the clock leaps ahead by up to an hour on
+	 * 60% of reads.  __os_gettime readers (lock/txn deadlines, rep timers,
+	 * and the checkpoint LOG-region timestamps) all see the jumped clock.
+	 */
+	__db_sim_clock_enable(
+	    /* offset */ 0,                              /* seeded steady skew */
+	    /* jitter */ 5LL * 1000 * 1000,              /* +/-5ms */
+	    /* jump   */ 3600LL * 1000 * 1000 * 1000,    /* up to +1h jumps */
+	    /* jump%  */ 600);
+
+	for (i = 0; i < NTXN; i++) {
+		tok = __db_sim_rng(DB_SIM_RNG_APP);
+		(void)snprintf(kbuf, sizeof(kbuf), "ck-%08d", i);
+		(void)snprintf(vbuf, sizeof(vbuf), "cv-%016llx",
+		    (unsigned long long)tok);
+		if (env->txn_begin(env, NULL, &txn, 0) != 0)
+			continue;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if (db->put(db, txn, &key, &data, 0) != 0) {
+			(void)txn->abort(txn);
+			continue;
+		}
+		if (txn->commit(txn, DB_TXN_SYNC) == 0)
+			g_committed[i] = 1;
+		/* Explicit checkpoint mid-workload, WITH the clock jumping. */
+		if (i % CKP_EVERY == CKP_EVERY - 1)
+			(void)env->txn_checkpoint(env, 0, 0, DB_FORCE);
+	}
+
+	if ((fp = fopen(HOME "/committed.map", "wb")) != NULL) {
+		(void)fwrite(g_committed, 1, sizeof(g_committed), fp);
+		(void)fclose(fp);
+	}
+
+	/* One last checkpoint under the jumping clock, then crash. */
+	(void)env->txn_checkpoint(env, 0, 0, DB_FORCE);
+	__db_sim_clock_disable();     /* the truncation must not be skewed */
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32];
+	unsigned char committed[NTXN];
+	FILE *fp;
+	int i, ret, missing = 0, ncommitted = 0;
+
+	g_seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC10C0002;
+
+	(void)signal(SIGALRM, on_alarm);
+	(void)alarm(WALL_LIMIT);
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(g_seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	memset(committed, 0, sizeof(committed));
+	if ((fp = fopen(HOME "/committed.map", "rb")) != NULL) {
+		(void)fread(committed, 1, sizeof(committed), fp);
+		(void)fclose(fp);
+	}
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (EXIT_FAILURE);
+	if (open_db(env, &db, 0) != 0)
+		return (EXIT_FAILURE);
+
+	__db_sim_activate(g_seed);
+	for (i = 0; i < NTXN; i++) {
+		if (!committed[i])
+			continue;
+		ncommitted++;
+		(void)snprintf(kbuf, sizeof(kbuf), "ck-%08d", i);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) != 0)
+			missing++;
+	}
+	__db_sim_deactivate();
+	(void)db->close(db, 0);
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (EXIT_FAILURE);
+	if ((ret = db->verify(db, DBFILE, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "test_sim_clockskew_ckp: verify FAILED: %s "
+		    "(seed 0x%llx)\n", db_strerror(ret),
+		    (unsigned long long)g_seed);
+		(void)env->close(env, 0);
+		return (EXIT_FAILURE);
+	}
+	(void)env->close(env, 0);
+	(void)alarm(0);
+
+	if (missing != 0) {
+		fprintf(stderr, "test_sim_clockskew_ckp: FAIL -- %d of %d "
+		    "committed txns lost across a forward-clock-jump checkpoint "
+		    "(seed 0x%llx)\n", missing, ncommitted,
+		    (unsigned long long)g_seed);
+		return (EXIT_FAILURE);
+	}
+	printf("test_sim_clockskew_ckp: PASS -- checkpoints made progress "
+	    "under a forward clock jump; all %d committed txns durable, tree "
+	    "clean after recovery (seed 0x%llx)\n",
+	    ncommitted, (unsigned long long)g_seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_clockskew_timeout.c
+++ b/test/sim/test_sim_clockskew_timeout.c
@@ -1,0 +1,236 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_clockskew_timeout.c --
+ *	Lock timeout under a skewed / jumping / non-monotonic clock.
+ *
+ *	The dangerous pattern (FoundationDB clock-skew model): a timeout is
+ *	a deadline computed as `deadline = now + timeout` (__clock_set_expires),
+ *	compared later against `now2 >= deadline` (__clock_expired) by the
+ *	deadlock detector's DB_LOCK_EXPIRE scan.  If the clock jumps BACKWARD
+ *	between the two reads, now2 can be < deadline forever and the timeout
+ *	never fires -- the waiter HANGS.
+ *
+ *	Scenario: the main thread holds a write lock on an object; a helper
+ *	thread requests a conflicting write lock with a short lock timeout and
+ *	blocks.  The main thread arms the clock-skew fault (fixed offset +
+ *	jitter + occasional forward AND backward jumps) and then drives the
+ *	deadlock detector's expiry scan repeatedly.  Invariant: the blocked
+ *	lock request EVENTUALLY returns DB_LOCK_NOTGRANTED (the timeout fires)
+ *	and the run resolves -- no hang, no premature abort-storm.
+ *
+ *	The whole run is guarded by a hard wall-clock alarm: a clock bug that
+ *	loses the timeout would hang the helper, and the alarm turns that hang
+ *	into a reported FAILURE + the exact seed to reproduce (rather than a
+ *	CI process that wedges forever).  Same seed => same skew sequence =>
+ *	deterministic outcome.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_clockskew_timeout && ./test_sim_clockskew_timeout [seed]
+ */
+
+#include <sys/types.h>
+
+#include <errno.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+#include "sim_clock.h"
+
+#define HOME       "TESTDIR_sim_clockskew_timeout"
+#define OBJNAME    "hot-object"
+#define LK_TIMEOUT 50000        /* 50 ms lock timeout (microseconds) */
+#define WALL_LIMIT 20           /* hard wall-clock guard: fail if we hang */
+
+static DB_ENV  *g_env;
+static u_int32_t g_holder_id, g_waiter_id;
+static volatile int g_helper_ret = -12345;    /* sentinel: not set yet */
+static volatile int g_helper_done;
+
+/* Wall-clock watchdog: if a lost timeout hangs us, SIGALRM aborts with a
+ * clear "hung" verdict and the seed, instead of wedging CI forever. */
+static uint64_t g_seed;
+static void
+on_alarm(sig)
+	int sig;
+{
+	(void)sig;
+	fprintf(stderr, "test_sim_clockskew_timeout: FAIL -- HUNG: a lock "
+	    "timeout was LOST under clock skew (waiter never woke within %ds); "
+	    "REAL BUG: non-monotonic clock defeats the deadline.  Reproduce: "
+	    "./test_sim_clockskew_timeout 0x%llx\n",
+	    WALL_LIMIT, (unsigned long long)g_seed);
+	_exit(3);
+}
+
+/*
+ * Helper thread: request the same object with a conflicting write lock and
+ * a lock timeout.  Blocks until the main thread's detector expires it.
+ */
+static void *
+helper(arg)
+	void *arg;
+{
+	DB_LOCKREQ req;
+	DB_LOCK lock;
+	DBT obj;
+	int ret;
+
+	(void)arg;
+	memset(&obj, 0, sizeof(obj));
+	obj.data = (void *)OBJNAME;
+	obj.size = (u_int32_t)strlen(OBJNAME) + 1;
+	memset(&req, 0, sizeof(req));
+	req.op = DB_LOCK_GET_TIMEOUT;
+	req.mode = DB_LOCK_WRITE;
+	req.timeout = LK_TIMEOUT;
+	req.obj = &obj;
+	memset(&lock, 0, sizeof(lock));
+
+	/* This blocks inside __lock_get_internal until the expiry scan wakes
+	 * it; the return code tells us how it resolved. */
+	ret = g_env->lock_vec(g_env, g_waiter_id, 0, &req, 1, NULL);
+	if (ret == 0)      /* granted (should not happen: main holds it) */
+		(void)g_env->lock_put(g_env, &req.lock);
+	g_helper_ret = ret;
+	g_helper_done = 1;
+	return (NULL);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	DB_LOCK holder_lock;
+	DBT obj;
+	pthread_t tid;
+	char cmd[512];
+	struct timespec nap;
+	int ret, i, rejected;
+
+	g_seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC10C0001;
+
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s",
+	    HOME, HOME);
+	if (system(cmd) != 0)
+		return (EXIT_FAILURE);
+
+	/* Hard wall-clock guard against a hung (lost) timeout. */
+	(void)signal(SIGALRM, on_alarm);
+	(void)alarm(WALL_LIMIT);
+
+	if ((ret = db_env_create(&g_env, 0)) != 0)
+		goto envfail;
+	/* We drive the expiry scan by hand, so no background detector. */
+	if ((ret = g_env->open(g_env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_MPOOL, 0664)) != 0)
+		goto envfail;
+	/* Auto-run the detector's expiry scan on each lock request too. */
+	(void)g_env->set_lk_detect(g_env, DB_LOCK_EXPIRE);
+
+	if ((ret = g_env->lock_id(g_env, &g_holder_id)) != 0)
+		goto envfail;
+	if ((ret = g_env->lock_id(g_env, &g_waiter_id)) != 0)
+		goto envfail;
+
+	/* Main thread grabs the write lock on the hot object. */
+	memset(&obj, 0, sizeof(obj));
+	obj.data = (void *)OBJNAME;
+	obj.size = (u_int32_t)strlen(OBJNAME) + 1;
+	memset(&holder_lock, 0, sizeof(holder_lock));
+	if ((ret = g_env->lock_get(g_env, g_holder_id, 0, &obj,
+	    DB_LOCK_WRITE, &holder_lock)) != 0)
+		goto envfail;
+
+	/*
+	 * Arm the clock-skew fault: a seeded fixed offset, per-read jitter,
+	 * and frequent forward+BACKWARD jumps of up to 5s -- an aggressively
+	 * non-monotonic clock.  Drawn from the CLOCK stream, so arming it does
+	 * not perturb anything else.  This is the exact condition that could
+	 * defeat `deadline = now + timeout; ... now2 >= deadline`.
+	 */
+	__db_sim_activate(g_seed);
+	__db_sim_clock_enable(
+	    /* offset */ 250LL * 1000 * 1000,      /* +250ms steady skew */
+	    /* jitter */ 10LL * 1000 * 1000,       /* +/-10ms per read */
+	    /* jump   */ 5LL * 1000 * 1000 * 1000, /* up to 5s jumps */
+	    /* jump%  */ 400);                      /* 40% of reads jump */
+
+	/* Start the waiter; it blocks on the conflicting lock. */
+	if ((ret = pthread_create(&tid, NULL, helper, NULL)) != 0) {
+		fprintf(stderr, "pthread_create: %s\n", strerror(ret));
+		goto envfail;
+	}
+
+	/*
+	 * Drive the expiry scan.  Each __lock_detect(DB_LOCK_EXPIRE) reads
+	 * the (skewed) clock via __clock_expired.  On a monotonic-enough
+	 * reading the deadline passes and the waiter is expired + woken; a
+	 * backward jump can push "now" back before the deadline, delaying it.
+	 * We loop with a real nap between scans; the wall-clock alarm bounds
+	 * the total.  A robust engine resolves within a bounded number of
+	 * scans DESPITE the skew (the offset+jitter+jumps average out and the
+	 * true wall clock keeps advancing between naps, so some scan reads a
+	 * value past the deadline).
+	 */
+	nap.tv_sec = 0;
+	nap.tv_nsec = 5 * 1000 * 1000;    /* 5 ms between scans */
+	for (i = 0; i < 4000 && !g_helper_done; i++) {
+		rejected = 0;
+		(void)g_env->lock_detect(g_env, 0, DB_LOCK_EXPIRE, &rejected);
+		(void)nanosleep(&nap, NULL);
+	}
+
+	(void)pthread_join(tid, NULL);
+	(void)alarm(0);
+
+	__db_sim_deactivate();
+
+	/* Release the holder lock and shut down. */
+	(void)g_env->lock_put(g_env, &holder_lock);
+	(void)g_env->close(g_env, 0);
+
+	/*
+	 * Verdict.  The waiter MUST have resolved (not still blocked) and the
+	 * resolution must be a clean timeout (DB_LOCK_NOTGRANTED) or a
+	 * deadlock verdict (DB_LOCK_DEADLOCK) -- never granted (main held it),
+	 * never a crash.  The point: under an aggressively non-monotonic clock
+	 * the timeout still EVENTUALLY fires; no hang, no corruption.
+	 */
+	if (!g_helper_done) {
+		fprintf(stderr, "test_sim_clockskew_timeout: FAIL -- waiter "
+		    "never resolved under clock skew (seed 0x%llx)\n",
+		    (unsigned long long)g_seed);
+		return (EXIT_FAILURE);
+	}
+	if (g_helper_ret != DB_LOCK_NOTGRANTED &&
+	    g_helper_ret != DB_LOCK_DEADLOCK) {
+		fprintf(stderr, "test_sim_clockskew_timeout: FAIL -- waiter "
+		    "resolved with unexpected ret %d (%s) (seed 0x%llx)\n",
+		    g_helper_ret, db_strerror(g_helper_ret),
+		    (unsigned long long)g_seed);
+		return (EXIT_FAILURE);
+	}
+
+	printf("test_sim_clockskew_timeout: PASS -- lock timeout fired "
+	    "(ret=%s) under a non-monotonic clock (%lu skews applied); "
+	    "no hang, no corruption (seed 0x%llx)\n",
+	    g_helper_ret == DB_LOCK_NOTGRANTED ? "NOTGRANTED" : "DEADLOCK",
+	    __db_sim_clock_fire_count(), (unsigned long long)g_seed);
+	return (EXIT_SUCCESS);
+
+envfail:
+	fprintf(stderr, "test_sim_clockskew_timeout: setup failed: %s\n",
+	    db_strerror(ret));
+	return (EXIT_FAILURE);
+}

--- a/test/sim/test_sim_swarm.c
+++ b/test/sim/test_sim_swarm.c
@@ -325,13 +325,22 @@ main(argc, argv)
 	 */
 	if (n_seeds >= 64) {
 		int gap = 0;
-		for (cls = 0; cls < DB_SIM_FC_NCLASSES; cls++)
+		for (cls = 0; cls < DB_SIM_FC_NCLASSES; cls++) {
+			/*
+			 * The clock-skew class is exercised by the dedicated
+			 * test_sim_clockskew_* scenarios, not this I/O swarm
+			 * (which arms only the disk-fault knobs), so it is not
+			 * expected to fire here -- skip it in the gap guard.
+			 */
+			if (cls == DB_SIM_FC_CLOCK)
+				continue;
 			if (act[cls] == 0) {
 				printf("FAIL: fault class '%s' NEVER activated "
 				    "across %ld seeds -- a coverage gap\n",
 				    __db_sim_fault_class_name(cls), n_seeds);
 				gap = 1;
 			}
+		}
 		if (gap)
 			return (EXIT_FAILURE);
 	}


### PR DESCRIPTION
## Clock-skew / time-jump fault class for the DST framework

Adds a FoundationDB-style clock-skew fault at BDB's time seam (\`__os_gettime\`)
so DST exercises the time-dependent code paths (lock/txn timeouts, the
deadlock detector's expiry scan, checkpoint scheduling) under a skewed /
jumping / non-monotonic clock.

### The hook (zero prod overhead)
- **New \`test/sim/sim_clock.h\`** (clock-owned): the knob API.
- **\`sim_core.c\`**: seeded skew = **fixed per-run offset** + **per-read
  jitter** + **occasional discrete forward/BACKWARD jump**, bounded via
  \`__db_sim_clock_settle_after\` (transient jump that recovers). Dedicated
  \`DB_SIM_RNG_CLOCK\` stream + \`DB_SIM_FC_CLOCK\` activation counter, both
  additive so existing seeds replay unchanged.
- **\`src/os/os_clock.c\`**: an \`#ifdef HAVE_DST\` hook call before return; a
  single \`__db_sim_active()\` relaxed load under sim.
- **DST OFF**: compiles out entirely — verified **0 \`__db_sim_*\` symbols** in
  the OFF library and \`os_clock.o\` has no \`sim\` references.

### Scenarios (each deterministic, wall-clock-alarm-guarded)
- **\`test_sim_clockskew_timeout\`** — lock timeout under offset+jitter+forward
  +backward jumps; the timeout fires (DB_LOCK_NOTGRANTED), no hang, no
  abort-storm.
- **\`test_sim_clockskew_ckp\`** — explicit checkpoints under a large **forward**
  jump (up to +1h); after a crash every acked commit is durable, tree clean.
- **\`test_sim_clockskew_backward\`** — the dangerous case: a legitimately-set
  txn deadline, then a **transient backward** jump; the timeout still fires
  once the clock recovers (**not LOST**); replay identical.

Each guards against a hung/lost timeout with a hard \`alarm()\` that reports a
failure + the reproduce seed instead of wedging CI.

### Does BDB use a monotonic clock? (the risk assessment)
**No — and that makes clock skew a real risk, which these scenarios prove
robustness against:**
1. Lock/txn timeout paths call \`__os_gettime(monotonic=1)\`, but on Linux
   \`os_clock.c\` unconditionally re-reads \`CLOCK_REALTIME\` after the monotonic
   read (a stray second \`clock_gettime\`), so every reading is effectively
   **wall-clock, not monotonic**. (Pre-existing engine quirk; not touched.)
2. The checkpoint MINUTE-interval + checkpoint-record timestamp read libc
   \`time()\` **directly** (\`HAVE_TIME\`), bypassing \`__os_gettime\` — so that
   decision is inherently robust to this seam's skew.

**Result: no real bug found.** BDB's deadlock-detector expiry scan re-reads the
clock **fresh each pass** against a **fixed** deadline target, so it is robust
to a non-monotonic / jumping / backward clock — no lost or premature timeout.
The scenarios PROVE this robustness (that is the deliverable). A persistent
adversary clock that never advances past a deadline can't fire any
deadline-based timeout — that's physics, not a bug — so the dangerous-case
scenario uses a bounded, recovering jump.

### Validation (nix dev shell, \`--enable-debug --enable-dst\`)
- 3 clock scenarios PASS; deterministic replay (same seed → identical output);
  seed-sensitive (skew counts vary).
- 18/18 across a 6-seed × 3-scenario sweep.
- Existing scenarios unaffected (11/11 regression), 64-seed swarm OK.
- OFF build: 0 \`__db_sim_*\` symbols.

Docs: DESIGN.md §1.4a + §3 table + catalog items 24/25; README layout + a
clock-skew section.