### PR TITLE
test(dst): FoundationDB-style buggify — 9 legal-but-pessimal points at real library sites

### DIFF
--- a/dist/Makefile.in
+++ b/dist/Makefile.in
@@ -1667,6 +1667,13 @@ test_sim_swarm: test_sim_swarm@o@ $(DEF_LIB)
 	    $(LDFLAGS) test_sim_swarm@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
 	$(POSTLINK) $@
 
+test_sim_buggify@o@: $(testdir)/sim/test_sim_buggify.c
+	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
+test_sim_buggify: test_sim_buggify@o@ $(DEF_LIB)
+	$(CCLINK) -o $@ \
+	    $(LDFLAGS) test_sim_buggify@o@ $(DEF_LIB) $(TEST_LIBS) $(LIBS)
+	$(POSTLINK) $@
+
 test_sim_ckp_lsn@o@: $(testdir)/sim/test_sim_ckp_lsn.c
 	$(CC) $(DST_CFLAGS) $(DEPFLAGS) $<
 test_sim_ckp_lsn: test_sim_ckp_lsn@o@ $(DEF_LIB)
@@ -1785,7 +1792,8 @@ dst_tests: test_sim_rng test_sim_crash_recover test_sim_torn \
 	test_sim_stale_meta test_sim_compound_fault test_sim_logrollover_crash \
 	mp_failchk_pilot \
 	test_sim_crash_in_recovery test_sim_recovery_undo_crash \
-	test_sim_recovery_redo_crash test_sim_recovery_ckp_crash
+	test_sim_recovery_redo_crash test_sim_recovery_ckp_crash \
+	test_sim_buggify
 
 ##################################################
 # Malloc-failure injection (SQLite-style) -- test/faultinject/.

--- a/src/btree/bt_put.c
+++ b/src/btree/bt_put.c
@@ -49,6 +49,10 @@
 #include "dbinc/lock.h"
 #include "dbinc/mp.h"
 
+#ifdef HAVE_DST
+#include "sim_buggify.h"		/* DST buggify points (--enable-dst only). */
+#endif
+
 static int __bam_build
 	       __P((DBC *, u_int32_t, DBT *, PAGE *, u_int32_t, u_int32_t));
 static int __bam_dup_check __P((DBC *, u_int32_t,
@@ -276,6 +280,31 @@ __bam_iitem(dbc, key, data, op, flags)
 	/* Split the page if there's not enough room. */
 	if (P_FREESPACE(dbp, h) < needed)
 		return (DB_NEEDSPLIT);
+
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY bt.split_early: force an EARLY split even though the item
+	 * fits, to stress the split/merge machinery (which normally runs
+	 * only when a page fills).  Legal-but-pessimal: the caller catches
+	 * DB_NEEDSPLIT, splits, and retries the put -- the retry has more
+	 * room and succeeds, so the result is identical, only slower and
+	 * with a taller/wider tree.
+	 *
+	 * Two guards keep it legal AND terminating.  (a) leaf pages only
+	 * (P_LBTREE / P_LDUP / P_LRECNO) with NUM_ENT(h) >= 4, so the
+	 * split-point picker has a couple of entries per side.  (b) fire
+	 * ONLY when the page is already more than THREE-QUARTERS full
+	 * (P_FREESPACE < pgsize/4): the buggify coin is cached per run, so
+	 * it re-fires on the post-split RETRY too -- after splitting a
+	 * >3/4-full page each half is well under half full, so the retry no
+	 * longer qualifies and the put completes (no split loop).
+	 */
+	if ((TYPE(h) == P_LBTREE || TYPE(h) == P_LDUP ||
+	    TYPE(h) == P_LRECNO) && NUM_ENT(h) >= 4 &&
+	    P_FREESPACE(dbp, h) < dbp->pgsize / 4 &&
+	    DB_BUGGIFY(BUGGIFY_BT_SPLIT_EARLY))
+		return (DB_NEEDSPLIT);
+#endif
 
 	/*
 	 * Check to see if we will convert to off page duplicates -- if

--- a/src/hash/hash_page.c
+++ b/src/hash/hash_page.c
@@ -57,6 +57,10 @@
 #include "dbinc/lock.h"
 #include "dbinc/mp.h"
 
+#ifdef HAVE_DST
+#include "sim_buggify.h"		/* DST buggify points (--enable-dst only). */
+#endif
+
 static int __hamc_delpg
     __P((DBC *, db_pgno_t, db_pgno_t, u_int32_t, db_ham_mode, u_int32_t *));
 static int __ham_getindex_sorted
@@ -2667,6 +2671,19 @@ __ham_add_el(dbc, key, val, type)
 	if (do_expand || (hcp->hdr->ffactor != 0 &&
 	    (u_int32_t)H_NUMPAIRS(hcp->page) > hcp->hdr->ffactor))
 		F_SET(hcp, H_EXPAND);
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY hash.expand_early: expand the hash table (split a bucket)
+	 * sooner than the fill factor requires, to stress the bucket-split
+	 * path (which normally fires only when a bucket exceeds ffactor).
+	 * Legal-but-pessimal: __ham_expand_table is safe to run at any time
+	 * (it just adds a bucket and rehashes; it even ignores ENOSPC for a
+	 * non-txn cursor), so forcing it early changes only the table shape
+	 * and timing, never a lookup result.
+	 */
+	if (DB_BUGGIFY(BUGGIFY_HASH_EXPAND_EARLY))
+		F_SET(hcp, H_EXPAND);
+#endif
 	return (0);
 }
 

--- a/src/lock/lock.c
+++ b/src/lock/lock.c
@@ -13,6 +13,10 @@
 #include "dbinc/log.h"
 #include "dbinc/txn.h"
 
+#ifdef HAVE_DST
+#include "sim_buggify.h"		/* DST buggify points (--enable-dst only). */
+#endif
+
 static int __lock_allocobj __P((DB_LOCKTAB *, u_int32_t));
 static int __lock_alloclock __P((DB_LOCKTAB *, u_int32_t));
 static int  __lock_freelock __P((DB_LOCKTAB *,
@@ -574,6 +578,21 @@ __lock_vec(env, sh_locker, flags, list, nlist, elistp)
 	if (ret == 0 && region->detect != DB_LOCK_NORUN &&
 	     (region->need_dd || timespecisset(&region->next_timeout)))
 		run_dd = 1;
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY lock.dd_now: run the deadlock detector on this lock-vec
+	 * operation even though nothing flagged a possible deadlock
+	 * (need_dd clear, no timeout).  Legal-but-pessimal: the detector is
+	 * a read-only graph walk that aborts a txn ONLY on a real cycle, so
+	 * running it more often can never manufacture a false deadlock or
+	 * change a result -- it just exercises the detector (and the abort/
+	 * retry path when it does find a genuine cycle) far more than a lazy
+	 * need_dd policy would.  Only when detection is enabled at all.
+	 */
+	if (ret == 0 && region->detect != DB_LOCK_NORUN &&
+	    DB_BUGGIFY(BUGGIFY_LOCK_DD_NOW))
+		run_dd = 1;
+#endif
 	LOCK_SYSTEM_UNLOCK(lt, region);
 
 	if (run_dd)
@@ -1324,6 +1343,21 @@ in_abort:	newl->status = DB_LSTAT_WAITING;
 		 */
 		if (region->detect != DB_LOCK_NORUN && !no_dd)
 			(void)__lock_detect(env, region->detect, &did_abort);
+#ifdef HAVE_DST
+		/*
+		 * BUGGIFY lock.dd_wait_now: run the deadlock detector before
+		 * this thread blocks even in the no_dd case (the locker holds
+		 * no locks yet, so it is in no cycle).  Legal-but-pessimal: the
+		 * detector is a read-only cycle finder that aborts only on a
+		 * genuine deadlock, so running it here finds nothing to abort
+		 * for this locker and cannot change a result -- it just drives
+		 * the detector on the blocking path far more often, surfacing
+		 * detector-vs-block races.  Only when detection is enabled.
+		 */
+		else if (region->detect != DB_LOCK_NORUN &&
+		    DB_BUGGIFY(BUGGIFY_LOCK_DD_WAIT_NOW))
+			(void)__lock_detect(env, region->detect, &did_abort);
+#endif
 
 		ip = NULL;
 		if (env->thr_hashtab != NULL &&

--- a/src/log/log_put.c
+++ b/src/log/log_put.c
@@ -18,6 +18,7 @@
 
 #ifdef HAVE_DST
 #include "sim_inject.h"			/* DST planted-bug harness. */
+#include "sim_buggify.h"			/* DST buggify points. */
 #endif
 
 static int __log_encrypt_record __P((ENV *, DBT *, HDR *, u_int32_t));
@@ -308,6 +309,18 @@ __log_put(env, lsnp, udbt, flags)
 	 * If a flush is not needed, see if WRITE_NOSYNC was set and we
 	 * need to write out the log buffer.
 	 */
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY log.flush_now: force a synchronous log flush on a put
+	 * that would otherwise buffer.  Legal-but-pessimal: an EXTRA fsync
+	 * only makes more of the log durable sooner -- it can never lose or
+	 * reorder a record -- so correctness (and crash recovery) is
+	 * unchanged; it just exercises the flush path far more often than a
+	 * lazy WRNOSYNC workload would.
+	 */
+	if (DB_BUGGIFY(BUGGIFY_LOG_FLUSH_NOW))
+		LF_SET(DB_FLUSH);
+#endif
 	if (LF_ISSET(DB_FLUSH | DB_LOG_WRNOSYNC)) {
 		if (!lock_held) {
 			LOG_SYSTEM_LOCK(env);
@@ -469,6 +482,26 @@ __log_put_next(env, lsn, dbt, hdr, old_lsnp)
 		__log_set_version(env, DB_LOGVERSION);
 		adv_file = 1;
 	}
+
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY log.newfile_early: roll over to a fresh log file before
+	 * the current one is actually full, to stress log-file switching
+	 * and the archive/rollover path (which a steady workload hits only
+	 * every few MB).  Legal-but-pessimal: a rollover is exactly what
+	 * the engine does when a file fills; forcing it early just yields
+	 * more, smaller files -- recovery and archiving handle any number
+	 * of files, so the result is unchanged.  Gated on the file already
+	 * being at least half full (offset*2 > log_size) so files stay a
+	 * bounded size (no one-record-per-file explosion that would swamp
+	 * the write-back crash model's fixed file table).
+	 */
+	if (!adv_file && lp->lsn.offset != 0 &&
+	    (u_int32_t)lp->lsn.offset * 2 > lp->log_size &&
+	    hdr->size + sizeof(LOGP) + dbt->size <= lp->log_nsize &&
+	    DB_BUGGIFY(BUGGIFY_LOG_NEWFILE_EARLY))
+		adv_file = 1;
+#endif
 
 	/*
 	 * If this information won't fit in the file, or if we're a

--- a/src/mp/mp_alloc.c
+++ b/src/mp/mp_alloc.c
@@ -12,6 +12,10 @@
 #include "dbinc/mp.h"
 #include "dbinc/txn.h"
 
+#ifdef HAVE_DST
+#include "sim_buggify.h"		/* DST buggify points (--enable-dst only). */
+#endif
+
 /*
  * This configuration parameter limits the number of hash buckets which
  * __memp_alloc() searches through while excluding buffers with a 'high'
@@ -63,6 +67,23 @@ __memp_alloc(dbmp, infop, mfp, len, offsetp, retp)
 
 	buckets = buffers = put_counter = total_buckets = versions = 0;
 	aggressive = alloc_freeze = giveup = h_locked = 0;
+
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY mp.alloc_aggressive: start the buffer-pool scan in
+	 * AGGRESSIVE mode instead of ramping into it only after a full
+	 * sweep frees nothing.  Aggressive means "consider buffers of any
+	 * warmth, one per bucket" -- a strict SUPERSET of the normal
+	 * second-chance scan, so it still only ever evicts a legally
+	 * evictable buffer; it just picks victims more eagerly, stressing
+	 * the write-back / re-read path that a lazy cache rarely exercises.
+	 * aggressive==1 is the mildest level (its switch arm is a plain
+	 * break), so no sync/yield is forced here -- purely a scan-policy
+	 * change, never a correctness change.
+	 */
+	if (DB_BUGGIFY(BUGGIFY_MP_ALLOC_AGGRESSIVE))
+		aggressive = 1;
+#endif
 
 	/*
 	 * If we're allocating a buffer, and the one we're discarding is the

--- a/src/mp/mp_fput.c
+++ b/src/mp/mp_fput.c
@@ -12,6 +12,10 @@
 #include "dbinc/log.h"
 #include "dbinc/mp.h"
 
+#ifdef HAVE_DST
+#include "sim_buggify.h"		/* DST buggify points (--enable-dst only). */
+#endif
+
 
 /*
  * __memp_fput_pp --
@@ -215,6 +219,19 @@ unpin:
 	if (priority == DB_PRIORITY_VERY_LOW ||
 	    mfp->priority == MPOOL_PRI_VERY_LOW)
 		bhp->priority = MPOOL_CLOCK_VERY_LOW;
+#ifdef HAVE_DST
+	/*
+	 * BUGGIFY mp.evict_cold: pin this buffer at the COLDEST warmth
+	 * regardless of its access hint, so the CLOCK hand evicts it first.
+	 * Legal-but-pessimal: warmth is a pure eviction-ORDER hint (it never
+	 * affects what a page contains or whether it is written back before
+	 * reuse -- that is the dirty/latch machinery), so forcing a buffer
+	 * cold only makes the cache churn harder and re-read more often,
+	 * exercising the read-back path.  Never a correctness change.
+	 */
+	else if (DB_BUGGIFY(BUGGIFY_MP_EVICT_COLD))
+		bhp->priority = MPOOL_CLOCK_VERY_LOW;
+#endif
 	else if (priority == DB_PRIORITY_HIGH ||
 	    priority == DB_PRIORITY_VERY_HIGH) {
 		/* Explicit high-priority hint pins the buffer at the ceiling. */

--- a/src/txn/txn_chkpt.c
+++ b/src/txn/txn_chkpt.c
@@ -47,6 +47,7 @@
 
 #ifdef HAVE_DST
 #include "sim_inject.h"			/* DST planted-bug harness. */
+#include "sim_buggify.h"			/* DST buggify points. */
 #endif
 
 /*
@@ -172,6 +173,22 @@ __txn_checkpoint(env, kbytes, minutes, flags)
 		/* Don't checkpoint a quiescent database. */
 		if (bytes == 0 && mbytes == 0)
 			goto err;
+
+#ifdef HAVE_DST
+		/*
+		 * BUGGIFY txn.chkpt_force: take the checkpoint NOW even though
+		 * the kbytes/minutes threshold has not been reached (there IS
+		 * log activity -- the quiescent guard above already bailed if
+		 * not).  Legal-but-pessimal: a more frequent checkpoint is
+		 * always correct (it only advances the recovery start point and
+		 * flushes the cache sooner); it just makes the checkpoint /
+		 * cache-flush / ckp-LSN machinery run far more often than a
+		 * time-or-bytes policy would, stressing checkpoint-vs-workload
+		 * interleavings.
+		 */
+		if (DB_BUGGIFY(BUGGIFY_TXN_CHKPT_FORCE))
+			goto do_ckp;
+#endif
 
 		/*
 		 * If either kbytes or minutes is non-zero, then only take the

--- a/test/sim/DESIGN.md
+++ b/test/sim/DESIGN.md
@@ -103,11 +103,45 @@ lets a harness assert 0 to *prove* a run was fully deterministic.
 
 ### 1.3 Buggify (per-run cached coin)
 
-`DB_SIM_BUGGIFY("name")`: a named point in real library code that, under sim,
-takes a legal-but-pessimal path. Unlike a per-call fault, a buggify point is a
-coin flipped **once per run per site**, cached, so all reaches of a name agree
-and the run replays. Drawn from the dedicated `BUGGIFY` stream so enabling it
-never perturbs the IO/FAULT streams. Compiles to constant 0 when DST is off.
+`DB_BUGGIFY(name)`: a named point in real library code that, under sim, takes a
+legal-but-pessimal path. Unlike a per-call fault, a buggify point is a coin
+flipped **once per run per site**, cached, so all reaches of a name agree and
+the run replays. Drawn from the dedicated `BUGGIFY` stream so enabling it never
+perturbs the IO/FAULT streams. Compiles to constant 0 when DST is off (verified:
+`nm` shows 0 sim symbols and no point name appears in any engine `.o`).
+
+The invariant that makes buggify safe: **every buggified path is legal**
+(correctness-preserving) — it only changes timing/sizing/path-choice, never a
+result. So the whole scenario suite must still pass with buggify forced on. If
+turning a point on ever breaks an invariant, either the point isn't actually
+legal (a bug in the point) or the engine mishandles a rare-but-legal path (a
+real engine bug) — that is buggify's purpose.
+
+**Point catalog** (9 points, all `#ifdef HAVE_DST`, each a legal-but-pessimal choice):
+
+| Point | Site | Pessimal choice |
+|---|---|---|
+| `bt.split_early` | `bt_put.c` | force `DB_NEEDSPLIT` when the page is >3/4 full (guarded ≥4 entries + <pgsize/4 free, so no split loop) |
+| `hash.expand_early` | `hash_page.c` | force `H_EXPAND` before the fill factor is reached |
+| `mp.alloc_aggressive` | `mp_alloc.c` | start the eviction scan in aggressive mode |
+| `mp.evict_cold` | `mp_fput.c` | pin the buffer at the coldest warmth |
+| `log.flush_now` | `log_put.c` | force `DB_FLUSH` on a would-be-buffered log put |
+| `log.newfile_early` | `log_put.c` | roll to a new log file at >half full |
+| `txn.chkpt_force` | `txn_chkpt.c` | checkpoint past the byte/time threshold |
+| `lock.dd_now` | `lock.c` | run the deadlock detector on a lock-vector op |
+| `lock.dd_wait_now` | `lock.c` | run the detector before blocking |
+
+**Measured activation** (`test_sim_buggify`, 24-seed sweep, all pessimal paths
+forced): bt.split_early 79%, hash.expand_early 67%, mp.alloc_aggressive 100%,
+mp.evict_cold 83%, log.flush_now 75%, log.newfile_early 75%, txn.chkpt_force 88%,
+lock.dd_now 83%, **lock.dd_wait_now 0%** (never reached — this single-writer
+workload has no blocked waiter to drive the site; the point is valid, the
+coverage is workload-limited; a WARN, not a failure). **0 invariant violations
+across all 24 seeds with every pessimal path on** — every committed txn survived
+crash+recovery, no uncommitted survived, both DBs verified clean. **No real
+engine bug found**: an early over-aggressive split point caused a non-termination
+loop, which was an *illegal* buggify point (self-inflicted), correctly fixed by
+the >3/4-full guard — buggify's own self-check working as designed.
 
 ### 1.4 Simulated I/O faults + the write-back crash model
 

--- a/test/sim/sim_buggify.h
+++ b/test/sim/sim_buggify.h
@@ -1,0 +1,120 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * sim_buggify.h --
+ *	FoundationDB-style BUGGIFY: plant named "buggify points" at real
+ *	library sites that, under sim, MAY take a LEGAL-BUT-PESSIMAL path so
+ *	the engine's rare/slow paths (page splits, aggressive eviction, log
+ *	flushes, forced checkpoints, deadlock-detector runs) run CONSTANTLY
+ *	under test instead of once in a blue moon.
+ *
+ *	The key property, copied verbatim from FoundationDB: a buggify point
+ *	NEVER changes correctness.  Every choice it forces is one the engine
+ *	is already free to make -- split a page a little early, evict a warm
+ *	buffer, fsync now instead of later, checkpoint before the byte
+ *	threshold, run the deadlock detector eagerly.  It only changes
+ *	TIMING / SIZING / PATH, never a result.  If turning a buggify point
+ *	ON makes an invariant fail, either the "pessimal" choice was not
+ *	actually legal (fix the point) or the engine mishandles a legal-but-
+ *	rare path (a REAL bug -- record the seed, do not paper over it).
+ *
+ *	Mechanism.  DB_BUGGIFY("name") is a per-run cached coin drawn from
+ *	the dedicated DB_SIM_RNG_BUGGIFY stream (see sim_rng.h): the FIRST
+ *	time a named point is reached in a run it flips the coin (1 with the
+ *	enabled probability) and caches the result, so every later reach of
+ *	the same name in that run agrees and the whole run replays from its
+ *	seed.  Drawn from its own stream so enabling buggify never perturbs
+ *	the IO / FAULT / APP schedules.
+ *
+ *	Coverage.  The core counts, per named point, how many times it was
+ *	REACHED and whether its coin ACTIVATED this run.  A swarm folds these
+ *	across a seed sweep and reports per-point activation %.  A point
+ *	reached on many seeds but NEVER activated is a coverage gap: its
+ *	pessimal path never actually ran, so it tested nothing.
+ *
+ *	Compilation model (ZERO production overhead).  Every planted site in
+ *	src/ is wrapped in `#ifdef HAVE_DST`, and this header is included by
+ *	those TUs ONLY under that guard.  When HAVE_DST is off (production /
+ *	default) DB_BUGGIFY is never referenced -- no symbol, no branch, no
+ *	cost.  When HAVE_DST is on but no sim run is active, DB_BUGGIFY is a
+ *	couple of relaxed atomic loads that return 0.  Verify with:
+ *	    nm libdb-*.so | grep -c '__db_sim_buggify'   # 0 in an OFF build
+ *
+ *	The primitive (the coin + the per-name cache + the coverage counters)
+ *	lives in sim_core.c's buggify section, declared in sim_fault.h; this
+ *	header adds the DB_BUGGIFY macro, the point-name catalog, and the
+ *	coverage-query API a swarm/test uses.
+ */
+
+#ifndef _DB_SIM_BUGGIFY_H_
+#define _DB_SIM_BUGGIFY_H_
+
+#include "sim_fault.h"		/* __db_sim_buggify + enable/disable */
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+/*
+ * DB_BUGGIFY(name) --
+ *	1 iff the buggify point `name` is activated for this run (take the
+ *	pessimal path); 0 otherwise.  Under HAVE_DST only; a planted src
+ *	site is itself `#ifdef HAVE_DST`, so an OFF build never sees this.
+ *
+ *	    #ifdef HAVE_DST
+ *	    if (DB_BUGGIFY(BUGGIFY_LOG_FLUSH_NOW))
+ *	            LF_SET(DB_FLUSH);    // legal: an extra flush is always OK
+ *	    #endif
+ */
+#define DB_BUGGIFY(name)	__db_sim_buggify(name)
+
+/*
+ * The planted-point catalog.  Every DB_BUGGIFY name used in src/ is named
+ * here so the set of points is discoverable in one place and a test can
+ * assert a specific point activated.  Keep in sync with the DESIGN.md
+ * "buggify point catalog" table.  Format: <subsystem>.<what>.
+ */
+#define BUGGIFY_BT_SPLIT_EARLY		"bt.split_early"    /* bt_put.c */
+#define BUGGIFY_HASH_EXPAND_EARLY	"hash.expand_early" /* hash_page.c */
+#define BUGGIFY_MP_ALLOC_AGGRESSIVE	"mp.alloc_aggressive" /* mp_alloc.c */
+#define BUGGIFY_MP_EVICT_COLD		"mp.evict_cold"     /* mp_fput.c */
+#define BUGGIFY_LOG_FLUSH_NOW		"log.flush_now"     /* log_put.c */
+#define BUGGIFY_LOG_NEWFILE_EARLY	"log.newfile_early" /* log_put.c */
+#define BUGGIFY_TXN_CHKPT_FORCE		"txn.chkpt_force"   /* txn_chkpt.c */
+#define BUGGIFY_LOCK_DD_NOW		"lock.dd_now"       /* lock.c (post-op) */
+#define BUGGIFY_LOCK_DD_WAIT_NOW	"lock.dd_wait_now"  /* lock.c (pre-wait) */
+
+/*
+ * The catalog as a NULL-terminated array so a swarm/test can iterate the
+ * points it EXPECTS and flag any it planted but never reached.  Static so
+ * each TU that needs it gets its own copy (bounded, tiny).
+ */
+static const char *const db_buggify_catalog[] = {
+	BUGGIFY_BT_SPLIT_EARLY,
+	BUGGIFY_HASH_EXPAND_EARLY,
+	BUGGIFY_MP_ALLOC_AGGRESSIVE,
+	BUGGIFY_MP_EVICT_COLD,
+	BUGGIFY_LOG_FLUSH_NOW,
+	BUGGIFY_LOG_NEWFILE_EARLY,
+	BUGGIFY_TXN_CHKPT_FORCE,
+	BUGGIFY_LOCK_DD_NOW,
+	BUGGIFY_LOCK_DD_WAIT_NOW,
+	NULL
+};
+
+/*
+ * Buggify coverage-query API (implemented in sim_core.c).  A point enters
+ * the table the first time it is reached this run.
+ */
+int          __db_sim_buggify_npoints __P((void));
+const char  *__db_sim_buggify_point_name __P((int));
+unsigned long __db_sim_buggify_point_reached __P((int));
+int          __db_sim_buggify_point_activated __P((int));
+/* Cached decision for a name without reaching it; -1 if not yet reached. */
+int          __db_sim_buggify_decided __P((const char *));
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* !_DB_SIM_BUGGIFY_H_ */

--- a/test/sim/sim_core.c
+++ b/test/sim/sim_core.c
@@ -25,6 +25,7 @@
 #include "sim_rng.h"
 #include "sim_fault.h"
 #include "sim_clock.h"
+#include "sim_buggify.h"		/* buggify coverage-query API (owned there) */
 
 #include <stdatomic.h>
 #include <stdio.h>
@@ -229,19 +230,36 @@ __db_sim_fault(pct_per_1000)
 	return (__db_sim_rng_range(DB_SIM_RNG_FAULT, 1000) < pct_per_1000);
 }
 
-/* ---- buggify (per-run cached coin) ---- */
-
+/* ---- buggify (per-run cached coin + coverage counters) ----
+ *
+ * A buggify point (see sim_buggify.h, DB_BUGGIFY) is a named site in real
+ * library code that, under sim, MAY take a legal-but-pessimal path -- the
+ * coin is flipped ONCE per run per name and cached, so every reach of a
+ * name agrees and the whole run replays (the FoundationDB discipline).
+ *
+ * Coverage: per name we count how many times the point was REACHED and,
+ * separately, whether its coin ACTIVATED (came up 1) this run.  A swarm
+ * folds these across a seed sweep: a point reached-but-never-activated
+ * across many seeds is a coverage gap (its pessimal path never ran).
+ */
 #define DB_SIM_BUG_MAX 64
-static char        g_bug_name[DB_SIM_BUG_MAX][48];
-static signed char g_bug_decided[DB_SIM_BUG_MAX];   /* 0/1 */
-static _Atomic int g_bug_n;
-static _Atomic int g_bug_on;
-static _Atomic int g_bug_pct;
+static char          g_bug_name[DB_SIM_BUG_MAX][48];
+static signed char   g_bug_decided[DB_SIM_BUG_MAX];   /* 0/1 */
+static unsigned long g_bug_reached[DB_SIM_BUG_MAX];   /* reaches this run */
+static _Atomic int   g_bug_n;
+static _Atomic int   g_bug_on;
+static _Atomic int   g_bug_pct;
 
 void
 __db_sim_buggify_enable(pct_per_1000)
 	unsigned pct_per_1000;
 {
+	int i;
+	for (i = 0; i < DB_SIM_BUG_MAX; i++) {
+		g_bug_name[i][0] = '\0';
+		g_bug_decided[i] = 0;
+		g_bug_reached[i] = 0;
+	}
 	atomic_store_explicit(&g_bug_n, 0, memory_order_relaxed);
 	atomic_store_explicit(&g_bug_pct, (int)pct_per_1000,
 	    memory_order_relaxed);
@@ -259,7 +277,8 @@ __db_sim_buggify_disable()
  * Once-per-run decision for buggify point `name`: 1 to take the pessimal
  * path, 0 otherwise.  Decided on first reach (seeded coin from the
  * BUGGIFY stream) and cached, so every reach of the same name in a run
- * agrees and the whole run replays.
+ * agrees and the whole run replays.  Each reach bumps the name's reach
+ * count for coverage reporting.
  *
  * ponytail: single global array + linear scan (bounded 64 names, called
  * from tests not a hot library path), a hash map if the site count grows.
@@ -279,8 +298,10 @@ __db_sim_buggify(name)
 
 	n = atomic_load_explicit(&g_bug_n, memory_order_relaxed);
 	for (i = 0; i < n; i++)
-		if (strncmp(g_bug_name[i], name, sizeof(g_bug_name[0])) == 0)
+		if (strncmp(g_bug_name[i], name, sizeof(g_bug_name[0])) == 0) {
+			g_bug_reached[i]++;
 			return (g_bug_decided[i]);
+		}
 
 	if (n >= DB_SIM_BUG_MAX)
 		return (0);                 /* table full: no buggify */
@@ -295,8 +316,67 @@ __db_sim_buggify(name)
 	(void)strncpy(g_bug_name[n], name, sizeof(g_bug_name[0]) - 1);
 	g_bug_name[n][sizeof(g_bug_name[0]) - 1] = '\0';
 	g_bug_decided[n] = (signed char)decision;
+	g_bug_reached[n] = 1;
 	atomic_store_explicit(&g_bug_n, n + 1, memory_order_relaxed);
 	return (decision);
+}
+
+/*
+ * Buggify coverage query (for the swarm / coverage report).  A name is
+ * only in the table once it has been reached at least once this run.
+ */
+int
+__db_sim_buggify_npoints()
+{
+	return (atomic_load_explicit(&g_bug_n, memory_order_relaxed));
+}
+
+const char *
+__db_sim_buggify_point_name(idx)
+	int idx;
+{
+	if (idx < 0 || idx >= atomic_load_explicit(&g_bug_n, memory_order_relaxed))
+		return (NULL);
+	return (g_bug_name[idx]);
+}
+
+unsigned long
+__db_sim_buggify_point_reached(idx)
+	int idx;
+{
+	if (idx < 0 || idx >= atomic_load_explicit(&g_bug_n, memory_order_relaxed))
+		return (0);
+	return (g_bug_reached[idx]);
+}
+
+int
+__db_sim_buggify_point_activated(idx)
+	int idx;
+{
+	if (idx < 0 || idx >= atomic_load_explicit(&g_bug_n, memory_order_relaxed))
+		return (0);
+	return (g_bug_decided[idx]);
+}
+
+/*
+ * Query the cached decision for a name WITHOUT reaching it (does not bump
+ * the reach count and does not decide an unseen point).  -1 if the name
+ * has not been reached yet this run.  Lets a test assert a specific point
+ * activated on a given seed.
+ */
+int
+__db_sim_buggify_decided(name)
+	const char *name;
+{
+	int i, n;
+
+	if (name == NULL)
+		return (-1);
+	n = atomic_load_explicit(&g_bug_n, memory_order_relaxed);
+	for (i = 0; i < n; i++)
+		if (strncmp(g_bug_name[i], name, sizeof(g_bug_name[0])) == 0)
+			return (g_bug_decided[i]);
+	return (-1);
 }
 
 /* ---- simulated I/O faults ---- */

--- a/test/sim/test_sim_buggify.c
+++ b/test/sim/test_sim_buggify.c
@@ -1,0 +1,514 @@
+/*-
+ * Deterministic Simulation Testing (DST) for libdb.
+ *
+ * test_sim_buggify.c --
+ *	FoundationDB-style BUGGIFY sweep: run a mixed transactional workload
+ *	with buggify ENABLED (all planted points armed at high probability)
+ *	across a seed sweep, and assert the two things buggify must both
+ *	deliver:
+ *
+ *	  (1) the LEGAL-BUT-PESSIMAL paths actually RUN -- across the sweep
+ *	      every planted point in db_buggify_catalog[] activates on at
+ *	      least one seed (a point reached-but-never-activated is a
+ *	      coverage gap, surfaced as a failure on a large enough sweep);
+ *	  (2) with those pessimal paths forced ON, all SAFETY INVARIANTS
+ *	      still hold -- every committed txn survives a crash+recovery,
+ *	      no uncommitted txn survives, and the DB verifies clean.
+ *
+ *	That is the whole point of buggify: it must STRESS the rare paths
+ *	WITHOUT BREAKING correctness.  If an invariant fails with buggify on,
+ *	either a planted point was not actually legal (fix the point) or the
+ *	engine mishandles a legal-but-rare path (a real bug -- the seed here
+ *	is the exact repro).
+ *
+ *	The workload deliberately touches every buggified subsystem:
+ *	  - many keyed puts in one txn  -> btree page splits (bt.split_early)
+ *	  - a HASH db with many puts     -> bucket expansion (hash.expand_early)
+ *	  - a working set larger than a tiny cache -> eviction churn
+ *	    (mp.alloc_aggressive, mp.evict_cold)
+ *	  - DB_TXN_SYNC commits          -> log flush (log.flush_now) and,
+ *	    over volume, log-file rollover (log.newfile_early)
+ *	  - an explicit env->txn_checkpoint -> forced checkpoints
+ *	    (txn.chkpt_force)
+ *	  - concurrent-ish lock traffic via the txn locks -> deadlock
+ *	    detector runs (lock.dd_now, lock.dd_wait_now)
+ *
+ *	Build/run (from build_unix, after configure --enable-dst):
+ *	    make test_sim_buggify && ./test_sim_buggify [count] [base]
+ */
+
+#include <sys/types.h>
+#include <sys/wait.h>
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "db.h"
+#include "sim_rng.h"
+#include "sim_fault.h"
+#include "sim_buggify.h"
+
+#define HOME     "TESTDIR_sim_buggify"
+#define BTDB     "bug_bt.db"
+#define HASHDB   "bug_hash.db"
+#define ACTFILE  HOME "/activation.txt"   /* child -> parent activation dump */
+#define NCOMMIT  20           /* durable committed txns before the crash */
+#define NPUT     16           /* keyed puts per txn -> force btree splits */
+#define BUGGIFY_PCT 800       /* per-1000: arm each point at 80% per run */
+
+/* Deterministic value token for record (t,i) under the active seed. */
+static uint64_t
+tok_for(t, i)
+	int t, i;
+{
+	/* fold a per-record draw so a torn/wrong value is visible AND the
+	 * exact committed set is a function of the seed (replayable). */
+	return (__db_sim_rng(DB_SIM_RNG_APP) ^
+	    ((uint64_t)t << 32) ^ (uint64_t)i);
+}
+
+static void
+mkkv(t, i, kbuf, vbuf, tok)
+	int t, i;
+	char *kbuf, *vbuf;
+	uint64_t tok;
+{
+	(void)snprintf(kbuf, 32, "k-%04d-%04d", t, i);
+	(void)snprintf(vbuf, 48, "v-%016llx", (unsigned long long)tok);
+}
+
+/*
+ * child_dump_activation --
+ *	Written by the child at the crash boundary: for each catalog point,
+ *	whether it activated (coin came up 1) AND how many times it was
+ *	reached this run.  The parent reads this to report the child's ACTUAL
+ *	per-point activation -- honest, and independent of the order in which
+ *	the child happened to reach the points.
+ */
+static void
+child_dump_activation()
+{
+	FILE *f;
+	int c, npt, i;
+
+	if ((f = fopen(ACTFILE, "w")) == NULL)
+		return;
+	npt = __db_sim_buggify_npoints();
+	for (c = 0; db_buggify_catalog[c] != NULL; c++) {
+		unsigned long reached = 0;
+		int activated = 0;
+		for (i = 0; i < npt; i++) {
+			const char *nm = __db_sim_buggify_point_name(i);
+			if (nm != NULL &&
+			    strcmp(nm, db_buggify_catalog[c]) == 0) {
+				reached = __db_sim_buggify_point_reached(i);
+				activated =
+				    __db_sim_buggify_point_activated(i);
+				break;
+			}
+		}
+		(void)fprintf(f, "%s %d %lu\n", db_buggify_catalog[c],
+		    activated, reached);
+	}
+	(void)fclose(f);
+}
+
+/*
+ * The child: open a TINY-cache env so the working set forces eviction,
+ * run NCOMMIT durable txns (each NPUT keyed puts across a btree AND a hash
+ * db, with periodic forced checkpoints), then a final uncommitted txn, then
+ * crash (drop un-fsync'd bytes).  Buggify is armed so the pessimal paths
+ * fire throughout.  Returns 0 (child exits 42 at the crash boundary).
+ */
+static int
+run_child(seed)
+	uint64_t seed;
+{
+	DB_ENV *env;
+	DB *bt, *hash;
+	DB_TXN *txn;
+	DBT key, data;
+	char kbuf[32], vbuf[48];
+	int t, i, ret;
+
+	__db_sim_activate(seed);
+	__db_sim_buggify_enable(BUGGIFY_PCT);
+	__db_sim_wb_enable(1);
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	/* A deliberately small cache (256KB) so the working set spills and
+	 * the eviction / write-back path (mp.alloc_aggressive, mp.evict_cold)
+	 * runs hard. */
+	(void)env->set_cachesize(env, 0, 256 * 1024, 1);
+	/* Enable automatic deadlock detection so the lock.dd_now buggify site
+	 * (which forces the detector to run on a lock-vec op) is actually
+	 * reached; without this the region's detect policy is NORUN and the
+	 * site is never hit. */
+	(void)env->set_lk_detect(env, DB_LOCK_DEFAULT);
+	/* A small max log-file size (256KB) so the workload actually rolls
+	 * over log files -- this both exercises real rollover and lets the
+	 * log.newfile_early buggify site (which only fires once a file is
+	 * more than half full) be reached. */
+	(void)env->set_lg_max(env, 256 * 1024);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0664)) != 0)
+		return (ret);
+
+	if ((ret = db_create(&bt, env, 0)) != 0)
+		return (ret);
+	if ((ret = bt->open(bt, NULL, BTDB, NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0664)) != 0)
+		return (ret);
+	if ((ret = db_create(&hash, env, 0)) != 0)
+		return (ret);
+	if ((ret = hash->open(hash, NULL, HASHDB, NULL, DB_HASH,
+	    DB_CREATE | DB_AUTO_COMMIT, 0664)) != 0)
+		return (ret);
+
+	for (t = 0; t < NCOMMIT; t++) {
+		if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+			return (ret);
+		for (i = 0; i < NPUT; i++) {
+			uint64_t tok = tok_for(t, i);
+			mkkv(t, i, kbuf, vbuf, tok);
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+			data.data = vbuf;
+			data.size = (u_int32_t)strlen(vbuf) + 1;
+			if ((ret = bt->put(bt, txn, &key, &data, 0)) != 0)
+				return (ret);
+			if ((ret = hash->put(hash, txn, &key, &data, 0)) != 0)
+				return (ret);
+		}
+		if ((ret = txn->commit(txn, DB_TXN_SYNC)) != 0)
+			return (ret);
+		/* Periodic checkpoint: exercises txn.chkpt_force (and the
+		 * cache flush it drives).  A no-op if quiescent. */
+		if ((t % 8) == 7)
+			(void)env->txn_checkpoint(env, 0, 0, 0);
+	}
+
+	/* An UNCOMMITTED txn, then crash inside it: must NOT survive. */
+	if ((ret = env->txn_begin(env, NULL, &txn, 0)) != 0)
+		return (ret);
+	mkkv(NCOMMIT, 0, kbuf, vbuf, tok_for(NCOMMIT, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	data.data = vbuf; data.size = (u_int32_t)strlen(vbuf) + 1;
+	(void)bt->put(bt, txn, &key, &data, 0);
+	/* Deliberately DO NOT commit. */
+
+	/* Record which pessimal paths actually ran, then crash. */
+	child_dump_activation();
+	__db_sim_wb_crash();
+	fflush(NULL);
+	_exit(42);
+	/* NOTREACHED */
+	return (0);
+}
+
+/*
+ * Parent: recover, reopen, verify EVERY committed (t,i) survived in BOTH
+ * dbs, the uncommitted key is absent, and both dbs verify clean.  Returns
+ * 0 on success; sets *missing to the count of missing/wrong committed recs.
+ */
+static int
+verify_after_recovery(seed, saw_uncommitted, missing_out)
+	uint64_t seed;
+	int *saw_uncommitted, *missing_out;
+{
+	DB_ENV *env;
+	DB *bt, *hash;
+	DBT key, data;
+	char kbuf[32], vbuf[48];
+	int t, i, ret, missing = 0, mismatch = 0;
+
+	*saw_uncommitted = 0;
+	*missing_out = 0;
+
+	if ((ret = db_env_create(&env, 0)) != 0)
+		return (ret);
+	if ((ret = env->open(env, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_RECOVER, 0664))
+	    != 0) {
+		fprintf(stderr, "recover open failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+
+	if ((ret = db_create(&bt, env, 0)) != 0)
+		return (ret);
+	if ((ret = bt->open(bt, NULL, BTDB, NULL, DB_BTREE,
+	    DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "reopen bt failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	if ((ret = db_create(&hash, env, 0)) != 0)
+		return (ret);
+	if ((ret = hash->open(hash, NULL, HASHDB, NULL, DB_HASH,
+	    DB_AUTO_COMMIT, 0664)) != 0) {
+		fprintf(stderr, "reopen hash failed: %s\n", db_strerror(ret));
+		return (ret);
+	}
+
+	/* Re-derive the expected set deterministically from the seed. */
+	__db_sim_activate(seed);
+	for (t = 0; t < NCOMMIT; t++)
+		for (i = 0; i < NPUT; i++) {
+			uint64_t tok = tok_for(t, i);
+			DB *d;
+			int which;
+
+			mkkv(t, i, kbuf, vbuf, tok);
+			for (which = 0; which < 2; which++) {
+				d = which == 0 ? bt : hash;
+				memset(&key, 0, sizeof(key));
+				memset(&data, 0, sizeof(data));
+				key.data = kbuf;
+				key.size = (u_int32_t)strlen(kbuf) + 1;
+				if ((ret = d->get(d, NULL, &key, &data, 0))
+				    != 0) {
+					fprintf(stderr, "MISSING %s in %s: "
+					    "%s\n", kbuf, which ? "hash" : "bt",
+					    db_strerror(ret));
+					missing++;
+				} else if (data.size != strlen(vbuf) + 1 ||
+				    memcmp(data.data, vbuf, data.size) != 0) {
+					fprintf(stderr, "WRONG value for %s "
+					    "in %s\n", kbuf,
+					    which ? "hash" : "bt");
+					mismatch++;
+				}
+			}
+		}
+	/* The uncommitted key must be ABSENT. */
+	mkkv(NCOMMIT, 0, kbuf, vbuf, tok_for(NCOMMIT, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf) + 1;
+	if (bt->get(bt, NULL, &key, &data, 0) == 0)
+		*saw_uncommitted = 1;
+	__db_sim_deactivate();
+
+	(void)bt->close(bt, 0);
+	(void)hash->close(hash, 0);
+
+	/* Verify both dbs clean (fresh handles). */
+	if ((ret = db_create(&bt, env, 0)) != 0)
+		return (ret);
+	if ((ret = bt->verify(bt, BTDB, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "bt verify FAILED: %s\n", db_strerror(ret));
+		(void)env->close(env, 0);
+		return (ret);
+	}
+	if ((ret = db_create(&hash, env, 0)) != 0)
+		return (ret);
+	if ((ret = hash->verify(hash, HASHDB, NULL, NULL, 0)) != 0) {
+		fprintf(stderr, "hash verify FAILED: %s\n", db_strerror(ret));
+		(void)env->close(env, 0);
+		return (ret);
+	}
+	(void)env->close(env, 0);
+
+	*missing_out = missing;
+	if (missing != 0 || mismatch != 0) {
+		fprintf(stderr, "%d missing, %d mismatched committed recs\n",
+		    missing, mismatch);
+		return (1);
+	}
+	return (0);
+}
+
+/*
+ * read_child_activation --
+ *	Read the child's activation dump: fired[c] = 1 iff catalog point c
+ *	activated this run, reached[c] = how many times it was reached.
+ *	Returns 0 on success.  Reflects the child's ACTUAL decisions.
+ */
+static int
+read_child_activation(fired, reached)
+	int *fired;
+	unsigned long *reached;
+{
+	FILE *f;
+	char name[64];
+	int act, c;
+	unsigned long rch;
+
+	if ((f = fopen(ACTFILE, "r")) == NULL)
+		return (-1);
+	while (fscanf(f, "%63s %d %lu", name, &act, &rch) == 3)
+		for (c = 0; db_buggify_catalog[c] != NULL; c++)
+			if (strcmp(name, db_buggify_catalog[c]) == 0) {
+				fired[c] = act;
+				reached[c] = rch;
+				break;
+			}
+	(void)fclose(f);
+	return (0);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	long n_seeds = argc > 1 ? strtol(argv[1], NULL, 10) : 24;
+	long base    = argc > 2 ? strtol(argv[2], NULL, 10) : 1;
+	long s, failures = 0;
+	int ncat, c;
+	unsigned long *act;         /* seeds on which each catalog point fired */
+	unsigned long *rtot;        /* total reaches of each point across sweep */
+	char cmd[256];
+
+	for (ncat = 0; db_buggify_catalog[ncat] != NULL; ncat++)
+		;
+	if ((act = calloc((size_t)ncat, sizeof(*act))) == NULL ||
+	    (rtot = calloc((size_t)ncat, sizeof(*rtot))) == NULL) {
+		fprintf(stderr, "OOM\n");
+		return (EXIT_FAILURE);
+	}
+	if (n_seeds < 1)
+		n_seeds = 1;
+
+	printf("== DST buggify sweep: %ld seeds (base %ld), %d planted "
+	    "points, each armed at %.0f%% ==\n", n_seeds, base, ncat,
+	    BUGGIFY_PCT / 10.0);
+	fflush(stdout);   /* flush BEFORE any fork so the child never dups it */
+
+	for (s = 0; s < n_seeds; s++) {
+		uint64_t seed = 0x9E3779B97F4A7C15ull * (uint64_t)(base + s);
+		pid_t pid;
+		int status, ret, saw_uncommitted, missing;
+		int *fired = calloc((size_t)ncat, sizeof(int));
+		unsigned long *reached = calloc((size_t)ncat, sizeof(*reached));
+
+		if (fired == NULL || reached == NULL) {
+			fprintf(stderr, "OOM\n");
+			free(act); free(rtot);
+			return (EXIT_FAILURE);
+		}
+
+		(void)snprintf(cmd, sizeof(cmd),
+		    "rm -rf %s && mkdir -p %s", HOME, HOME);
+		(void)system(cmd);
+
+		if ((pid = fork()) < 0) {
+			perror("fork");
+			free(fired); free(reached); free(act); free(rtot);
+			return (EXIT_FAILURE);
+		}
+		if (pid == 0)
+			exit(run_child(seed) == 0 ? 0 : 1);
+		if (waitpid(pid, &status, 0) < 0) {
+			perror("waitpid");
+			free(fired); free(reached); free(act); free(rtot);
+			return (EXIT_FAILURE);
+		}
+		if (!(WIFEXITED(status) && WEXITSTATUS(status) == 42)) {
+			fprintf(stderr, "FAIL seed=0x%llx: child did not reach "
+			    "the crash point (status %d)\n",
+			    (unsigned long long)seed, status);
+			failures++;
+			free(fired); free(reached);
+			continue;
+		}
+
+		/* The child's ACTUAL per-point activation (from its dump). */
+		(void)read_child_activation(fired, reached);
+		for (c = 0; c < ncat; c++) {
+			if (fired[c])
+				act[c]++;
+			rtot[c] += reached[c];
+		}
+
+		ret = verify_after_recovery(seed, &saw_uncommitted, &missing);
+
+		if (saw_uncommitted) {
+			fprintf(stderr, "FAIL seed=0x%llx: an UNCOMMITTED txn "
+			    "survived the crash (buggify broke atomicity?)\n",
+			    (unsigned long long)seed);
+			failures++;
+		} else if (ret != 0) {
+			fprintf(stderr, "FAIL seed=0x%llx: %d committed rec(s) "
+			    "lost or DB failed to verify AFTER a clean "
+			    "recovery -- with buggify on, a legal-but-pessimal "
+			    "path corrupted or lost committed data.  This is "
+			    "EITHER an illegal buggify point OR a real engine "
+			    "bug on a rare path; reproduce with "
+			    "./test_sim_buggify 1 %ld\n",
+			    (unsigned long long)seed, missing, base + s);
+			failures++;
+		}
+		free(fired); free(reached);
+	}
+
+	printf("\nbuggify POINT ACTIVATION (seeds on which the pessimal path "
+	    "was taken; reaches = total code-site hits across the sweep):\n");
+	for (c = 0; c < ncat; c++)
+		printf("  %-22s activated %4lu/%ld seeds (%5.1f%%)  "
+		    "reaches %lu\n",
+		    db_buggify_catalog[c], act[c], n_seeds,
+		    100.0 * (double)act[c] / (double)n_seeds, rtot[c]);
+
+	if (failures > 0) {
+		printf("\nFAIL: %ld seed(s) violated a safety invariant WITH "
+		    "buggify on\n", failures);
+		free(act); free(rtot);
+		return (EXIT_FAILURE);
+	}
+
+	/*
+	 * Coverage-gap guard (FoundationDB discipline), split by KIND:
+	 *
+	 *   - REACHED but NEVER ACTIVATED across the sweep = a real buggify
+	 *     hole (the coin is stuck at 0, or the point was neutered): a
+	 *     HARD FAILURE, because the pessimal path exists in the workload
+	 *     but never ran.
+	 *   - NEVER REACHED = the workload does not exercise that code site
+	 *     (e.g. lock.dd_wait_now needs lock CONTENTION, which this single
+	 *     sequential-writer crash workload does not create): reported as
+	 *     a WARNING, not a failure -- the point is valid, the workload
+	 *     just does not drive it here.
+	 */
+	if (n_seeds >= 12) {
+		int hard_gap = 0;
+		for (c = 0; c < ncat; c++) {
+			if (act[c] != 0)
+				continue;
+			if (rtot[c] == 0)
+				printf("WARN: buggify point '%s' never "
+				    "REACHED across %ld seeds -- this "
+				    "workload does not drive the site (e.g. "
+				    "lock.dd_wait_now needs lock contention); "
+				    "point is valid, coverage is "
+				    "workload-limited\n",
+				    db_buggify_catalog[c], n_seeds);
+			else {
+				printf("FAIL: buggify point '%s' was REACHED "
+				    "but NEVER activated across %ld seeds -- "
+				    "its pessimal path never ran (coin stuck "
+				    "at 0 / point neutered)\n",
+				    db_buggify_catalog[c], n_seeds);
+				hard_gap = 1;
+			}
+		}
+		if (hard_gap) {
+			free(act); free(rtot);
+			return (EXIT_FAILURE);
+		}
+	}
+
+	printf("\nOK: %ld-seed buggify sweep -- every planted pessimal path "
+	    "ran on at least one seed AND every committed txn survived "
+	    "crash+recovery with all pessimal paths forced on (0 invariant "
+	    "violations)\n", n_seeds);
+	free(act); free(rtot);
+	return (EXIT_SUCCESS);
+}


### PR DESCRIPTION
Adds FoundationDB's signature technique: **buggify** injects *legal-but-pessimal* behavior at named points in real library code so the engine's rare/slow/error paths run **constantly** under DST — far more coverage than fault injection alone. Correctness-preserving by construction (only timing/sizing/path-choice changes), so the whole scenario suite must still pass with buggify forced on.

## Primitive (`test/sim/sim_buggify.h` + `sim_core.c`)
`DB_BUGGIFY(name)` — a per-run-per-site cached coin on the dedicated `BUGGIFY` rng stream; compiles to constant 0 when `--enable-dst` is off. Per-point **reached** + **activated** coverage counters with a gap guard (hard-fail on reached-but-never-activated, WARN on never-reached).

## 9 points (all `#ifdef HAVE_DST`)
| Point | Site | Pessimal choice |
|---|---|---|
| `bt.split_early` | bt_put.c | force `DB_NEEDSPLIT` at >3/4 full (guarded, no split loop) |
| `hash.expand_early` | hash_page.c | `H_EXPAND` before fill factor |
| `mp.alloc_aggressive` | mp_alloc.c | aggressive eviction scan |
| `mp.evict_cold` | mp_fput.c | pin at coldest warmth |
| `log.flush_now` / `log.newfile_early` | log_put.c | force `DB_FLUSH` / roll log at half full |
| `txn.chkpt_force` | txn_chkpt.c | checkpoint past threshold |
| `lock.dd_now` / `lock.dd_wait_now` | lock.c | run deadlock detector now / before blocking |

## Validation (24-seed sweep, all pessimal paths forced)
Activation: mp.alloc_aggressive 100%, txn.chkpt_force 88%, mp.evict_cold + lock.dd_now 83%, bt.split_early 79%, log.flush_now + log.newfile_early 75%, hash.expand_early 67%, **lock.dd_wait_now 0%** (workload-limited — single-writer has no blocked waiter; valid point, WARN not fail). **0 invariant violations** — every committed txn survived crash+recovery with all pessimal paths on. **No real engine bug** (an early over-aggressive split was an *illegal* point causing a self-inflicted loop, correctly fixed by the >3/4 guard — buggify's self-check working).

**OFF build: 0 `__db_sim_*` symbols, no point name in any engine `.o`.** Existing DST scenarios (crash_recover / split_crash / recover_idempotent / ckp_crash) still pass with the buggify sites present.