### PR TITLE
fix(os): make __os_gettime honor monotonic clock request

### DIFF
--- a/src/os/os_clock.c
+++ b/src/os/os_clock.c
@@ -38,8 +38,6 @@ __os_gettime(env, tp, monotonic)
 #endif
 		RETRY_CHK((clock_gettime(
 		    CLOCK_REALTIME, (struct timespec *)tp)), ret);
-
-	RETRY_CHK((clock_gettime(CLOCK_REALTIME, (struct timespec *)tp)), ret);
 	if (ret != 0) {
 		sc = "clock_gettime";
 		goto err;


### PR DESCRIPTION
## The bug

In `src/os/os_clock.c`, `__os_gettime()` had a stray unconditional
`clock_gettime(CLOCK_REALTIME, tp)` immediately after the
`#if HAVE_CLOCK_MONOTONIC / if (monotonic) ... else ...` block:

```c
#if defined(HAVE_CLOCK_MONOTONIC)
	if (monotonic)
		RETRY_CHK((clock_gettime(CLOCK_MONOTONIC, (struct timespec *)tp)), ret);
	else
#endif
		RETRY_CHK((clock_gettime(CLOCK_REALTIME, (struct timespec *)tp)), ret);

	RETRY_CHK((clock_gettime(CLOCK_REALTIME, (struct timespec *)tp)), ret);   /* stray: clobbers the above */
	if (ret != 0) { ... }
```

The stray line overwrote whatever the guarded read produced, so
`__os_gettime(env, tp, monotonic=1)` **always** returned
`CLOCK_REALTIME` (wall clock) — the `CLOCK_MONOTONIC` branch was dead
code. Every "monotonic" read in BDB was actually a wall clock, subject
to NTP steps, manual `date` changes, suspend/resume, and leap seconds,
silently breaking jump-proof deadline math for callers that pass
`monotonic=1`.

## The fix

Delete the one stray line (a bad merge/paste artifact). The `if/else`
block already sets both `tp` and `ret` correctly for both the
monotonic and realtime cases (and for the no-`HAVE_CLOCK_MONOTONIC`
fall-through, where the `else` collapses and the REALTIME read runs
unconditionally). So the subsequent `if (ret != 0)` error check still
sees a valid `ret` on every code path.

```diff
 		RETRY_CHK((clock_gettime(
 		    CLOCK_REALTIME, (struct timespec *)tp)), ret);
-
-	RETRY_CHK((clock_gettime(CLOCK_REALTIME, (struct timespec *)tp)), ret);
 	if (ret != 0) {
```

## Verification

- **Direct before/after proof**: a standalone check with
  `HAVE_CLOCK_MONOTONIC` defined shows the fixed body returns
  `CLOCK_MONOTONIC` for `monotonic=1` (uptime ~758128 s) vs
  `CLOCK_REALTIME` for `monotonic=0` (epoch ~1.78e9 s), distinct clock
  domains, and never steps backward across a `usleep`. The **buggy**
  body fails that same assertion (it returns the epoch value for
  `monotonic=1`).
- **--enable-dst clockskew scenarios**: `test_sim_clockskew_backward`,
  `test_sim_clockskew_timeout`, `test_sim_clockskew_ckp` all still
  PASS (they proved robustness to a jumping clock; with a real
  monotonic clock they still pass).
- **TCL timeout smoke**: `lock001`, `txn001`, `ssi001` all PASS
  (built `--enable-test --with-tcl=...`); these exercise lock/txn
  timeout paths that read the clock.
- Clean builds (`--enable-debug`, `--enable-dst`, `--enable-test`),
  0 errors; `db_dump -V` reports `Berkeley DB 5.3.33`.

## Scope

One-line deletion; only `src/os/os_clock.c` changed.

## Note (out of scope)

On this toolchain the configure probe in `dist/aclocal/clock.m4`
leaves `HAVE_CLOCK_MONOTONIC` undefined because its test program
includes only `<sys/time.h>` (modern glibc/clang put `clock_gettime`/
`CLOCK_MONOTONIC` in `<time.h>`), so the monotonic branch is compiled
out in default builds here. That is a **separate, pre-existing**
configure limitation, not part of this fix, and left untouched per the
scope of this change. The source-level clobber fixed here is real and
matters on every platform whose probe succeeds.