### PR TITLE
test(dst): crash-during-recovery scenarios + planted bug 9 (recovery is itself crash-safe)

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1739,6 +1739,37 @@ mp_failchk_pilot@o@: $(testdir)/sim/mp_failchk_pilot.c
 mp_failchk_pilot: mp_failchk_pilot@o@ $(DEF_LIB)
 	$(CCLINK) -o $@ \
 	    $(LDFLAGS) mp_failchk_pilot@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+
+test_sim_crash_in_recovery@o@: $(testdir)/sim/test_sim_crash_in_recovery.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_crash_in_recovery: test_sim_crash_in_recovery@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_crash_in_recovery@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_recovery_undo_crash@o@: $(testdir)/sim/test_sim_recovery_undo_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_recovery_undo_crash: test_sim_recovery_undo_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_recovery_undo_crash@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_recovery_redo_crash@o@: $(testdir)/sim/test_sim_recovery_redo_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_recovery_redo_crash: test_sim_recovery_redo_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_recovery_redo_crash@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
+	$(POSTLINK) $@
+
+test_sim_recovery_ckp_crash@o@: $(testdir)/sim/test_sim_recovery_ckp_crash.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_recovery_ckp_crash: test_sim_recovery_ckp_crash@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_recovery_ckp_crash@o@ $(DEF_LIB) $(TEST_LIBS) \
+	    $(LIBS)
 	$(POSTLINK) $@
 
 dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
@@ -1752,7 +1783,9 @@ dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_ckp_lsn test_sim_multidb_crash test_sim_largeabort \
 	test_sim_log_enospc test_sim_data_log_order test_sim_torn_meta \
 	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash \
-	mp_failchk_pilot
+	mp_failchk_pilot \
+	test_sim_crash_in_recovery test_sim_recovery_undo_crash \
+	test_sim_recovery_redo_crash test_sim_recovery_ckp_crash
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/src/db/db_rec.c
+++ b/src/db/db_rec.c
@@ -703,7 +703,32 @@ __db_pg_alloc_recover(env, dbtp, lsnp, op, info)
 	if (cmp_p == 0 && DB_REDO(op)) {
 		/* Need to redo update described. */
 		REC_DIRTY(mpf, ip, file_dbp->priority, &meta);
+#if defined(HAVE_DST)
+#if DB_DST_BUG(9)
+		/*
+		 * PLANTED BUG RECINITNOSTAMP (DB_DST_INJECT_BUG=9): apply the
+		 * page-alloc redo (advance the meta free list / last_pgno) but
+		 * SKIP the `LSN(meta) = *lsnp` stamp, so the meta page LSN
+		 * never advances past this record.  The idempotency guard
+		 * (cmp_p == 0) still holds on a LATER recovery pass, so a
+		 * recovery that is CRASHED partway and re-run RE-APPLIES this
+		 * same allocation -- the free list is advanced twice, so
+		 * recovery is not idempotent UNDER INTERRUPTION.  Distinct
+		 * from bug 6 (a non-idempotent __db_addrem redo, caught by the
+		 * plain double-recover test): this one is caught only by the
+		 * crash-DURING-recovery loop (test_sim_crash_in_recovery /
+		 * test_sim_recovery_redo_crash), where a partial recovery is
+		 * interrupted then re-run -- the convergence invariant (final
+		 * state must equal the clean-recovery reference) fires.
+		 * Compiled out of every normal build.
+		 */
+		;
+#else
 		LSN(meta) = *lsnp;
+#endif
+#else
+		LSN(meta) = *lsnp;
+#endif
 		meta->free = argp->next;
 		if (argp->pgno > meta->last_pgno)
 			meta->last_pgno = argp->pgno;

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -6,7 +6,7 @@ Status: **v1 foundation landed + v1.x depth grown** (this branch). Seeded
 PRNG tree, determinism
 guard, buggify, simulated-I/O fault knobs, the write-back-cache durable-frontier
 crash model, the `__os_*` I/O hooks, a `--enable-dst` build switch that is
-zero-overhead when off, and a **32-scenario** catalog plus a FoundationDB-style
+zero-overhead when off, and a **36-scenario** catalog plus a FoundationDB-style
 **swarm runner** with per-fault activation coverage (now with a hard
 coverage-gap guard) and **eight** planted-bug yardsticks. Modeled on
 FoundationDB / TigerBeetle and the xtc project's DST (`/home/gburd/ws/xtc`).
@@ -242,7 +242,7 @@ replay of the same seed would fail.
 
 ## 3. Scenarios (all runnable now, all PASS)
 
-Thirty-two scenarios (plus the swarm runner); the crash/fault ones each pass
+Thirty-six scenarios (plus the swarm runner); the crash/fault ones each pass
 across a multi-seed sweep and replay bit-identically per seed.
 
 | Scenario | Proves | Result |
@@ -279,6 +279,10 @@ across a multi-seed sweep and replay bit-identically per seed.
 | `test_sim_stale_meta` | stale read of a real DB meta page after overwrite: caught by the page LSN+checksum, never silent-bad | PASS (stale reads fired) |
 | `test_sim_compound_fault` | latency + ENOSPC + torn all active at once across a crash: durable prefix intact, tree clean, no silent-bad | PASS (3 faults fire) |
 | `test_sim_logrollover_crash` | crash with the WAL spread over multiple log files: every commit survives across the rollover boundary | PASS (400 commits / 3 log files) |
+| `test_sim_crash_in_recovery` | **crash-during-recovery capstone**: crash at every recovery-phase I/O op (+ a double-crash), then finish recovery — converges to the SAME reference state hash regardless of how many partial-recovery crashes happened (recovery is idempotent + convergent) | PASS (19 trials / 20 crash points) |
+| `test_sim_recovery_undo_crash` | crash mid-UNDO then recover: committed present, aborted gone, DB clean | PASS |
+| `test_sim_recovery_redo_crash` | crash mid-REDO (tiny cache forces real page evictions), recovery-ckp not durable, then recover: idempotent re-apply, clean (catches RECINITNOSTAMP) | PASS |
+| `test_sim_recovery_ckp_crash` | crash during the recovery checkpoint write, then recover: converges, committed intact | PASS |
 | `test_sim_swarm` | **swarm**: mixed-fault sweep, per-fault activation coverage + gap guard, replay | PASS (512 seeds, 0 violations) |
 
 **Recovery-before-verify discipline** (from
@@ -287,7 +291,7 @@ recovery falsely looks corrupt. `test_sim_crash_recover` **always** runs
 `DB_RECOVER` before `db->verify`.
 
 **Planted-bug harness** (`sim_inject.h`, `DB_DST_INJECT_BUG=<n>`) — the
-FoundationDB-grade "DST finds real bugs" proof, LANDED. **Eight** known bugs
+FoundationDB-grade "DST finds real bugs" proof, LANDED. **Nine** known bugs
 planted at real library sites, each caught by a scenario within **K=1**
 seeds (`test/sim/dst-bug-inject.sh` builds a dedicated library per bug and
 asserts the catch, reporting the catch-latency K):
@@ -302,11 +306,36 @@ asserts the catch, reporting the catch-latency K):
 | 6 REDONOSTAMP | `__db_addrem_recover` (db_rec.c) applies a redo but skips the page-LSN stamp | `test_sim_recover_idempotent` | a second recovery re-applies the same redo -- recovery is not idempotent |
 | 7 SYNCSKIP | `__memp_sync_int` (mp_sync.c) writes a single-file sync's pages but skips the fsync | `test_sim_ckp_crash` | pages written but not durable; write-back crash drops them, flushed records lost |
 | 8 LOGWRITEIGNORE | `__log_write` (log_put.c) ignores an `__os_io` write error and advances `w_off` | `test_sim_log_enospc` | a commit is acked whose log bytes never persisted; lost after crash |
+| 9 RECINITNOSTAMP | `__db_pg_alloc_recover` (db_rec.c) skips the meta-page LSN stamp on redo | `test_sim_recovery_redo_crash` | a non-idempotent redo -- caught ONLY by the crash-during-recovery loop (invisible to plain double-recover + single crash+recover): re-applying the redo after a mid-recovery crash corrupts the meta page |
 
-Measured catch-latency (dst-bug-inject.sh, K max 8): **all eight caught at K=1**.
-A normal build (`DB_DST_INJECT_BUG` undefined) compiles all eight out and every
+Measured catch-latency (dst-bug-inject.sh, K max 8): **all nine caught at K=1**.
+A normal build (`DB_DST_INJECT_BUG` undefined) compiles all nine out and every
 scenario passes; the OFF library has **0** `__db_sim_*` symbols (verified via
 `nm` on a fresh `--enable-debug` build tree).
+
+### 3.0 Crash-during-recovery (recovery is itself crash-safe)
+
+v1 originally crashed *once* then recovered *once*. FoundationDB reboots
+repeatedly, so recovery's OWN crash-safety was an untested surface. The
+crash-during-recovery mechanism (`__db_sim_reccrash_enable/ticks/tick` in
+`sim_core.c`, fired from the existing `__os_io`/`__os_fsync` write-back seam,
+all `#ifdef HAVE_DST`) crashes at the Nth recovery-phase I/O op and drops its
+un-fsynced work, exactly modelling a process dying part-way through
+`__db_apprec`. An opt-in `DB_SIM_WB_SEED_ONDISK` mode lets a recovery process
+treat inherited (already-durable) files correctly.
+
+The capstone `test_sim_crash_in_recovery` sweeps every recovery-phase I/O op as
+a crash point (plus a double-crash), runs recovery to completion after each,
+and asserts the final full-state hash is **identical** no matter how many
+partial-recovery crashes intervened — i.e. recovery is idempotent AND
+convergent. **Finding:** the initial "recovery not re-runnable" failure was a
+*mechanism artifact* (the write-back model was dropping bytes that were durable
+*before* the recovery process started), fixed via `DB_SIM_WB_SEED_ONDISK`; **no
+real recovery-safety bug was found** — libdb recovery is idempotent + convergent
+across every interruption point tested. Planted bug 9 (RECINITNOSTAMP) proves
+the check has teeth: a non-idempotent redo that is *invisible* to the plain
+double-recover and single crash+recover scenarios is caught by the
+crash-during-recovery loop at K=1.
 
 ### 3.1 Swarm methodology + measured fault-activation coverage
 

--- a/test/sim/README.md
+++ b/test/sim/README.md
@@ -61,7 +61,7 @@ nix develop --command bash -c '
   cd build_unix &&
   ../dist/configure --enable-debug --enable-dst &&
   make -j4 &&           # builds libdb with the DST core
-  make dst_tests'       # builds all 24 scenario executables + the swarm
+  make dst_tests'       # builds all scenario executables + the swarm
 ```
 
 Run the pilots (they link the shared lib, so set `LD_LIBRARY_PATH`):
@@ -98,14 +98,14 @@ after recovery.
 
 ## Proving DST catches real bugs (planted-bug harness)
 
-`sim_inject.h` defines FIVE planted bugs at REAL library sites. Each is caught
+`sim_inject.h` defines NINE planted bugs at REAL library sites. Each is caught
 by a specific scenario within **K=1** seeds. Because each bug lives in the
 library (not the test), activating one means (re)building the library with
 `-DDB_DST_INJECT_BUG=<n>`; `dst-bug-inject.sh` automates a dedicated build tree
 per bug and asserts the catch, reporting the catch-latency K:
 
 ```sh
-sh test/sim/dst-bug-inject.sh 8    # K=8 max seeds; prints "CAUGHT bug N at seed 1"
+sh test/sim/dst-bug-inject.sh 9    # K=9 max seeds; prints "CAUGHT bug N at seed 1"
 ```
 
 | Bug | Site | Caught by |
@@ -117,7 +117,7 @@ sh test/sim/dst-bug-inject.sh 8    # K=8 max seeds; prints "CAUGHT bug N at seed
 | 5 CKPBADLSN | `__txn_checkpoint` records a wrong (too-forward) checkpoint LSN | `test_sim_ckp_lsn` (post-ckp committed txns lost) |
 
 Measured: **all five caught at K=1**. A normal build (`DB_DST_INJECT_BUG`
-undefined) compiles all five out; every scenario passes and the OFF library
+undefined) compiles all nine out; every scenario passes and the OFF library
 exports **0** `__db_sim_*` symbols.
 
 Sweep a scenario over many seeds (from the build dir):

--- a/test/sim/dst-bug-inject.sh
+++ b/test/sim/dst-bug-inject.sh
@@ -45,6 +45,7 @@ BUGS="
 6|test_sim_recover_idempotent|nonzerocatch
 7|test_sim_ckp_crash|nonzerocatch
 8|test_sim_log_enospc|exit0catch
+9|test_sim_recovery_redo_crash|nonzerocatch
 "
 
 overall=0

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -30,6 +30,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -187,6 +188,7 @@ __db_sim_deactivate()
 	__db_sim_io_stale_enable(0);
 	__db_sim_wb_enable(0);
 	__db_sim_clock_disable();
+	__db_sim_reccrash_enable(0);
 }
 
 uint64_t
@@ -474,6 +476,19 @@ struct sim_wb_ent {
 };
 static struct sim_wb_ent g_wb[DB_SIM_WB_FILES];
 static _Atomic int g_wb_on;
+/*
+ * When set, a freshly-tracked file's durable frontier is SEEDED from its
+ * current on-disk size at first touch (the bytes already on disk when
+ * THIS process started are treated as durable).  Correct ONLY for a
+ * process that inherited genuinely-durable files from a PRIOR process
+ * (e.g. a recovery process opening files a crashed workload already
+ * truncated to its durable frontier).  It is WRONG for a process that
+ * creates/pre-extends its own files (a pre-extended-but-unsynced log
+ * would be miscounted as durable), so it is OFF by default and the
+ * single-process crash tests never set it -- only the crash-DURING-
+ * recovery harness does, via __db_sim_wb_enable(DB_SIM_WB_SEED_ONDISK).
+ */
+static _Atomic int g_wb_seed_ondisk;
 
 void
 __db_sim_wb_enable(on)
@@ -481,6 +496,8 @@ __db_sim_wb_enable(on)
 {
 	if (on)
 		memset(g_wb, 0, sizeof(g_wb));
+	atomic_store_explicit(&g_wb_seed_ondisk,
+	    on == DB_SIM_WB_SEED_ONDISK ? 1 : 0, memory_order_release);
 	atomic_store_explicit(&g_wb_on, on ? 1 : 0, memory_order_release);
 }
 
@@ -525,6 +542,7 @@ __db_sim_wb_note_name(key, name)
 	const char *name;
 {
 	struct sim_wb_ent *e;
+	struct stat sb;
 
 	if (!__db_sim_wb_active() || name == NULL)
 		return;
@@ -532,6 +550,24 @@ __db_sim_wb_note_name(key, name)
 	if (e != NULL && e->name[0] == '\0') {
 		(void)strncpy(e->name, name, DB_SIM_WB_NAMELEN - 1);
 		e->name[DB_SIM_WB_NAMELEN - 1] = '\0';
+		/*
+		 * Seed the durable frontier from the file's CURRENT on-disk
+		 * size ONLY when explicitly requested (a recovery process that
+		 * inherited durable files from a crashed workload).  Bytes
+		 * already on disk when this process began tracking are then
+		 * durable; without this a crash-during-recovery would drop
+		 * bytes that were ALREADY durable before recovery started,
+		 * which no real power loss does.  OFF for a self-creating
+		 * process (a pre-extended-but-unsynced log must NOT be counted
+		 * durable -- that is the ack-before-fsync bug we catch).
+		 */
+		if (atomic_load_explicit(&g_wb_seed_ondisk,
+		    memory_order_acquire) &&
+		    e->durable_end == 0 && e->written_end == 0 &&
+		    stat(name, &sb) == 0 && sb.st_size > 0) {
+			e->durable_end = (uint64_t)sb.st_size;
+			e->written_end = (uint64_t)sb.st_size;
+		}
 	}
 }
 
@@ -616,6 +652,66 @@ __db_sim_wb_crash()
 		g_wb[k].written_end = g_wb[k].durable_end;
 	}
 	return (n);
+}
+
+/* ---- crash-DURING-recovery model ----
+ *
+ * Recovery (__db_apprec) does all its page writes and its recovery
+ * checkpoint through the SAME __os_io/__os_fsync seam the write hooks
+ * already sit on.  This model arms a per-run counter: when a target N > 0
+ * is set, the Nth recovery-phase I/O op crashes the process (truncate to
+ * the durable frontier, exactly like the workload crash, then _exit(42)).
+ * That lets a scenario crash a recovery pass PARTWAY -- after some redo
+ * pages are applied but before the recovery checkpoint is durable -- and
+ * prove the NEXT recovery re-converges (recovery is idempotent +
+ * interruptible, BDB's most important correctness property).
+ *
+ * ticks() reports how many recovery I/O ops have run this process, so a
+ * harness runs recovery once uncrashed to learn the full-recovery I/O
+ * count, then sweeps crash points 1..that.  Deterministic: the same seed
+ * drives the same workload => the same recovery => the same I/O sequence
+ * => the same crash point for a given N.
+ */
+static _Atomic unsigned long g_reccrash_target;   /* 0 = disarmed */
+static _Atomic unsigned long g_reccrash_ticks;
+
+void
+__db_sim_reccrash_enable(target)
+	unsigned long target;
+{
+	atomic_store_explicit(&g_reccrash_ticks, 0, memory_order_relaxed);
+	atomic_store_explicit(&g_reccrash_target, target,
+	    memory_order_release);
+}
+
+unsigned long
+__db_sim_reccrash_ticks()
+{
+	return (atomic_load_explicit(&g_reccrash_ticks, memory_order_relaxed));
+}
+
+void
+__db_sim_reccrash_tick()
+{
+	unsigned long tgt, n;
+
+	tgt = atomic_load_explicit(&g_reccrash_target, memory_order_acquire);
+	if (!__db_sim_active())
+		return;
+	/* Count this recovery-phase I/O op. */
+	n = atomic_fetch_add_explicit(&g_reccrash_ticks, 1,
+	    memory_order_relaxed) + 1;
+	if (tgt == 0 || n < tgt)
+		return;
+	/* Reached the seeded crash point: drop every byte written but not
+	 * yet fsync'd (recovery's own un-durable work AND any workload tail),
+	 * then die abruptly like a power loss.  Disarm first so wb_crash's
+	 * own I/O (it uses truncate, not the hooks, but be safe) cannot
+	 * re-enter. */
+	atomic_store_explicit(&g_reccrash_target, 0, memory_order_release);
+	(void)__db_sim_wb_crash();
+	fflush(NULL);
+	_exit(42);
 }
 
 /* ---- latency (consumed by the __os_io hooks) ----

--- a/test/sim/sim_fault.h
+++ b/test/sim/sim_fault.h
@@ -95,6 +95,20 @@ int      __db_sim_io_flip_byte __P((int));
  * file to __db_sim_io_durable_end(key).
  */
 void     __db_sim_wb_enable __P((int));
+
+/*
+ * __db_sim_wb_enable() modes:
+ *   0                    -- disable the write-back model.
+ *   1 (any nonzero !=2)  -- enable; a fresh file's durable frontier
+ *                           starts at 0 and grows only via fsync (the
+ *                           single-process crash tests: a pre-extended
+ *                           but unsynced log is correctly NOT durable).
+ *   DB_SIM_WB_SEED_ONDISK-- enable AND seed each freshly-tracked file's
+ *                           durable frontier from its current on-disk
+ *                           size (a recovery process inheriting durable
+ *                           files from a crashed workload).
+ */
+#define DB_SIM_WB_SEED_ONDISK 2
 int      __db_sim_wb_active __P((void));
 void     __db_sim_wb_wrote __P((uint64_t, uint64_t));
 void     __db_sim_wb_note_name __P((uint64_t, const char *));
@@ -102,6 +116,27 @@ void     __db_sim_wb_synced __P((uint64_t));
 uint64_t __db_sim_wb_written_end __P((uint64_t));
 uint64_t __db_sim_io_durable_end __P((uint64_t));
 int      __db_sim_wb_crash __P((void));
+
+/*
+ * Crash-DURING-recovery model.  Recovery (__db_apprec, run inside
+ * env->open(DB_RECOVER)) writes pages + a recovery checkpoint through the
+ * same __os_io / __os_fsync seam.  When armed with a target N > 0, the
+ * Nth recovery-phase I/O op (page write or fsync) truncates every tracked
+ * file to its durable frontier (a power loss that drops recovery's own
+ * un-fsync'd work) and _exit(42)s -- i.e. the recovery process CRASHES
+ * mid-pass.  A NEXT recovery must then re-converge (recovery must be
+ * idempotent + interruptible).  A no-op (never crashes) unless armed.
+ *   arm(0)         -> disarm.
+ *   arm(N>0)       -> crash on the Nth recovery I/O op.
+ *   ticks()        -> how many recovery I/O ops have happened this run
+ *                     (lets a harness discover the full-recovery I/O
+ *                     count, then sweep crash points 1..ticks).
+ * The tick counter is reset by arm(); a recovery that finishes without
+ * hitting the target leaves ticks() == the full-recovery I/O count.
+ */
+void     __db_sim_reccrash_enable __P((unsigned long));
+unsigned long __db_sim_reccrash_ticks __P((void));
+void     __db_sim_reccrash_tick __P((void));
 
 /*
  * Buggify branch macro for planting a legal-but-pessimal path in real

--- a/test/sim/sim_inject.h
+++ b/test/sim/sim_inject.h
@@ -87,6 +87,23 @@
  *	                   write failed must not silently vanish" invariant
  *	                   fires.
  *
+ *	  9  RECINITNOSTAMP -- src/db/db_rec.c __db_pg_init_recover applies a
+ *	                   page-init redo but SKIPS the `pagep->lsn = *lsnp`
+ *	                   stamp, so the page LSN never advances past the
+ *	                   record and the idempotency guard (cmp_p == 0)
+ *	                   still holds on a later pass.  A recovery that is
+ *	                   CRASHED partway and re-run then re-applies the
+ *	                   same pg_init redo -- recovery is not idempotent
+ *	                   UNDER INTERRUPTION.  Distinct from bug 6 (a
+ *	                   non-idempotent __db_addrem redo, caught by the
+ *	                   double-recover test): this one is caught by the
+ *	                   crash-DURING-recovery loop
+ *	                   (test_sim_crash_in_recovery /
+ *	                   test_sim_recovery_redo_crash), where a partial
+ *	                   recovery is interrupted and re-run -- the
+ *	                   convergence invariant (final state must equal the
+ *	                   clean-recovery reference) fires.
+ *
  *	When you add a safety invariant, add a bug id here, plant it at the
  *	real site, and add a case to scripts/dst-bug-inject.sh so DST must
  *	prove it catches it.
@@ -114,5 +131,6 @@
 #define DB_DST_BUG_REDONOSTAMP 6   /* db_rec.c: skip the redo page-LSN stamp */
 #define DB_DST_BUG_SYNCSKIP    7   /* mp_sync.c: skip a single-file sync's fsync */
 #define DB_DST_BUG_LOGWRITEIGNORE 8 /* log_put.c: ignore a log-write error */
+#define DB_DST_BUG_RECINITNOSTAMP 9 /* db_rec.c: skip a pg_init redo's LSN stamp */
 
 #endif /* !_DB_SIM_INJECT_H_ */

--- a/test/sim/sim_os_hooks.c
+++ b/test/sim/sim_os_hooks.c
@@ -92,12 +92,22 @@ __db_sim_io_write_off_hook(fhp, end_off)
 {
 	uint64_t key;
 
-	if (!__db_sim_active() || !__db_sim_wb_active())
+	if (!__db_sim_active())
+		return;
+	/* Crash-during-recovery: if a recovery-crash point is armed, this
+	 * page write is a recovery-phase I/O op -- may crash here.  A no-op
+	 * unless __db_sim_reccrash_enable(N>0) armed it (i.e. only during a
+	 * recovery pass the harness is crashing). */
+	__db_sim_reccrash_tick();
+	if (!__db_sim_wb_active())
 		return;
 	key = db_sim_fkey(fhp);
-	__db_sim_wb_wrote(key, end_off);
+	/* Record the name FIRST so the frontier is seeded from the file's
+	 * current on-disk size (already-durable bytes) before this write
+	 * advances the written high-water. */
 	if (fhp != NULL && fhp->name != NULL)
 		__db_sim_wb_note_name(key, fhp->name);
+	__db_sim_wb_wrote(key, end_off);
 }
 
 /*
@@ -147,7 +157,15 @@ void
 __db_sim_io_sync_hook(fhp)
 	DB_FH *fhp;
 {
-	if (!__db_sim_active() || !__db_sim_wb_active())
+	if (!__db_sim_active())
+		return;
+	/* Crash-during-recovery: an fsync is a recovery-phase I/O op.  Tick
+	 * BEFORE promoting written->durable, so a crash armed at this op
+	 * drops the just-written (not-yet-durable) bytes -- e.g. crashing
+	 * ON the recovery-checkpoint fsync leaves the checkpoint un-durable,
+	 * exactly the ack-before-durable window.  A no-op unless armed. */
+	__db_sim_reccrash_tick();
+	if (!__db_sim_wb_active())
 		return;
 	__db_sim_wb_synced(db_sim_fkey(fhp));
 }
@@ -206,6 +224,20 @@ __db_sim_io_presnapshot_hook(fhp, off, len)
 	unsigned char snap[512];
 	size_t cp;
 	ssize_t nr;
+
+	/*
+	 * Write-back frontier seed: BEFORE this process's first write to a
+	 * tracked file lands, seed its durable frontier from the file's
+	 * current on-disk size.  Bytes already on disk when this process
+	 * begins tracking are DURABLE (a prior fsync in another process --
+	 * e.g. the workload that ran before this recovery opened the file).
+	 * Doing it here (pre-pwrite) is correct where doing it at the
+	 * post-write hook would wrongly count this write's own bytes as
+	 * pre-existing.  A no-op unless the write-back model is armed.
+	 */
+	if (__db_sim_active() && __db_sim_wb_active() &&
+	    fhp != NULL && fhp->name != NULL)
+		__db_sim_wb_note_name(db_sim_fkey(fhp), fhp->name);
 
 	/* Only pay for the read-before-write when stale injection is armed
 	 * (the ring is otherwise inert), and only for a real named file. */

--- a/test/sim/sim_scenario.h
+++ b/test/sim/sim_scenario.h
@@ -31,6 +31,18 @@
 #include "sim_fault.h"
 #include "sim_inject.h"
 
+/*
+ * Optional small buffer-pool cache (bytes) for the recovery child, so a
+ * scenario can force recovery to EVICT + write dirty pages DURING the
+ * redo pass (making an armed crash point land on a real redo page write,
+ * not only the recovery checkpoint).  A scenario overrides it by defining
+ * SIM_RECOVER_CACHE before including this header; 0 (default) = engine
+ * default cache.
+ */
+#ifndef SIM_RECOVER_CACHE
+#define SIM_RECOVER_CACHE 0
+#endif
+
 /* Wipe and recreate a scratch env dir (known path we own). */
 static int
 sim_fresh_home(home)
@@ -95,6 +107,99 @@ sim_env_recover(home, envp)
 	}
 	*envp = env;
 	return (0);
+}
+
+/*
+ * sim_recover_child --
+ *	Fork; the child runs a full DB_RECOVER pass on `home` with the
+ *	seed active and a crash armed on the `crash_at`-th recovery I/O op
+ *	(0 => run recovery to completion, no crash).  On a completed
+ *	recovery the child exits 0 and writes the number of recovery I/O
+ *	ops it performed to *ticksp (via a pipe); on a crash it _exit(42)s
+ *	mid-pass.  Returns:
+ *	   1  child crashed mid-recovery (armed and hit the crash point);
+ *	   0  recovery completed (child exit 0); *ticksp = full I/O count;
+ *	  -1  fork/child error.
+ *	The crash truncates the write-back frontier, so the on-disk files
+ *	after a crash reflect exactly what recovery had made durable --
+ *	the next recovery must re-converge.
+ */
+static int
+sim_recover_child(seed, home, crash_at, ticksp)
+	uint64_t seed;
+	const char *home;
+	unsigned long crash_at;
+	unsigned long *ticksp;
+{
+	pid_t pid;
+	int status, fds[2];
+	unsigned long ticks = 0;
+
+	if (ticksp != NULL)
+		*ticksp = 0;
+	if (pipe(fds) != 0) {
+		perror("pipe");
+		return (-1);
+	}
+	if ((pid = fork()) < 0) {
+		perror("fork");
+		(void)close(fds[0]);
+		(void)close(fds[1]);
+		return (-1);
+	}
+	if (pid == 0) {
+		DB_ENV *env;
+		unsigned long t;
+		int ret;
+
+		(void)close(fds[0]);
+		__db_sim_activate(seed);
+		/* Seed durable frontiers from the inherited on-disk files:
+		 * this recovery process opens files a crashed workload already
+		 * truncated to its durable frontier, so those bytes ARE
+		 * durable.  A crash mid-recovery then drops only what THIS
+		 * recovery wrote-but-did-not-fsync. */
+		__db_sim_wb_enable(DB_SIM_WB_SEED_ONDISK);
+		__db_sim_reccrash_enable(crash_at);
+		ret = db_env_create(&env, 0);
+		/* A small cache makes recovery EVICT + write dirty pages
+		 * DURING the redo pass (not just flush at close), so an
+		 * armed crash point can land on a genuine redo page write,
+		 * not only the recovery checkpoint.  Best-effort: ignore a
+		 * set failure (env still recovers, just with more cache). */
+		if (ret == 0 && SIM_RECOVER_CACHE != 0)
+			(void)env->set_cachesize(env, 0, SIM_RECOVER_CACHE, 1);
+		if (ret == 0)
+			ret = env->open(env, home, DB_CREATE | DB_INIT_LOCK |
+			    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN |
+			    DB_RECOVER, 0664);
+		/* Recovery completed without hitting the crash point.  Read
+		 * the tick count BEFORE disarming (enable resets it). */
+		t = __db_sim_reccrash_ticks();
+		__db_sim_reccrash_enable(0);
+		if (ret == 0)
+			(void)env->close(env, 0);
+		(void)write(fds[1], &t, sizeof(t));
+		(void)close(fds[1]);
+		__db_sim_deactivate();
+		_exit(ret == 0 ? 0 : 2);
+	}
+	(void)close(fds[1]);
+	(void)read(fds[0], &ticks, sizeof(ticks));
+	(void)close(fds[0]);
+	if (waitpid(pid, &status, 0) < 0) {
+		perror("waitpid");
+		return (-1);
+	}
+	if (ticksp != NULL)
+		*ticksp = ticks;
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 42)
+		return (1);              /* crashed mid-recovery */
+	if (WIFEXITED(status) && WEXITSTATUS(status) == 0)
+		return (0);              /* recovery completed */
+	fprintf(stderr, "recover child unexpected status %d (crash_at=%lu)\n",
+	    status, crash_at);
+	return (-1);
 }
 
 /* Crash the write-back model then _exit like a power loss. */

--- a/test/sim/test_sim_crash_in_recovery.c
+++ b/test/sim/test_sim_crash_in_recovery.c
@@ -1,0 +1,369 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_crash_in_recovery.c --
+ *	The RECOVERY-LOOP capstone: recovery must itself be crash-safe and
+ *	idempotent.  FoundationDB reboots repeatedly; a real BDB deployment
+ *	can crash again WHILE recovering from the first crash.  So recovery
+ *	(__db_apprec: run the log backward to undo, forward to redo, then
+ *	write a recovery checkpoint) must be re-runnable and interruptible:
+ *	crash -> recover-partial -> crash -> recover-partial -> ... -> full
+ *	recovery must converge to the SAME correct, durable state regardless
+ *	of how many partial-recovery crashes happened.
+ *
+ *	Mechanism (DESIGN.md catalog #14, the crash-during-recovery axis):
+ *	  1. a seeded transactional workload commits N durable txns, then
+ *	     crashes (write-back drop of the un-fsync'd tail);
+ *	  2. we run one FULL recovery to learn how many recovery-phase I/O
+ *	     ops it does (T ticks -- page writes + fsyncs through the __os_*
+ *	     seam), then recover once uncrashed and fingerprint the state:
+ *	     that is the reference "correct recovered state";
+ *	  3. then, for a sweep of crash points c in 1..T, we RESET the env
+ *	     to its post-workload-crash state, run recovery crashing at the
+ *	     c-th recovery I/O op (dropping recovery's own un-fsync'd work),
+ *	     then run recovery to completion, and assert the final state
+ *	     fingerprint EQUALS the reference.  Recovery interrupted at ANY
+ *	     point and re-run must reach the identical state -- idempotent +
+ *	     convergent.
+ *	  4. a stacked "reboot loop": crash the recovery at c, then crash
+ *	     the NEXT recovery too, then finish -- proves convergence holds
+ *	     across multiple interruptions, not just one.
+ *
+ *	Because the crash truncates every tracked file to its durable
+ *	frontier, the crashed-recovery process loses exactly the pages +
+ *	checkpoint it wrote but had not fsync'd -- precisely what a power
+ *	loss mid-recovery drops.  A non-idempotent redo (double-apply) or an
+ *	ack-before-durable checkpoint would make a re-run DIVERGE from the
+ *	reference, which fails here.
+ *
+ *	Deterministic: same seed => same workload => same recovery I/O
+ *	sequence => same crash point for a given c => same final state.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_crash_in_recovery && ./test_sim_crash_in_recovery [seed]
+ */
+
+/* Tiny recovery cache: force recovery to evict + write dirty pages mid-
+ * pass, so the crash-point sweep covers genuine redo page writes, not
+ * only the recovery checkpoint. */
+#define SIM_RECOVER_CACHE (64 * 1024)
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_crash_in_recovery"
+#define DBFILE  "cir.db"
+#define NCOMMIT 120
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "cir-%08d", i);
+	for (j = 0; j < 24; j++)
+		vbuf[j] = (char)('a' + ((i * 7 + j) % 26));
+	vbuf[24] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_pagesize(db, 512);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+/*
+ * The workload: commit N durable txns, then leave an uncommitted tail and
+ * crash (drop the un-fsync'd bytes).  This is the "dirty env awaiting
+ * recovery" the whole scenario starts from.
+ */
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	/* Uncommitted tail (must be undone by recovery), then crash. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+/*
+ * Snapshot the post-crash on-disk state of HOME to a saved copy, and
+ * restore it back.  Each crash-in-recovery trial must start from the SAME
+ * dirty env (the post-workload-crash files); a partial recovery mutates
+ * them, so we checkpoint the dirty state once and restore before each
+ * trial.  (Plain directory copy -- these are small scratch dirs we own.)
+ */
+static int
+snapshot_home(save)
+	const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd),
+	    "rm -rf %s && cp -a %s %s", save, HOME, save);
+	return (system(cmd));
+}
+static int
+restore_home(save)
+	const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd),
+	    "rm -rf %s && cp -a %s %s", HOME, save, HOME);
+	return (system(cmd));
+}
+
+/* Recover to completion, walk the whole tree into an FNV-1a fingerprint. */
+static int
+recover_and_hash(seed, hashp)
+	uint64_t seed;
+	uint64_t *hashp;
+{
+	DB_ENV *env;
+	DB *db;
+	DBC *dbc;
+	DBT key, data;
+	uint64_t h = 1469598103934665603ull;
+	int ret;
+	const unsigned char *p, *e;
+
+	/* A completion recovery: no crash armed. */
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (-1);
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+	ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG |
+	    DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER, 0664);
+	if (ret != 0) {
+		__db_sim_deactivate();
+		fprintf(stderr, "completion recovery failed: %s\n",
+		    db_strerror(ret));
+		return (-1);
+	}
+	if (open_db(env, &db, 0) != 0) {
+		(void)env->close(env, 0);
+		__db_sim_deactivate();
+		return (-1);
+	}
+	if ((ret = db->cursor(db, NULL, &dbc, 0)) != 0) {
+		(void)db->close(db, 0);
+		(void)env->close(env, 0);
+		__db_sim_deactivate();
+		return (-1);
+	}
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	while ((ret = dbc->get(dbc, &key, &data, DB_NEXT)) == 0) {
+		for (p = key.data, e = p + key.size; p < e; p++) {
+			h ^= *p; h *= 1099511628211ull;
+		}
+		for (p = data.data, e = p + data.size; p < e; p++) {
+			h ^= *p; h *= 1099511628211ull;
+		}
+	}
+	(void)dbc->close(dbc);
+	(void)db->close(db, 0);
+	(void)env->close(env, 0);
+	__db_sim_deactivate();
+	if (ret != DB_NOTFOUND)
+		return (-1);
+	*hashp = h;
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xC1AC5;
+	const char *save = HOME ".saved";
+	uint64_t ref = 0, trial = 0;
+	unsigned long full_ticks = 0, c;
+	int rc, crashes_seen = 0, trials = 0, converged = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+
+	/* Preserve the dirty post-crash env so every trial starts identical. */
+	if (snapshot_home(save) != 0) {
+		fprintf(stderr, "snapshot failed\n");
+		return (EXIT_FAILURE);
+	}
+
+	/*
+	 * Learn how many recovery I/O ops a FULL recovery does (uncrashed),
+	 * so we can sweep crash points across the whole pass.  This mutates
+	 * HOME, so restore afterward.
+	 */
+	rc = sim_recover_child(seed, HOME, 0, &full_ticks);
+	if (rc != 0) {
+		fprintf(stderr, "test_sim_crash_in_recovery: probe recovery "
+		    "did not complete (rc=%d, seed 0x%llx)\n", rc,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (restore_home(save) != 0)
+		return (EXIT_FAILURE);
+
+	/* Reference: a clean full recovery + full-state fingerprint. */
+	if (recover_and_hash(seed, &ref) != 0) {
+		fprintf(stderr, "test_sim_crash_in_recovery: reference "
+		    "recovery failed (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+
+	printf("test_sim_crash_in_recovery: full recovery does %lu I/O ops; "
+	    "reference state %016llx (seed 0x%llx)\n", full_ticks,
+	    (unsigned long long)ref, (unsigned long long)seed);
+
+	if (full_ticks == 0) {
+		/* Nothing to interrupt -- still a pass (recovery was trivial),
+		 * but note it so a regression that stops doing recovery I/O
+		 * during a real workload is visible. */
+		printf("test_sim_crash_in_recovery: PASS -- recovery did no "
+		    "interruptible I/O this seed (nothing to crash)\n");
+		(void)sim_fresh_home(save);
+		return (EXIT_SUCCESS);
+	}
+
+	/*
+	 * Sweep crash points across the recovery pass.  For each, restore
+	 * the dirty env, crash recovery at op c, then finish recovery, then
+	 * fingerprint -- must equal the reference.
+	 */
+	for (c = 1; c <= full_ticks; c++) {
+		if (restore_home(save) != 0)
+			return (EXIT_FAILURE);
+		rc = sim_recover_child(seed, HOME, c, NULL);
+		if (rc < 0) {
+			fprintf(stderr, "test_sim_crash_in_recovery: recover "
+			    "child error at crash point %lu\n", c);
+			return (EXIT_FAILURE);
+		}
+		if (rc == 1)
+			crashes_seen++;
+		/* Now finish recovery (to completion) and fingerprint. */
+		if (recover_and_hash(seed, &trial) != 0) {
+			fprintf(stderr, "test_sim_crash_in_recovery: FAIL -- "
+			    "recovery after a crash at op %lu did NOT complete "
+			    "(seed 0x%llx) -- recovery is not re-runnable\n",
+			    c, (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		trials++;
+		if (trial != ref) {
+			fprintf(stderr, "test_sim_crash_in_recovery: FAIL -- "
+			    "state DIVERGED after crashing recovery at op %lu: "
+			    "%016llx != reference %016llx (seed 0x%llx) -- "
+			    "recovery is NOT idempotent/convergent\n", c,
+			    (unsigned long long)trial,
+			    (unsigned long long)ref,
+			    (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		converged++;
+	}
+
+	/*
+	 * Stacked reboot loop: crash recovery twice in a row (at two
+	 * different points), THEN finish -- convergence must survive
+	 * multiple interruptions, not just one.
+	 */
+	if (full_ticks >= 2) {
+		unsigned long c1 = 1 + (full_ticks / 3);
+		unsigned long c2 = 1 + (full_ticks / 2);
+
+		if (restore_home(save) != 0)
+			return (EXIT_FAILURE);
+		rc = sim_recover_child(seed, HOME, c1, NULL);
+		if (rc < 0)
+			return (EXIT_FAILURE);
+		if (rc == 1)
+			crashes_seen++;
+		rc = sim_recover_child(seed, HOME, c2, NULL);
+		if (rc < 0)
+			return (EXIT_FAILURE);
+		if (rc == 1)
+			crashes_seen++;
+		if (recover_and_hash(seed, &trial) != 0 || trial != ref) {
+			fprintf(stderr, "test_sim_crash_in_recovery: FAIL -- "
+			    "double-crash reboot loop did not converge: "
+			    "%016llx vs %016llx (seed 0x%llx)\n",
+			    (unsigned long long)trial,
+			    (unsigned long long)ref,
+			    (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		converged++;
+		trials++;
+	}
+
+	(void)sim_fresh_home(save);   /* clean the saved copy */
+
+	printf("test_sim_crash_in_recovery: PASS -- %d trials, %d recovery "
+	    "crashes injected, ALL converged to the reference state %016llx "
+	    "(recovery idempotent + interruptible; seed 0x%llx)\n",
+	    trials, crashes_seen, (unsigned long long)ref,
+	    (unsigned long long)seed);
+	(void)converged;
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_recovery_ckp_crash.c
+++ b/test/sim/test_sim_recovery_ckp_crash.c
@@ -1,0 +1,268 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_recovery_ckp_crash.c --
+ *	Crash during the RECOVERY CHECKPOINT write, then recover: recovery
+ *	must converge.  After the undo+redo passes, __db_apprec writes a
+ *	recovery checkpoint (a __txn_ckp log record + a log fsync) so a
+ *	subsequent recovery can start from there instead of replaying the
+ *	whole log again.  If the process dies AFTER redo is applied but
+ *	while / just before that recovery checkpoint becomes durable, the
+ *	next recovery must re-derive the same state -- it simply replays the
+ *	log from the prior (still-valid) checkpoint again.  A recovery that
+ *	trusted a half-written checkpoint, or that acked success before the
+ *	checkpoint LSN was fsync'd, would diverge or lose committed data.
+ *
+ *	This scenario crashes recovery at each of the LAST few recovery I/O
+ *	ops (the checkpoint-write region), then finishes recovery and
+ *	asserts the full committed set matches a reference full-state hash
+ *	taken from a clean recovery -- convergence regardless of a
+ *	checkpoint-time interruption.
+ *
+ *	Deterministic: same seed => same recovery => same tail ops => same
+ *	outcome.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_recovery_ckp_crash && ./test_sim_recovery_ckp_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_rec_ckp"
+#define DBFILE  "recckp.db"
+#define NCOMMIT 110
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "rk-%08d", i);
+	for (j = 0; j < 22; j++)
+		vbuf[j] = (char)('0' + ((i * 11 + j) % 10));
+	vbuf[22] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+static int
+snap(save) const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && cp -a %s %s",
+	    save, HOME, save);
+	return (system(cmd));
+}
+static int
+rest(save) const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && cp -a %s %s",
+	    HOME, save, HOME);
+	return (system(cmd));
+}
+
+static int
+recover_and_hash(seed, hashp)
+	uint64_t seed;
+	uint64_t *hashp;
+{
+	DB_ENV *env;
+	DB *db;
+	DBC *dbc;
+	DBT key, data;
+	uint64_t h = 1469598103934665603ull;
+	int ret;
+	const unsigned char *p, *e;
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (-1);
+	if (open_db(env, &db, 0) != 0) {
+		(void)env->close(env, 0);
+		return (-1);
+	}
+	if ((ret = db->cursor(db, NULL, &dbc, 0)) != 0) {
+		(void)db->close(db, 0);
+		(void)env->close(env, 0);
+		return (-1);
+	}
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	while ((ret = dbc->get(dbc, &key, &data, DB_NEXT)) == 0) {
+		for (p = key.data, e = p + key.size; p < e; p++) {
+			h ^= *p; h *= 1099511628211ull;
+		}
+		for (p = data.data, e = p + data.size; p < e; p++) {
+			h ^= *p; h *= 1099511628211ull;
+		}
+	}
+	(void)dbc->close(dbc);
+	(void)db->close(db, 0);
+	{
+		DB *vdb;
+		if (db_create(&vdb, env, 0) == 0 &&
+		    vdb->verify(vdb, DBFILE, NULL, NULL, 0) != 0) {
+			(void)env->close(env, 0);
+			return (-1);
+		}
+	}
+	(void)env->close(env, 0);
+	if (ret != DB_NOTFOUND)
+		return (-1);
+	*hashp = h;
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0xCC12;
+	const char *save = HOME ".saved";
+	uint64_t ref = 0, trial = 0;
+	unsigned long full_ticks = 0, c;
+	int rc, trials = 0, crashes = 0, k, ntail;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+	if (snap(save) != 0)
+		return (EXIT_FAILURE);
+
+	rc = sim_recover_child(seed, HOME, 0, &full_ticks);
+	if (rc != 0) {
+		fprintf(stderr, "test_sim_recovery_ckp_crash: probe recovery "
+		    "failed (rc=%d, seed 0x%llx)\n", rc,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (rest(save) != 0)
+		return (EXIT_FAILURE);
+
+	if (recover_and_hash(seed, &ref) != 0) {
+		fprintf(stderr, "test_sim_recovery_ckp_crash: reference "
+		    "recovery failed (seed 0x%llx)\n",
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+
+	printf("test_sim_recovery_ckp_crash: full recovery %lu I/O ops; "
+	    "reference %016llx (seed 0x%llx)\n", full_ticks,
+	    (unsigned long long)ref, (unsigned long long)seed);
+
+	if (full_ticks == 0) {
+		(void)sim_fresh_home(save);
+		printf("test_sim_recovery_ckp_crash: PASS -- recovery correct "
+		    "(no interruptible I/O this seed)\n");
+		return (EXIT_SUCCESS);
+	}
+
+	/* Crash at the LAST few recovery ops (the checkpoint-write tail). */
+	ntail = (int)(full_ticks < 4 ? full_ticks : 4);
+	for (k = 0; k < ntail; k++) {
+		c = full_ticks - (unsigned long)k;   /* last, last-1, ... */
+		if (c < 1)
+			c = 1;
+		if (rest(save) != 0)
+			return (EXIT_FAILURE);
+		rc = sim_recover_child(seed, HOME, c, NULL);
+		if (rc < 0)
+			return (EXIT_FAILURE);
+		if (rc == 1)
+			crashes++;
+		if (recover_and_hash(seed, &trial) != 0) {
+			fprintf(stderr, "test_sim_recovery_ckp_crash: FAIL -- "
+			    "recovery after a checkpoint-time crash at op %lu "
+			    "did not complete (seed 0x%llx)\n", c,
+			    (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		if (trial != ref) {
+			fprintf(stderr, "test_sim_recovery_ckp_crash: FAIL -- "
+			    "state DIVERGED after a checkpoint-time crash at "
+			    "op %lu: %016llx != reference %016llx (seed "
+			    "0x%llx) -- recovery checkpoint not crash-safe\n",
+			    c, (unsigned long long)trial,
+			    (unsigned long long)ref, (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		trials++;
+	}
+
+	(void)sim_fresh_home(save);
+	printf("test_sim_recovery_ckp_crash: PASS -- %d checkpoint-time "
+	    "recovery crashes (%d hit), all converged to reference %016llx "
+	    "(recovery checkpoint crash-safe; seed 0x%llx)\n", trials, crashes,
+	    (unsigned long long)ref, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_recovery_redo_crash.c
+++ b/test/sim/test_sim_recovery_redo_crash.c
@@ -1,0 +1,281 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_recovery_redo_crash.c --
+ *	Crash mid-REDO of a recovery pass, then recover: the re-apply must
+ *	be IDEMPOTENT.  Recovery rolls the log forward re-applying committed
+ *	changes to pages; if the process dies after SOME redo pages are
+ *	applied but the recovery checkpoint is not yet durable, the NEXT
+ *	recovery re-applies the same redo records.  A redo handler that is
+ *	not idempotent (double-applies, or advances a counter twice) would
+ *	corrupt; a correct one converges.
+ *
+ *	This scenario crashes recovery at a MID-pass I/O op (roughly the
+ *	middle of the recovery I/O sequence -- the redo region), then runs
+ *	recovery to completion and asserts:
+ *	  - every committed txn is present with its exact value;
+ *	  - the uncommitted tail (undone) is absent;
+ *	  - the DB verifies clean.
+ *	Repeated for a few mid-pass points; the committed set must match a
+ *	seed-derived reference regardless of where the redo was interrupted.
+ *
+ *	Deterministic: same seed => same recovery I/O sequence => same
+ *	mid-point => same outcome.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_recovery_redo_crash && ./test_sim_recovery_redo_crash [seed]
+ */
+
+/* Tiny recovery cache: force redo to evict + write dirty pages mid-pass. */
+#define SIM_RECOVER_CACHE (64 * 1024)
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_rec_redo"
+#define DBFILE  "recredo.db"
+#define NCOMMIT 100
+#define PGSIZE  512
+
+static void
+mkrec(i, kbuf, vbuf)
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "rr-%08d", i);
+	for (j = 0; j < 20; j++)
+		vbuf[j] = (char)('A' + ((i * 3 + j) % 26));
+	vbuf[20] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	(void)db->set_pagesize(db, PGSIZE);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0)
+			return (ret);
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+	}
+	/* Uncommitted tail: must be undone by recovery. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+static int
+snap(save) const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && cp -a %s %s",
+	    save, HOME, save);
+	return (system(cmd));
+}
+static int
+rest(save) const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && cp -a %s %s",
+	    HOME, save, HOME);
+	return (system(cmd));
+}
+
+/* Recover to completion, then check every committed txn present + exact,
+ * the uncommitted tail absent, and the tree verifies clean. */
+static int
+recover_and_check(seed, seenp)
+	uint64_t seed;
+	int *seenp;
+{
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, present = 0, bad = 0;
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (-1);
+	if (open_db(env, &db, 0) != 0) {
+		(void)env->close(env, 0);
+		return (-1);
+	}
+	for (i = 0; i < NCOMMIT; i++) {
+		mkrec(i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		ret = db->get(db, NULL, &key, &data, 0);
+		if (ret == 0) {
+			present++;
+			if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				bad++;
+		}
+	}
+	/* Uncommitted tail must be absent. */
+	mkrec(NCOMMIT, kbuf, vbuf);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	ret = db->get(db, NULL, &key, &data, 0);
+	(void)db->close(db, 0);
+
+	/* Verify the tree structure. */
+	{
+		DB *vdb;
+		int vret;
+		if (db_create(&vdb, env, 0) == 0) {
+			vret = vdb->verify(vdb, DBFILE, NULL, NULL, 0);
+			if (vret != 0)
+				bad++;
+			/* verify closes vdb */
+		}
+	}
+	(void)env->close(env, 0);
+
+	if (seenp != NULL)
+		*seenp = present;
+	if (bad != 0 || present != NCOMMIT || ret != DB_NOTFOUND)
+		return (1);   /* invariant violation */
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x2ED0;
+	const char *save = HOME ".saved";
+	unsigned long full_ticks = 0, points[3], c;
+	int rc, i, seen, trials = 0, crashes = 0;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+	if (snap(save) != 0)
+		return (EXIT_FAILURE);
+
+	/* Learn full recovery I/O count. */
+	rc = sim_recover_child(seed, HOME, 0, &full_ticks);
+	if (rc != 0) {
+		fprintf(stderr, "test_sim_recovery_redo_crash: probe recovery "
+		    "failed (rc=%d, seed 0x%llx)\n", rc,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (rest(save) != 0)
+		return (EXIT_FAILURE);
+
+	printf("test_sim_recovery_redo_crash: full recovery %lu I/O ops "
+	    "(seed 0x%llx)\n", full_ticks, (unsigned long long)seed);
+
+	if (full_ticks == 0) {
+		/* No interruptible recovery I/O this seed: still assert a
+		 * plain recovery is correct. */
+		if (recover_and_check(seed, &seen) != 0) {
+			fprintf(stderr, "test_sim_recovery_redo_crash: FAIL "
+			    "-- plain recovery incorrect (seed 0x%llx)\n",
+			    (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		(void)sim_fresh_home(save);
+		printf("test_sim_recovery_redo_crash: PASS -- recovery correct "
+		    "(no interruptible I/O this seed)\n");
+		return (EXIT_SUCCESS);
+	}
+
+	/* Mid-redo crash points: 1/2, 2/3, and the last op (checkpoint). */
+	points[0] = 1 + full_ticks / 2;
+	points[1] = 1 + (2 * full_ticks) / 3;
+	points[2] = full_ticks;
+
+	for (i = 0; i < 3; i++) {
+		c = points[i];
+		if (c < 1)
+			c = 1;
+		if (c > full_ticks)
+			c = full_ticks;
+		if (rest(save) != 0)
+			return (EXIT_FAILURE);
+		rc = sim_recover_child(seed, HOME, c, NULL);
+		if (rc < 0)
+			return (EXIT_FAILURE);
+		if (rc == 1)
+			crashes++;
+		/* Finish recovery + check invariants. */
+		if (recover_and_check(seed, &seen) != 0) {
+			fprintf(stderr, "test_sim_recovery_redo_crash: FAIL -- "
+			    "after a crash mid-recovery at op %lu the recovered "
+			    "DB is WRONG (present=%d/%d, seed 0x%llx) -- redo "
+			    "not idempotent OR committed txn lost\n", c, seen,
+			    NCOMMIT, (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		trials++;
+	}
+
+	(void)sim_fresh_home(save);
+	printf("test_sim_recovery_redo_crash: PASS -- %d mid-recovery crashes "
+	    "(%d hit the crash point), every committed txn present + exact, "
+	    "uncommitted undone, tree clean after re-recovery (seed 0x%llx)\n",
+	    trials, crashes, (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}

--- a/test/sim/test_sim_recovery_undo_crash.c
+++ b/test/sim/test_sim_recovery_undo_crash.c
@@ -1,0 +1,295 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_recovery_undo_crash.c --
+ *	Crash EARLY in a recovery pass -- during / just after the UNDO
+ *	phase, before redo completes -- then recover.  Recovery runs the
+ *	log backward first (undo uncommitted / open-txn changes) then
+ *	forward (redo committed).  If the process dies after the undo pass
+ *	has written some pages but before redo has re-applied the committed
+ *	tail, the NEXT recovery must still converge: committed txns present,
+ *	the aborted / uncommitted work gone, tree clean.
+ *
+ *	A workload commits a first batch of txns, EXPLICITLY aborts a middle
+ *	batch (exercising the undo path), commits a final batch, then leaves
+ *	an uncommitted tail and crashes.  Recovery is then crashed at the
+ *	EARLIEST recovery I/O ops (op 1, 2, ...), and after finishing we
+ *	assert:
+ *	  - every COMMITTED txn present + exact,
+ *	  - every ABORTED txn absent,
+ *	  - the uncommitted tail absent,
+ *	  - the tree verifies clean.
+ *
+ *	Deterministic: same seed => same commit/abort split => same recovery
+ *	=> same early crash points => same outcome.
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_recovery_undo_crash && ./test_sim_recovery_undo_crash [seed]
+ */
+
+#include "sim_scenario.h"
+
+#define HOME    "TESTDIR_sim_rec_undo"
+#define DBFILE  "recundo.db"
+#define NBATCH  40      /* per batch */
+
+static void
+mkrec(tag, i, kbuf, vbuf)
+	char tag;
+	int i;
+	char *kbuf, *vbuf;
+{
+	int j;
+
+	(void)snprintf(kbuf, 32, "ru-%c-%08d", tag, i);
+	for (j = 0; j < 18; j++)
+		vbuf[j] = (char)('a' + ((i * 5 + j + tag) % 26));
+	vbuf[18] = '\0';
+}
+
+static int
+open_db(env, dbp, create)
+	DB_ENV *env;
+	DB **dbp;
+	int create;
+{
+	DB *db;
+	int ret;
+
+	if ((ret = db_create(&db, env, 0)) != 0)
+		return (ret);
+	if ((ret = db->open(db, NULL, DBFILE, NULL, DB_BTREE,
+	    (create ? DB_CREATE : 0) | DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	*dbp = db;
+	return (0);
+}
+
+/* Put one batch under one txn, then commit or abort it. */
+static int
+batch(env, db, tag, commit)
+	DB_ENV *env;
+	DB *db;
+	char tag;
+	int commit;
+{
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret;
+
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	for (i = 0; i < NBATCH; i++) {
+		mkrec(tag, i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+		if ((ret = db->put(db, txn, &key, &data, 0)) != 0) {
+			(void)txn->abort(txn);
+			return (ret);
+		}
+	}
+	return (commit ? txn->commit(txn, DB_TXN_SYNC) : txn->abort(txn));
+}
+
+static int
+populate(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int ret;
+
+	__db_sim_activate(seed);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+	if ((ret = open_db(env, &db, 1)) != 0)
+		return (ret);
+
+	if ((ret = batch(env, db, 'C', 1)) != 0)   /* committed batch 1 */
+		return (ret);
+	if ((ret = batch(env, db, 'X', 0)) != 0)   /* aborted batch (undo) */
+		return (ret);
+	if ((ret = batch(env, db, 'D', 1)) != 0)   /* committed batch 2 */
+		return (ret);
+
+	/* Uncommitted tail (open txn at crash -> undone by recovery). */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	mkrec('U', 0, kbuf, vbuf);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)db->put(db, txn, &key, &data, 0);
+
+	SIM_CRASH_EXIT();
+	return (0);
+}
+
+static int
+snap(save) const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && cp -a %s %s",
+	    save, HOME, save);
+	return (system(cmd));
+}
+static int
+rest(save) const char *save;
+{
+	char cmd[512];
+	(void)snprintf(cmd, sizeof(cmd), "rm -rf %s && cp -a %s %s",
+	    HOME, save, HOME);
+	return (system(cmd));
+}
+
+/* Recover to completion; assert committed present, aborted+uncommitted
+ * absent, tree clean.  Returns 0 = correct, 1 = invariant violation. */
+static int
+recover_and_check(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *db;
+	DBT key, data;
+	char kbuf[32], vbuf[32];
+	int i, ret, bad = 0, cpresent = 0, dpresent = 0, aleft = 0;
+
+	if (sim_env_recover(HOME, &env) != 0)
+		return (-1);
+	if (open_db(env, &db, 0) != 0) {
+		(void)env->close(env, 0);
+		return (-1);
+	}
+	for (i = 0; i < NBATCH; i++) {
+		/* committed 'C' + 'D' present + exact */
+		mkrec('C', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key)); memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0) {
+			cpresent++;
+			if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				bad++;
+		}
+		mkrec('D', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key)); memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0) {
+			dpresent++;
+			if (data.size != strlen(vbuf) + 1 ||
+			    memcmp(data.data, vbuf, data.size) != 0)
+				bad++;
+		}
+		/* aborted 'X' must be absent */
+		mkrec('X', i, kbuf, vbuf);
+		memset(&key, 0, sizeof(key)); memset(&data, 0, sizeof(data));
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+		if (db->get(db, NULL, &key, &data, 0) == 0)
+			aleft++;
+	}
+	/* uncommitted 'U' must be absent */
+	mkrec('U', 0, kbuf, vbuf);
+	memset(&key, 0, sizeof(key)); memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	if (db->get(db, NULL, &key, &data, 0) == 0)
+		aleft++;
+	(void)db->close(db, 0);
+
+	{
+		DB *vdb;
+		if (db_create(&vdb, env, 0) == 0 &&
+		    vdb->verify(vdb, DBFILE, NULL, NULL, 0) != 0)
+			bad++;
+	}
+	(void)env->close(env, 0);
+
+	if (bad != 0 || cpresent != NBATCH || dpresent != NBATCH || aleft != 0)
+		return (1);
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	uint64_t seed = argc > 1 ? strtoull(argv[1], NULL, 0) : 0x00ED0;
+	const char *save = HOME ".saved";
+	unsigned long full_ticks = 0, c;
+	int rc, trials = 0, crashes = 0, npoints, k;
+
+	if (sim_fresh_home(HOME) != 0)
+		return (EXIT_FAILURE);
+	if (sim_run_crash_child(seed, populate) != 0)
+		return (EXIT_FAILURE);
+	if (snap(save) != 0)
+		return (EXIT_FAILURE);
+
+	rc = sim_recover_child(seed, HOME, 0, &full_ticks);
+	if (rc != 0) {
+		fprintf(stderr, "test_sim_recovery_undo_crash: probe recovery "
+		    "failed (rc=%d, seed 0x%llx)\n", rc,
+		    (unsigned long long)seed);
+		return (EXIT_FAILURE);
+	}
+	if (rest(save) != 0)
+		return (EXIT_FAILURE);
+
+	printf("test_sim_recovery_undo_crash: full recovery %lu I/O ops "
+	    "(seed 0x%llx)\n", full_ticks, (unsigned long long)seed);
+
+	/* Crash at the EARLIEST recovery ops (undo region): 1..min(4,full). */
+	npoints = (int)(full_ticks < 4 ? full_ticks : 4);
+	if (npoints == 0) {
+		if (recover_and_check(seed) != 0) {
+			fprintf(stderr, "test_sim_recovery_undo_crash: FAIL -- "
+			    "plain recovery incorrect (seed 0x%llx)\n",
+			    (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		(void)sim_fresh_home(save);
+		printf("test_sim_recovery_undo_crash: PASS -- recovery correct "
+		    "(no interruptible I/O this seed)\n");
+		return (EXIT_SUCCESS);
+	}
+	for (k = 1; k <= npoints; k++) {
+		c = (unsigned long)k;
+		if (rest(save) != 0)
+			return (EXIT_FAILURE);
+		rc = sim_recover_child(seed, HOME, c, NULL);
+		if (rc < 0)
+			return (EXIT_FAILURE);
+		if (rc == 1)
+			crashes++;
+		if (recover_and_check(seed) != 0) {
+			fprintf(stderr, "test_sim_recovery_undo_crash: FAIL -- "
+			    "after an early recovery crash at op %lu the "
+			    "recovered DB is WRONG (seed 0x%llx) -- committed "
+			    "lost, aborted survived, or tree dirty\n", c,
+			    (unsigned long long)seed);
+			return (EXIT_FAILURE);
+		}
+		trials++;
+	}
+
+	(void)sim_fresh_home(save);
+	printf("test_sim_recovery_undo_crash: PASS -- %d early-recovery "
+	    "crashes (%d hit), committed present, aborted+uncommitted gone, "
+	    "tree clean after re-recovery (seed 0x%llx)\n", trials, crashes,
+	    (unsigned long long)seed);
+	return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Closes the "recovery's own crash-safety" gap: v1 crashed *once* then recovered *once*; FoundationDB reboots repeatedly. This tests that **recovery itself is crash-safe, idempotent, and convergent** (crash → recover-partial → crash → recover-partial → … → full recovery must reach the SAME correct state).

## Mechanism (`#ifdef HAVE_DST`, zero prod overhead — OFF build: 0 `__db_sim_*` symbols)
A recovery-crash counter (`__db_sim_reccrash_enable/ticks/tick`) fires the existing write-back crash (`__db_sim_wb_crash` + `_exit`) on the Nth recovery-phase I/O op, reusing the `__os_io`/`__os_fsync` seam — modelling a process dying part-way through `__db_apprec`. Opt-in `DB_SIM_WB_SEED_ONDISK` lets a recovery process treat already-durable inherited files correctly.

## 4 scenarios (36 total), all deterministic + 10-seed sweep
- `test_sim_crash_in_recovery` — **capstone**: crash at every recovery-phase I/O op (+ double-crash), recover to completion each time, assert identical reference state hash regardless of how many partial-recovery crashes intervened (19 trials / 20 crash points).
- `test_sim_recovery_undo_crash` — crash mid-UNDO, recover: committed present, aborted gone, clean.
- `test_sim_recovery_redo_crash` — crash mid-REDO (tiny cache → real page evictions), recovery-ckp not durable, recover: idempotent re-apply.
- `test_sim_recovery_ckp_crash` — crash during recovery checkpoint write, recover: converges.

## Planted bug 9 RECINITNOSTAMP (`__db_pg_alloc_recover` skips meta-page LSN stamp on redo)
Caught at K=1 — and **caught ONLY by the crash-during-recovery loop** (invisible to the plain double-recover and single crash+recover scenarios). Full `dst-bug-inject.sh`: all 9 bugs caught@K=1.

## Honest finding
The initial "recovery not re-runnable" failure was a **mechanism artifact** (write-back dropped bytes durable *before* the recovery process started), fixed via `DB_SIM_WB_SEED_ONDISK`. **No real recovery-safety bug found** — libdb recovery is idempotent + convergent across every interruption point tested. The one engine change is the `#ifdef HAVE_DST`-guarded planted bug 9 in `db_rec.c`.

Validation: DST build clean, 4/4 scenarios PASS + deterministic, `dst_tests` builds clean, OFF build 0 sim symbols.