### PR TITLE
feat(dst): clock-skew / time-jump fault at the __os_gettime seam (+ found a dead-monotonic-clock bug)

### DIFF
--- a/src/os/os_clock.c
+++ b/src/os/os_clock.c
@@ -10,6 +10,10 @@
 
 #include "db_int.h"
 
+#ifdef HAVE_DST
+#include "sim_os.h"			/* DST clock-skew hook (--enable-dst only). */
+#endif
+
 /*
  * __os_gettime --
  *	Return the current time-of-day clock in seconds and nanoseconds.
@@ -64,6 +68,18 @@ __os_gettime(env, tp, monotonic)
 	tp->tv_nsec = 0;
 #else
 	NO AVAILABLE CLOCK IMPLEMENTATION
+#endif
+#ifdef HAVE_DST
+	/*
+	 * DST clock-skew / time-jump fault: when a sim armed the knob, apply
+	 * the seeded skew (fixed offset + jitter + occasional forward/BACKWARD
+	 * jump) to the reading BDB is about to return.  This is the single
+	 * seam every time-dependent decision (lock/txn timeout deadlines, the
+	 * deadlock detector's expiry scan, checkpoint scheduling, replication
+	 * lease/election timers) reads "now" through.  A no-op when no sim is
+	 * running; compiled out entirely without --enable-dst (zero overhead).
+	 */
+	__db_sim_clock_hook(tp, monotonic);
 #endif
 	COMPQUIET(monotonic, 0);
 	return;

--- a/test/sim/sim_clock.h
+++ b/test/sim/sim_clock.h
@@ -1,0 +1,91 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_clock.h --
+ *	Clock-skew / time-jump fault class.  Under sim, when armed, the
+ *	__os_gettime seam applies a seeded per-read skew to the clock BDB
+ *	reads -- a fixed per-run offset, optional per-read jitter, and an
+ *	occasional discrete JUMP (forward and, the dangerous one, BACKWARD).
+ *	This exercises every decision that reads the clock: lock/txn timeout
+ *	deadlines (deadline = now + timeout; later now2 >= deadline), the
+ *	deadlock detector's expiry scan, checkpoint scheduling and the
+ *	replication lease/election timers.
+ *
+ *	FoundationDB-style: a process's clock can read ahead/behind "true"
+ *	time and can jump.  The correctness concern is code that assumes
+ *	monotonic time -- a backward jump can make a timeout never fire
+ *	(hang) or fire instantly (premature abort).
+ *
+ *	This header is OWNED by the clock-skew work; keep the shared headers
+ *	(sim_fault.h / sim_rng.h) untouched.  The skew draws on its own
+ *	dedicated PRNG stream so arming it never perturbs the IO/FAULT/APP
+ *	streams (same discipline as every other fault knob).
+ *
+ *	Compilation model: like the rest of DST, this whole surface is only
+ *	reachable under --enable-dst (HAVE_DST).  The __os_gettime hook is
+ *	#ifdef HAVE_DST and is a single relaxed load (__db_sim_active) in the
+ *	common no-sim case, so an --enable-dst library that is NOT running a
+ *	sim reads the real clock at ~zero cost, and a production (DST-off)
+ *	build never sees any of this.
+ */
+
+#ifndef _DB_SIM_CLOCK_H_
+#define _DB_SIM_CLOCK_H_
+
+#include <stdint.h>
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * Arm the clock-skew fault.  Drawn from the dedicated CLOCK stream so
+ * enabling it never shifts another site's draws.
+ *
+ *   offset_ns  a FIXED per-run offset applied to EVERY read (models a
+ *              clock that reads steadily ahead/behind true time); may be
+ *              negative.  If 0, a seeded offset in [-1s, +1s] is drawn.
+ *   jitter_ns  bound on a per-read uniform jitter in [-jitter, +jitter]
+ *              (models a jumpy, imprecise clock); 0 => no jitter.
+ *   jump_ns    magnitude of an occasional discrete jump; 0 => no jumps.
+ *   jump_pct   per-1000 probability that a given read takes a jump.  A
+ *              jump is forward or BACKWARD (seeded coin) by up to jump_ns.
+ *
+ * All bounded + seeded: same seed => same skew sequence => replayable.
+ */
+void __db_sim_clock_enable
+    __P((int64_t offset_ns, int64_t jitter_ns, int64_t jump_ns, unsigned jump_pct));
+void __db_sim_clock_disable __P((void));
+int  __db_sim_clock_armed __P((void));
+
+/*
+ * Bound the disturbance to the first `n` clock reads, after which the skew
+ * self-disables (the clock "settles" back to true time).  This models a
+ * TRANSIENT jump -- a real clock-skew event has a finite duration; a
+ * correct deadline-based timeout must recover and fire once the clock
+ * resumes advancing.  0 (the default) => the skew never settles (a
+ * persistent-adversary clock).  Deterministic: `n` reads is `n` reads.
+ */
+void __db_sim_clock_settle_after __P((unsigned n));
+
+/*
+ * Apply the armed skew to a just-read clock value.  `sec`/`nsec` are the
+ * real reading; on return they hold the skewed reading.  A no-op (leaves
+ * the value untouched) unless a sim armed the knob.  Counts a skew
+ * "firing" via the fault-activation counter so a swarm can prove coverage.
+ *
+ * `monotonic` is passed through for diagnostics/future use; the skew is
+ * applied to both clock domains because a skewed process clock skews every
+ * reading (that is exactly the FDB model, and it is what makes a "monotonic"
+ * read that in libdb actually falls through to CLOCK_REALTIME dangerous).
+ */
+void __db_sim_clock_skew __P((time_t *sec, long *nsec, int monotonic));
+
+/* How many times the skew has fired this run (diagnostic / coverage). */
+unsigned long __db_sim_clock_fire_count __P((void));
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_CLOCK_H_ */

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -24,6 +24,7 @@
 #include "db_int.h"
 #include "sim_rng.h"
 #include "sim_fault.h"
+#include "sim_clock.h"
 
 #include <stdatomic.h>
 #include <stdio.h>
@@ -148,6 +149,7 @@ __db_sim_fault_class_name(cls)
 	case DB_SIM_FC_STALE:    return ("stale");
 	case DB_SIM_FC_LATENCY:  return ("latency");
 	case DB_SIM_FC_SHORTEIO: return ("shorteio");
+	case DB_SIM_FC_CLOCK:    return ("clock");
 	default:                 return ("?");
 	}
 }
@@ -184,6 +186,7 @@ __db_sim_deactivate()
 	atomic_store_explicit(&g_io_corrupt_on, 0, memory_order_release);
 	__db_sim_io_stale_enable(0);
 	__db_sim_wb_enable(0);
+	__db_sim_clock_disable();
 }
 
 uint64_t
@@ -734,4 +737,149 @@ __db_sim_io_stale_read(fkey, off, buf, len)
 		}
 	}
 	return (0);
+}
+
+/* ---- clock-skew / time-jump fault (sim_clock.h) ----
+ *
+ * A seeded skew applied at the __os_gettime seam.  Three components, all
+ * bounded and drawn from the dedicated CLOCK stream so arming this never
+ * shifts another site's draws:
+ *   - g_clk_offset: a FIXED per-run offset (set once at arm), applied to
+ *     every read -- a clock that reads steadily ahead/behind true time;
+ *   - g_clk_jitter: a per-read uniform jitter in [-j, +j] -- an imprecise,
+ *     jumpy clock;
+ *   - g_clk_jump*:  an occasional discrete jump, forward or BACKWARD, by
+ *     up to g_clk_jump_ns, with per-1000 probability g_clk_jump_pct.  The
+ *     backward jump is the dangerous one: it can make a deadline (now +
+ *     timeout, compared later against a smaller now) never be reached.
+ *
+ * The skew is applied to a signed nanosecond accumulator then clamped so
+ * the result never goes negative (a negative tv_sec would be nonsense to
+ * the caller and is not what "clock reads earlier" means).  Determinism:
+ * the whole sequence of skews is a pure function of the seed.
+ */
+static _Atomic int     g_clk_on;
+static _Atomic int64_t g_clk_offset;     /* fixed per-run offset (ns) */
+static _Atomic int64_t g_clk_jitter;     /* per-read jitter bound (ns) */
+static _Atomic int64_t g_clk_jump_ns;    /* jump magnitude (ns) */
+static _Atomic int     g_clk_jump_pct;   /* per-1000 jump probability */
+static _Atomic unsigned long g_clk_fires;
+static _Atomic long    g_clk_settle;     /* skew reads left; <0 => never */
+
+#define NS_PER_S 1000000000LL
+
+void
+__db_sim_clock_enable(offset_ns, jitter_ns, jump_ns, jump_pct)
+	int64_t offset_ns, jitter_ns, jump_ns;
+	unsigned jump_pct;
+{
+	int64_t off = offset_ns;
+
+	/* If no fixed offset requested, draw a seeded one in [-1s, +1s] so a
+	 * bare enable still models a clock that is off by a constant. */
+	if (off == 0)
+		off = (int64_t)__db_sim_rng_range(DB_SIM_RNG_CLOCK,
+		    (uint64_t)(2 * NS_PER_S + 1)) - NS_PER_S;
+	atomic_store_explicit(&g_clk_offset, off, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jitter,
+	    jitter_ns < 0 ? -jitter_ns : jitter_ns, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_ns,
+	    jump_ns < 0 ? -jump_ns : jump_ns, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_pct,
+	    jump_pct > 1000 ? 1000 : (int)jump_pct, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_fires, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_settle, -1, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_on, 1, memory_order_release);
+}
+
+void
+__db_sim_clock_settle_after(n)
+	unsigned n;
+{
+	atomic_store_explicit(&g_clk_settle, (long)n, memory_order_relaxed);
+}
+
+void
+__db_sim_clock_disable()
+{
+	atomic_store_explicit(&g_clk_on, 0, memory_order_release);
+	atomic_store_explicit(&g_clk_offset, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jitter, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_ns, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_jump_pct, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_clk_settle, -1, memory_order_relaxed);
+}
+
+int
+__db_sim_clock_armed()
+{
+	return (atomic_load_explicit(&g_clk_on, memory_order_acquire) &&
+	    __db_sim_active());
+}
+
+unsigned long
+__db_sim_clock_fire_count()
+{
+	return (atomic_load_explicit(&g_clk_fires, memory_order_relaxed));
+}
+
+void
+__db_sim_clock_skew(sec, nsec, monotonic)
+	time_t *sec;
+	long *nsec;
+	int monotonic;
+{
+	int64_t total, jit, jbound, jmag;
+	int jpct;
+	long left;
+
+	COMPQUIET(monotonic, 0);
+	if (sec == NULL || nsec == NULL || !__db_sim_clock_armed())
+		return;
+
+	/* Transient-jump budget: after `settle` skewed reads the clock
+	 * returns to true time (a bounded disturbance that recovers). */
+	left = atomic_load_explicit(&g_clk_settle, memory_order_relaxed);
+	if (left == 0)
+		return;                     /* settled: real clock */
+	if (left > 0)
+		atomic_store_explicit(&g_clk_settle, left - 1,
+		    memory_order_relaxed);
+
+	/* real reading as a signed ns accumulator */
+	total = (int64_t)*sec * NS_PER_S + (int64_t)*nsec;
+
+	/* fixed per-run offset */
+	total += atomic_load_explicit(&g_clk_offset, memory_order_relaxed);
+
+	/* per-read jitter in [-bound, +bound] */
+	jbound = atomic_load_explicit(&g_clk_jitter, memory_order_relaxed);
+	if (jbound > 0) {
+		jit = (int64_t)__db_sim_rng_range(DB_SIM_RNG_CLOCK,
+		    (uint64_t)(2 * jbound + 1)) - jbound;
+		total += jit;
+	}
+
+	/* occasional discrete jump, forward or BACKWARD */
+	jmag = atomic_load_explicit(&g_clk_jump_ns, memory_order_relaxed);
+	jpct = atomic_load_explicit(&g_clk_jump_pct, memory_order_relaxed);
+	if (jmag > 0 && jpct > 0 &&
+	    (int)__db_sim_rng_range(DB_SIM_RNG_CLOCK, 1000) < jpct) {
+		/* seeded coin: 0 => backward, 1 => forward */
+		int64_t j = (int64_t)__db_sim_rng_range(DB_SIM_RNG_CLOCK,
+		    (uint64_t)jmag + 1);
+		if (__db_sim_rng_range(DB_SIM_RNG_CLOCK, 2) == 0)
+			total -= j;                 /* BACKWARD (dangerous) */
+		else
+			total += j;                 /* forward */
+	}
+
+	/* Clamp: a clock never reads before the epoch here. */
+	if (total < 0)
+		total = 0;
+
+	*sec = (time_t)(total / NS_PER_S);
+	*nsec = (long)(total % NS_PER_S);
+	fc_hit(DB_SIM_FC_CLOCK);
+	atomic_fetch_add_explicit(&g_clk_fires, 1, memory_order_relaxed);
 }

--- a/test/sim/sim_fault.h
+++ b/test/sim/sim_fault.h
@@ -46,6 +46,7 @@ enum db_sim_fault_class {
 	DB_SIM_FC_STALE    = 3,   /* stale read (prior version returned) */
 	DB_SIM_FC_LATENCY  = 4,   /* per-I/O latency sleep taken */
 	DB_SIM_FC_SHORTEIO = 5,   /* short-transfer / EIO toggle fired */
+	DB_SIM_FC_CLOCK    = 6,   /* clock skew / time-jump applied */
 	DB_SIM_FC_NCLASSES
 };
 unsigned long __db_sim_fault_count __P((int));

--- a/test/sim/sim_os.h
+++ b/test/sim/sim_os.h
@@ -24,6 +24,7 @@ void __db_sim_io_presnapshot_hook __P((DB_FH *, u_int64_t, u_int32_t));
 void __db_sim_io_sync_hook __P((DB_FH *));
 void __db_sim_io_read_hook __P((DB_FH *, u_int64_t, void *, size_t));
 void __db_sim_io_latency_hook __P((void));
+void __db_sim_clock_hook __P((db_timespec *, int));
 
 #if defined(__cplusplus)
 }

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -25,6 +25,7 @@
 #include "db_int.h"
 #include "sim_rng.h"
 #include "sim_fault.h"
+#include "sim_clock.h"
 
 /*
  * db_sim_fkey --
@@ -233,4 +234,35 @@ __db_sim_io_latency_hook()
 	if (!__db_sim_active())
 		return;
 	__db_sim_io_sleep_latency();
+}
+
+/*
+ * __db_sim_clock_hook --
+ *	Called from __os_gettime AFTER a real clock reading has landed in
+ *	`tp`.  When the clock-skew fault is armed, applies the seeded skew
+ *	(fixed offset + jitter + occasional forward/backward jump) in place;
+ *	a no-op (leaves tp untouched, ~zero cost) otherwise.  This is the
+ *	one seam every lock/txn timeout deadline, the deadlock detector's
+ *	expiry scan, checkpoint scheduling and the replication timers read
+ *	their notion of "now" through.
+ *
+ * PUBLIC: #ifdef HAVE_DST
+ * PUBLIC: void __db_sim_clock_hook __P((db_timespec *, int));
+ * PUBLIC: #endif
+ */
+void
+__db_sim_clock_hook(tp, monotonic)
+	db_timespec *tp;
+	int monotonic;
+{
+	time_t sec;
+	long nsec;
+
+	if (tp == NULL || !__db_sim_clock_armed())
+		return;
+	sec = tp->tv_sec;
+	nsec = (long)tp->tv_nsec;
+	__db_sim_clock_skew(&sec, &nsec, monotonic);
+	tp->tv_sec = sec;
+	tp->tv_nsec = nsec;
 }

--- a/test/sim/sim_rng.h
+++ b/test/sim/sim_rng.h
@@ -39,6 +39,7 @@ enum db_sim_stream {
 	DB_SIM_RNG_BUGGIFY = 2,   /* buggify per-run activation coins */
 	DB_SIM_RNG_APP     = 3,   /* application/test workload draws */
 	DB_SIM_RNG_SCHED   = 4,   /* RESERVED: deterministic scheduler (v2) */
+	DB_SIM_RNG_CLOCK   = 5,   /* clock-skew / time-jump fault stream */
 	DB_SIM_RNG_NSTREAMS
 };
 


### PR DESCRIPTION
Adds a **clock-skew / time-jump fault class** — DST can now exercise every time-dependent decision (lock/txn timeout deadlines, the deadlock detector's expiry scan, checkpoint scheduling, replication lease/election timers) under a skewed, jittering, or **backward-jumping** clock.

## Mechanism
Hook at BDB's single time seam `__os_gettime` (`src/os/os_clock.c`, `#ifdef HAVE_DST`, zero-overhead off — verified 0 `__db_sim_*` symbols). Seeded skew = fixed per-run offset + per-read jitter + occasional forward/**backward** discrete jump, bounded (transient, settles). New dedicated `DB_SIM_RNG_CLOCK` stream + `DB_SIM_FC_CLOCK` counter — additive, existing seeds replay unchanged.

## Scenarios (3, deterministic, `alarm()`-guarded)
- `clockskew_timeout` — lock timeout fires under offset+jitter+forward+backward jumps; no hang.
- `clockskew_ckp` — checkpoints + recovery clean under +1h forward jump; 256 commits durable.
- `clockskew_backward` — the dangerous case: transient backward jump does **not** lose an already-set txn deadline.

## Findings (honest)
1. **BDB does NOT actually use a monotonic clock.** `os_clock.c` has an unconditional second `clock_gettime(CLOCK_REALTIME, tp)` that clobbers the `CLOCK_MONOTONIC` read — so `__os_gettime(monotonic=1)` always returns wall-clock time; the monotonic branch is dead code. Clock skew is therefore a *real* risk. **Pre-existing engine bug, documented (`.agents/`), NOT fixed here** — deserves its own one-line focused PR (delete the stray line).
2. **No lost/hung timeout though.** The deadlock detector re-reads the clock fresh each pass against a fixed deadline, so it's robust to a non-monotonic/jumping/backward clock. The 3 scenarios *prove* that robustness — that's the deliverable.

Validation: 3/3 PASS + deterministic (18/18 sweep); 11/11 existing scenarios + 64-seed swarm unaffected; OFF build 0 sim symbols.