### PR TITLE
fix(env): failchk recovers dead process's DB-handle mutex in place instead of returning EBUSY

### DIFF
--- a/src/dbinc/db_int.in
+++ b/src/dbinc/db_int.in
@@ -636,12 +636,13 @@ typedef enum {
 	if ((ip) != NULL) {						\
 		DB_ASSERT(env, ((ip)->dbth_state == THREAD_ACTIVE  ||	\
 		    (ip)->dbth_state == THREAD_FAILCHK));		\
-		(ip)->dbth_state = THREAD_OUT;				\
+		if ((ip)->dbth_state != THREAD_FAILCHK)			\
+			(ip)->dbth_state = THREAD_OUT;			\
 	}								\
 } while (0)
 #else
 #define	ENV_LEAVE(env, ip) do {						\
-	if ((ip) != NULL)						\
+	if ((ip) != NULL && (ip)->dbth_state != THREAD_FAILCHK)		\
 		(ip)->dbth_state = THREAD_OUT;				\
 } while (0)
 #endif

--- a/src/env/env_failchk.c
+++ b/src/env/env_failchk.c
@@ -56,6 +56,15 @@ __env_failchk_pp(dbenv, flags)
 	ENV_ENTER(env, ip);
 	FAILCHK_THREAD(env, ip);	/* mark as failchk thread */
 	ret = __env_failchk_int(dbenv);
+	/*
+	 * Clear the failchk marker so ENV_LEAVE retires the slot normally.
+	 * ENV_ENTER/ENV_LEAVE preserve THREAD_FAILCHK across the nested
+	 * enters that the cleanup path (e.g. __dbreg_log_close -> __log_put)
+	 * performs, so this thread is still marked THREAD_FAILCHK here; undo
+	 * it explicitly since this is the frame that owns the marker.
+	 */
+	if (ip != NULL && ip->dbth_state == THREAD_FAILCHK)
+		ip->dbth_state = THREAD_ACTIVE;
 	ENV_LEAVE(env, ip);
 	return (ret);
 }
@@ -506,7 +515,17 @@ init:			ip->dbth_pid = id.pid;
 			SH_TAILQ_INIT(&ip->dbth_xatxn);
 		}
 		MUTEX_UNLOCK(env, renv->mtx_regenv);
-	} else
+	} else if (state == THREAD_ACTIVE && ip->dbth_state == THREAD_FAILCHK)
+		/*
+		 * A nested ENV_ENTER by the failchk thread (e.g. the failchk
+		 * cleanup path logging through __log_put) must not downgrade
+		 * the THREAD_FAILCHK marker to THREAD_ACTIVE: the mutex-destroy
+		 * code relies on it to recover a dead process's mutex in place
+		 * instead of returning a hard EBUSY.  No-op for normal threads,
+		 * whose state is never THREAD_FAILCHK.
+		 */
+		; /* preserve THREAD_FAILCHK */
+	else
 		ip->dbth_state = state;
 	*ipp = ip;
 


### PR DESCRIPTION
## The bug

Two processes share a real (non-DB_PRIVATE) txn+lock region; one is `kill -9`'d mid-txn holding a write lock while it has an open DB handle. The survivor runs `DB_ENV->failchk`. On **every** seed, failchk correctly aborted the dead txn, freed its locks, and freed its log info -- then returned **`EBUSY` (BDB2027 "unable to destroy mutex: Device or resource busy")** instead of `0` (recovered in place). EBUSY is outside failchk's documented contract (0 or `DB_RUNRECOVERY`), breaking failchk's promise of in-place recovery without a full `DB_RECOVER`.

## Root cause

`__env_failchk_pp` marks the failchk thread `THREAD_FAILCHK` so `__db_pthread_mutex_destroy` (and its fcntl/tas/win32 twins) recover a dead process's still-held mutex in place. But the failchk **cleanup** path re-enters the library and logs:

```
__dbreg_failchk -> __dbreg_close_id_int -> __dbreg_log_close -> __log_put
    -> ENV_ENTER -> __env_set_state(..., THREAD_ACTIVE)
```

which **flipped the failchk thread's marker** `THREAD_FAILCHK -> THREAD_ACTIVE` (and `ENV_LEAVE` -> `THREAD_OUT`). When control later reached the mutex destroy, the `THREAD_VERIFY` lookup no longer saw `THREAD_FAILCHK`, `failchk_thread` was computed `FALSE`, and the still-held mutex became a hard EBUSY.

## Fix chosen: option 2 (ENV_ENTER/ENV_LEAVE) — and why

DST-V2-DESIGN.md sec.3a offers two options. I chose **option 2 (general)** over option 1 (localized save/restore around the dbreg path) because the marker-clobber is **general, not dbreg-specific**: all four mutex backends (pthread/tas/fcntl/win32) key off `dbth_state == THREAD_FAILCHK`, and multiple failchk sub-paths log during cleanup (txn abort, dbreg close, memp). Option 1 would fix only the dbreg path and leave every sibling failchk sub-path that logs still broken. Option 2 fixes it once at the shared choke point.

- `__env_set_state`: a nested `ENV_ENTER` (THREAD_ACTIVE) on a thread already `THREAD_FAILCHK` **preserves** the marker instead of downgrading it.
- `ENV_LEAVE`: does not force `THREAD_OUT` on a `THREAD_FAILCHK` thread.
- `__env_failchk_pp`: explicitly clears the marker after `__env_failchk_int` so its own `ENV_LEAVE` still retires the slot normally.

**Zero-cost / no behavior change for normal threads:** outside failchk no thread is ever `THREAD_FAILCHK` (only `__env_failchk_pp` sets it, via the single `FAILCHK_THREAD` call site), so both new guards are never taken on hot paths. This is a real engine fix (NOT under `HAVE_DST`); it ships in production.

## Diff (23 insertions, 3 deletions across 2 files)

`src/env/env_failchk.c` + `src/dbinc/db_int.in` (ENV_LEAVE macro). No new dependencies, no DST-only code, no `__db_sim_` symbols.

## Proof: mp-failchk now returns 0-in-place on every seed

`bash ../test/sim/mp-failchk.sh` (seeds 0x51ED 0x1 0x2 0x3 0x4 0xBEEF 0xC0FFEE 0xDEAD):
- 8/8 `failchk returned: 0 (recovered in place)`
- 8/8 `PASS -- failchk released the dead txn's write lock, 32 committed intact, uncommitted gone, verifies clean`
- **0** occurrences of BDB2027 / EBUSY / "SEVERE" / "escalating to DB_RECOVER" / DB_RUNRECOVERY
- No orphan processes, no leftover test homes

Before the fix, every seed hit `SEVERE: failchk returned a non-recovery error (Device or resource busy)` and escalated to `DB_RECOVER`.

## Regression (all pass)

| Test | Result | Covers |
|---|---|---|
| env012 | DONE | DB_REGISTER + failchk multi-process kill/recover (subtests e, i, j) |
| recd001 | DONE | recovery (abort/commit/prepare across many ops) |
| recd002 | DONE | recovery (splits, removes, printlog) |
| txn001 | DONE | begin/commit/abort/prepare |
| lock001 | DONE | basic lock ops |
| ssi001, ssi002 | DONE | serializable snapshot isolation |

Also: `make dst_tests` builds; `test_sim_rng` passes; a `--enable-dst`-OFF build compiles clean with **0** `__db_sim_` symbols and the FAILCHK guard present in the shipped `db_int.h`.

## Honest correctness assessment

The fix targets the shared choke point every failchk sub-path routes through when it re-enters the library, so it is correct for all sub-paths that log (txn/dbreg/memp), not just dbreg. The DIAGNOSTIC `ENV_LEAVE` already asserted `THREAD_FAILCHK` was a legal state to leave in, so the invariant (a failchk thread may re-enter/leave while keeping its marker) matches the code's pre-existing expectations. A failchk thread is single and transient and runs while the env is being repaired, not under normal concurrency, so preserving its marker across nested enters is safe.

**Residual risk:** low. The only way the marker could leak is if a code path set `THREAD_FAILCHK` and then failed to reach `__env_failchk_pp`'s explicit clear -- but `FAILCHK_THREAD` has exactly one call site, immediately followed by `__env_failchk_int` + the clear + `ENV_LEAVE` in the same function with no early return between them. All recovery/txn/failchk regression tests are green.