### PR TITLE
fix(atomic): make Windows/MSVC db build compile clean

### DIFF
--- a/build_windows/VS10/db.vcxproj
+++ b/build_windows/VS10/db.vcxproj
@@ -335,6 +335,7 @@
     <ClCompile Include="..\..\src\os\os_addrinfo.c"/>
     <ClCompile Include="..\..\src\os_windows\os_abs.c"/>
     <ClCompile Include="..\..\src\os\os_alloc.c"/>
+    <ClCompile Include="..\..\src\os\os_atomic.c"/>
     <ClCompile Include="..\..\src\os_windows\os_clock.c"/>
     <ClCompile Include="..\..\src\os_windows\os_config.c"/>
     <ClCompile Include="..\..\src\os_windows\os_cpu.c"/>

--- a/build_windows/VS10/db.vcxproj
+++ b/build_windows/VS10/db.vcxproj
@@ -336,6 +336,9 @@
     <ClCompile Include="..\..\src\os_windows\os_abs.c"/>
     <ClCompile Include="..\..\src\os\os_alloc.c"/>
     <ClCompile Include="..\..\src\os\os_atomic.c"/>
+    <ClCompile Include="..\..\src\os\os_aio.c"/>
+    <ClCompile Include="..\..\src\os\os_aio_iocp.c"/>
+    <ClCompile Include="..\..\src\os\os_aio_pool.c"/>
     <ClCompile Include="..\..\src\os_windows\os_clock.c"/>
     <ClCompile Include="..\..\src\os_windows\os_config.c"/>
     <ClCompile Include="..\..\src\os_windows\os_cpu.c"/>

--- a/build_windows/VS10/db_small.vcxproj
+++ b/build_windows/VS10/db_small.vcxproj
@@ -303,6 +303,7 @@
     <ClCompile Include="..\..\src\mutex\mut_win32.c"/>
     <ClCompile Include="..\..\src\os\os_abort.c"/>
     <ClCompile Include="..\..\src\os\os_alloc.c"/>
+    <ClCompile Include="..\..\src\os\os_atomic.c"/>
     <ClCompile Include="..\..\src\os\os_ctime.c"/>
     <ClCompile Include="..\..\src\os\os_pid.c"/>
     <ClCompile Include="..\..\src\os\os_root.c"/>

--- a/build_windows/VS10/db_small.vcxproj
+++ b/build_windows/VS10/db_small.vcxproj
@@ -304,6 +304,9 @@
     <ClCompile Include="..\..\src\os\os_abort.c"/>
     <ClCompile Include="..\..\src\os\os_alloc.c"/>
     <ClCompile Include="..\..\src\os\os_atomic.c"/>
+    <ClCompile Include="..\..\src\os\os_aio.c"/>
+    <ClCompile Include="..\..\src\os\os_aio_iocp.c"/>
+    <ClCompile Include="..\..\src\os\os_aio_pool.c"/>
     <ClCompile Include="..\..\src\os\os_ctime.c"/>
     <ClCompile Include="..\..\src\os\os_pid.c"/>
     <ClCompile Include="..\..\src\os\os_root.c"/>

--- a/build_windows/VS8/db.vcproj
+++ b/build_windows/VS8/db.vcproj
@@ -279,6 +279,7 @@
     <File RelativePath="..\..\src\os\os_addrinfo.c"/>
     <File RelativePath="..\..\src\os_windows\os_abs.c"/>
     <File RelativePath="..\..\src\os\os_alloc.c"/>
+    <File RelativePath="..\..\src\os\os_atomic.c"/>
     <File RelativePath="..\..\src\os_windows\os_clock.c"/>
     <File RelativePath="..\..\src\os_windows\os_config.c"/>
     <File RelativePath="..\..\src\os_windows\os_cpu.c"/>

--- a/build_windows/VS8/db.vcproj
+++ b/build_windows/VS8/db.vcproj
@@ -280,6 +280,9 @@
     <File RelativePath="..\..\src\os_windows\os_abs.c"/>
     <File RelativePath="..\..\src\os\os_alloc.c"/>
     <File RelativePath="..\..\src\os\os_atomic.c"/>
+    <File RelativePath="..\..\src\os\os_aio.c"/>
+    <File RelativePath="..\..\src\os\os_aio_iocp.c"/>
+    <File RelativePath="..\..\src\os\os_aio_pool.c"/>
     <File RelativePath="..\..\src\os_windows\os_clock.c"/>
     <File RelativePath="..\..\src\os_windows\os_config.c"/>
     <File RelativePath="..\..\src\os_windows\os_cpu.c"/>

--- a/build_windows/VS8/db_small.vcproj
+++ b/build_windows/VS8/db_small.vcproj
@@ -237,6 +237,9 @@
     <File RelativePath="..\..\src\os\os_abort.c"/>
     <File RelativePath="..\..\src\os\os_alloc.c"/>
     <File RelativePath="..\..\src\os\os_atomic.c"/>
+    <File RelativePath="..\..\src\os\os_aio.c"/>
+    <File RelativePath="..\..\src\os\os_aio_iocp.c"/>
+    <File RelativePath="..\..\src\os\os_aio_pool.c"/>
     <File RelativePath="..\..\src\os\os_ctime.c"/>
     <File RelativePath="..\..\src\os\os_pid.c"/>
     <File RelativePath="..\..\src\os\os_root.c"/>

--- a/build_windows/VS8/db_small.vcproj
+++ b/build_windows/VS8/db_small.vcproj
@@ -236,6 +236,7 @@
     <File RelativePath="..\..\src\mutex\mut_win32.c"/>
     <File RelativePath="..\..\src\os\os_abort.c"/>
     <File RelativePath="..\..\src\os\os_alloc.c"/>
+    <File RelativePath="..\..\src\os\os_atomic.c"/>
     <File RelativePath="..\..\src\os\os_ctime.c"/>
     <File RelativePath="..\..\src\os\os_pid.c"/>
     <File RelativePath="..\..\src\os\os_root.c"/>

--- a/build_windows/db.h
+++ b/build_windows/db.h
@@ -2809,16 +2809,21 @@ typedef struct {
  *
  * The global variables dbrdonly, dirf and pagf were not retained when 4BSD
  * replaced the dbm interface with ndbm, and are not supported here.
+ *
+ * These unprefixed 4BSD names (delete, fetch, firstkey, nextkey, store, ...)
+ * are C-only historic aliases: they collide with C++ keywords and standard
+ * library member names (e.g. std::atomic<>::store, which MSVC's <atomic>
+ * pulls into any C++ translation unit).  Suppress them for C++.
  */
+#if !defined(__cplusplus)
 #define	dbminit(a)	__db_dbm_init(a)
 #define	dbmclose	__db_dbm_close
-#if !defined(__cplusplus)
 #define	delete(a)	__db_dbm_delete(a)
-#endif
 #define	fetch(a)	__db_dbm_fetch(a)
 #define	firstkey	__db_dbm_firstkey
 #define	nextkey(a)	__db_dbm_nextkey(a)
 #define	store(a, b)	__db_dbm_store(a, b)
+#endif
 
 /*******************************************************
  * Hsearch historic interface.

--- a/src/dbinc/atomic.h
+++ b/src/dbinc/atomic.h
@@ -108,7 +108,16 @@ typedef struct {
  * Modification operations delegate to ENV-aware functions.
  */
 #define	atomic_read(p)		__os_atomic_read(p)
+/*
+ * atomic_init collides with the C++ <atomic> free function std::atomic_init
+ * (and C11 <stdatomic.h> atomic_init).  MSVC's C++ standard library pulls
+ * <atomic> into any C++ translation unit, and the macro would rewrite that
+ * declaration -> compile failure.  Berkeley DB only calls atomic_init() from
+ * C sources, so define the macro only for C.
+ */
+#if !defined(__cplusplus)
 #define	atomic_init(p, val)	__os_atomic_init((p), (val))
+#endif
 
 /*
  * atomic_read_relaxed: torn-read-free load with no ordering, for pure

--- a/src/dbinc/db.in
+++ b/src/dbinc/db.in
@@ -2778,16 +2778,21 @@ typedef struct {
  *
  * The global variables dbrdonly, dirf and pagf were not retained when 4BSD
  * replaced the dbm interface with ndbm, and are not supported here.
+ *
+ * These unprefixed 4BSD names (delete, fetch, firstkey, nextkey, store, ...)
+ * are C-only historic aliases: they collide with C++ keywords and standard
+ * library member names (e.g. std::atomic<>::store, which MSVC's <atomic>
+ * pulls into any C++ translation unit).  Suppress them for C++.
  */
+#if !defined(__cplusplus)
 #define	dbminit(a)	__db_dbm_init@DB_VERSION_UNIQUE_NAME@(a)
 #define	dbmclose	__db_dbm_close@DB_VERSION_UNIQUE_NAME@
-#if !defined(__cplusplus)
 #define	delete(a)	__db_dbm_delete@DB_VERSION_UNIQUE_NAME@(a)
-#endif
 #define	fetch(a)	__db_dbm_fetch@DB_VERSION_UNIQUE_NAME@(a)
 #define	firstkey	__db_dbm_firstkey@DB_VERSION_UNIQUE_NAME@
 #define	nextkey(a)	__db_dbm_nextkey@DB_VERSION_UNIQUE_NAME@(a)
 #define	store(a, b)	__db_dbm_store@DB_VERSION_UNIQUE_NAME@(a, b)
+#endif
 
 /*******************************************************
  * Hsearch historic interface.

--- a/src/os/os_atomic.c
+++ b/src/os/os_atomic.c
@@ -1896,6 +1896,15 @@ __os_atomic_thread_fence()
     !defined(HAVE_ATOMIC_SYNC_BUILTIN)
 
 /*
+ * The Interlocked* intrinsics take a `LONG volatile *`.  We cast the address
+ * of db_atomic_t::value to that type through `interlocked_val` (matching
+ * mut_win32.c); it was referenced here but never defined for this TU.
+ */
+#ifndef interlocked_val
+#define	interlocked_val		long volatile *
+#endif
+
+/*
  * __os_atomic_init --
  *	Initialize an atomic variable (Windows).
  *


### PR DESCRIPTION
## Problem

The `db` library fails to build under MSVC (GitHub `windows msbuild` CI). Investigation on a Windows/ARM64 host (MSVC 17 VS2022 + MSVC 18 VS2026) surfaced four real, independent Windows-build breaks in the atomics/AIO area.

### 1. `interlocked_val` undeclared in `os_atomic.c` (compile, C)
The Windows Interlocked tier casts `&db_atomic_t::value` to `LONG volatile *` through the `interlocked_val` macro, defined only in `src/mutex/mut_win32.c`. In `os_atomic.c` it was undeclared, so `(interlocked_val)(&p->value)` parsed as a *function call*:

```
os_atomic.c(1957): error C2065: 'interlocked_val': undeclared identifier
os_atomic.c(1957): error C2064: term does not evaluate to a function taking 0 arguments
```

### 2. macro collisions with MSVC C++ `<atomic>` (compile, C++)
`db.vcxproj` compiles `lang/cxx/*.cpp` as C++. MSVC's C++ standard library transitively pulls `<atomic>` into every C++ TU. Two Berkeley DB macros then rewrote standard-library identifiers *inside* `<atomic>`:

- `db.h`'s legacy 4BSD `dbm(3)` alias `#define store(a, b) ...` clobbered `std::_Atomic_storage<>::store` -> `C4003` / `C2059`.
- `dbinc/atomic.h`'s `#define atomic_init(p, val) ...` clobbered the `std::atomic_init` free-function template -> `C2059` / `C2086 redefinition of std::__os_atomic_init`.

### 3. `os_atomic.c` missing from the Windows projects (link)
The atomic implementations live in `os_atomic.c`, which is in the Unix `Makefile.in` but was never added to the Windows VS project files -> `LNK2019/LNK2001 unresolved external symbol __os_atomic_read/_inc/_dec/_cas/_init`.

### 4. `os_aio*` missing from the Windows projects (link)
Same class of gap: the async-I/O layer (`__os_aio_*` in `os_aio.c`, referenced by `mp_bh.c`/`mp_region.c`) was added to Unix but not to Windows -> `LNK2019 unresolved external symbol __os_aio_create/_submit/_reap/_destroy/_ctx_available`.

## Root cause

`store`/`fetch`/`firstkey`/`nextkey`/`dbminit`/`dbmclose`/`delete` are the historic **C-only** 4BSD `dbm` interface (`delete` was already `#if !defined(__cplusplus)`-guarded because it is a C++ keyword). `atomic_init` is the C11 / C++ `<atomic>` reserved spelling. Neither is ever called from C++ here. And `os_atomic.c` / `os_aio*.c` were added to the Unix build without updating the hand-maintained Windows project files.

## Fix

- `src/os/os_atomic.c`: define `interlocked_val` locally in the Windows tier (guarded, same self-contained pattern as `mut_win32.c`).
- `src/dbinc/db.in` (+ regenerated `build_windows/db.h` via `dist/s_windows`): wrap the whole unprefixed 4BSD `dbm` macro set in `#if !defined(__cplusplus)`, extending the existing `delete` precedent.
- `src/dbinc/atomic.h`: define the `atomic_init` compatibility macro only for C.
- `build_windows/VS10/{db,db_small}.vcxproj` and `build_windows/VS8/{db,db_small}.vcproj`: add `os_atomic.c` and the `os_aio.c` / `os_aio_iocp.c` / `os_aio_pool.c` sources (the latter two are empty TUs unless `HAVE_IOCP` / `HAVE_AIO_THREADPOOL` are configured), mirroring the Unix build.

No behavior change for C consumers; C++ TUs never used any of these macros.

## Validation

- **GitHub `windows msbuild` CI (x64, v143)**: green on the final commit.
- **MSVC 17 (VS2022) and MSVC 18 (VS2026)** on Windows/ARM64: `os_atomic.c` (`/TC`) and `cxx_db.cpp` (`/TP`) compile with 0 errors; a full manual compile+link of the `db` project sources produces `libdb.dll` with 0 unresolved externals (the `__os_atomic_*` and `__os_aio_*` symbols now resolve).
- **Linux autoconf default** (`../dist/configure && make`): clean.
- **Linux `--enable-cxx`**: clean (14 cxx objects — confirms no C++ path needs the guarded macros).
- **Meson/Ninja**: clean (274/274, links `libdb.so`).

Depends on the regenerated Windows headers from #114 (merged); rebased onto master so this PR is only the atomics/AIO Windows-build delta.