### PR TITLE
fix(windows): regenerate stale build_windows headers (fixes MSVC build)

### DIFF
--- a/build_windows/clib_port.h
+++ b/build_windows/clib_port.h
@@ -89,10 +89,10 @@
  * File modes.
  */
 #ifdef DB_WIN32
-#ifndef S_IREAD				/* WinCE doesn't have S_IREAD. */
+#ifndef S_IREAD
 #define	S_IREAD		0
 #endif
-#ifndef S_IWRITE			/* WinCE doesn't have S_IWRITE. */
+#ifndef S_IWRITE
 #define	S_IWRITE	0
 #endif
 #ifndef	S_IRUSR

--- a/build_windows/db.h
+++ b/build_windows/db.h
@@ -61,9 +61,9 @@ extern "C" {
 #define	DB_VERSION_RELEASE	2
 #define	DB_VERSION_MAJOR	5
 #define	DB_VERSION_MINOR	3
-#define	DB_VERSION_PATCH	29
-#define	DB_VERSION_STRING	"Berkeley DB 5.3.29: (September  9, 2013)"
-#define	DB_VERSION_FULL_STRING	"Berkeley DB 11g Release 2, library version 11.2.5.3.29: (September  9, 2013)"
+#define	DB_VERSION_PATCH	33
+#define	DB_VERSION_STRING	"Berkeley DB 5.3.33: (July 31, 2026)"
+#define	DB_VERSION_FULL_STRING	"Berkeley DB 11g Release 2, library version 11.2.5.3.33: (July 31, 2026)"
 
 /*
  * !!!
@@ -2451,6 +2451,7 @@ struct __db_env {
 #define	DB_ENV_YIELDCPU		0x00020000 /* DB_YIELDCPU set */
 #define DB_ENV_HOTBACKUP	0x00040000 /* DB_HOTBACKUP_IN_PROGRESS set */
 #define DB_ENV_NOFLUSH		0x00080000 /* DB_NOFLUSH set */
+#define	DB_ENV_MPOOL_AIO	0x00100000 /* DB_MPOOL_AIO set */
 	u_int32_t flags;
 
 	/* DB_ENV PUBLIC HANDLE LIST BEGIN */
@@ -2933,6 +2934,7 @@ typedef struct entry {
 #define	DB_LOG_VERIFY_WARNING			0x00000080
 #define	DB_LOG_WRNOSYNC				0x00000020
 #define	DB_LOG_ZERO				0x00000010
+#define	DB_MPOOL_AIO				0x00100000
 #define	DB_MPOOL_CREATE				0x00000001
 #define	DB_MPOOL_DIRTY				0x00000002
 #define	DB_MPOOL_DISCARD			0x00000001
@@ -3043,9 +3045,9 @@ typedef struct entry {
 #define	DB_TXN_NOT_DURABLE			0x00000004
 #define	DB_TXN_NOWAIT				0x00000002
 #define	DB_TXN_SNAPSHOT				0x00000004
-#define	DB_TXN_SNAPSHOT_SAFE			0x00000080
+#define	DB_TXN_SNAPSHOT_SAFE			0x00000800
 #define	DB_TXN_SYNC				0x00000008
-#define	DB_TXN_WAIT				0x00000100
+#define	DB_TXN_WAIT				0x00000080
 #define	DB_TXN_WRITE_NOSYNC			0x00000020
 #define	DB_UNREF				0x00020000
 #define	DB_UPGRADE				0x00000001
@@ -3113,7 +3115,7 @@ int db_env_create __P((DB_ENV **, u_int32_t));
 char *db_version __P((int *, int *, int *));
 char *db_full_version __P((int *, int *, int *, int *, int *));
 int log_compare __P((const DB_LSN *, const DB_LSN *));
-#if defined(DB_WIN32) && !defined(DB_WINCE)
+#if defined(DB_WIN32)
 int db_env_set_win_security __P((SECURITY_ATTRIBUTES *sa));
 #endif
 int db_sequence_create __P((DB_SEQUENCE **, DB *, u_int32_t));

--- a/build_windows/db_config.h
+++ b/build_windows/db_config.h
@@ -334,9 +334,6 @@
 /* Define to 1 to use VMS mutexes. */
 /* #undef HAVE_MUTEX_VMS */
 
-/* Define to 1 to use VxWorks mutexes. */
-/* #undef HAVE_MUTEX_VXWORKS */
-
 /* Define to 1 to use the MSVC compiler and Windows mutexes. */
 #define HAVE_MUTEX_WIN32 1
 
@@ -567,9 +564,6 @@
 /* Define to 1 if you have the `vsnprintf' function. */
 #define HAVE_VSNPRINTF 1
 
-/* Define to 1 if building VxWorks. */
-/* #undef HAVE_VXWORKS */
-
 /* Define to 1 if you have the `yield' function. */
 /* #undef HAVE_YIELD */
 
@@ -586,16 +580,16 @@
 #define PACKAGE_NAME "Berkeley DB"
 
 /* Define to the full name and version of this package. */
-#define PACKAGE_STRING "Berkeley DB 5.3.29"
+#define PACKAGE_STRING "Berkeley DB 5.3.33"
 
 /* Define to the one symbol short name of this package. */
-#define PACKAGE_TARNAME "db-5.3.29"
+#define PACKAGE_TARNAME "db-5.3.33"
 
 /* Define to the home page for this package. */
 #define PACKAGE_URL "http://www.oracle.com/technology/software/products/berkeley-db/index.html"
 
 /* Define to the version of this package. */
-#define PACKAGE_VERSION "5.3.29"
+#define PACKAGE_VERSION "5.3.33"
 
 /* The size of a `char', as computed by sizeof. */
 /* #undef SIZEOF_CHAR */

--- a/build_windows/db_int.h
+++ b/build_windows/db_int.h
@@ -24,9 +24,6 @@
 #ifdef HAVE_SYS_SELECT_H
 #include <sys/select.h>
 #endif
-#ifdef HAVE_VXWORKS
-#include <selectLib.h>
-#endif
 #endif
 
 #if TIME_WITH_SYS_TIME
@@ -40,11 +37,7 @@
 #endif
 #endif
 
-#ifdef HAVE_VXWORKS
-#include <net/uio.h>
-#else
 #include <sys/uio.h>
-#endif
 
 #if defined(HAVE_REPLICATION_THREADS)
 #ifdef HAVE_SYS_SOCKET_H
@@ -644,12 +637,13 @@ typedef enum {
 	if ((ip) != NULL) {						\
 		DB_ASSERT(env, ((ip)->dbth_state == THREAD_ACTIVE  ||	\
 		    (ip)->dbth_state == THREAD_FAILCHK));		\
-		(ip)->dbth_state = THREAD_OUT;				\
+		if ((ip)->dbth_state != THREAD_FAILCHK)			\
+			(ip)->dbth_state = THREAD_OUT;			\
 	}								\
 } while (0)
 #else
 #define	ENV_LEAVE(env, ip) do {						\
-	if ((ip) != NULL)						\
+	if ((ip) != NULL && (ip)->dbth_state != THREAD_FAILCHK)		\
 		(ip)->dbth_state = THREAD_OUT;				\
 } while (0)
 #endif

--- a/build_windows/libdb.rc
+++ b/build_windows/libdb.rc
@@ -1,6 +1,6 @@
 1 VERSIONINFO
- FILEVERSION 5,0,3,29
- PRODUCTVERSION 5,0,3,29
+ FILEVERSION 5,0,3,33
+ PRODUCTVERSION 5,0,3,33
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -18,5 +18,16 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "Oracle\0"
             VALUE "FileDescription", "Berkeley DB 5.3 DLL\0"
-            VALUE "FileVersion", "5.3.29\0"
+            VALUE "FileVersion", "5.3.33\0"
             VALUE "InternalName", "libdb53.dll\0"
+            VALUE "LegalCopyright", "Copyright © Oracle 1997, 2013\0"
+            VALUE "OriginalFilename", "libdb53.dll\0"
+            VALUE "ProductName", "Oracle libdb\0"
+            VALUE "ProductVersion", "5.3.33\0"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END


### PR DESCRIPTION
The committed Windows headers (`build_windows/*.h`) were frozen at **5.3.29 (2013)** and never regenerated as the tree evolved, so the MSVC build (`db.vcxproj`) failed with 7 errors:

- **C2065 `'DB_MPOOL_AIO' undeclared`** (`env_method.c`, `env_config.c`) — the AIO mpool flag added to `src/dbinc/db.in` + `api_flags` was missing from the frozen `build_windows/db.h`.
- **C2099 `initializer is not a constant`** — a knock-on of the undeclared `DB_MPOOL_AIO` used in the `EnvMap[]`/`ConfigMap[]` aggregate initializers.

Regenerated via `dist/s_windows` (the canonical generator), which also:
- syncs the version to 5.3.33 (was 5.3.29);
- corrects `DB_TXN_SNAPSHOT_SAFE` / `DB_TXN_WAIT` flag values (SSI work);
- picks up the failchk `THREAD_FAILCHK`-preservation fix in `db_int.h` (`ENV_LEAVE`, from #113);
- drops dead VxWorks/WinCE conditionals;
- refreshes `libdb.rc` version-info.

**No source changes** — purely the generated Windows headers catching up to the tree they mirror. The `windows msbuild` CI job on this PR validates the fix.