### PR TITLE
fix(hash): honor a custom comparator on legacy unsorted hash pages

### DIFF
--- a/src/hash/hash_page.c
+++ b/src/hash/hash_page.c
@@ -682,11 +682,15 @@ __ham_getindex_unsorted(dbc, p, key, match, indx)
 			break;
 		case H_KEYDATA:
 			if (t->h_compare != NULL) {
-				DB_INIT_DBT(pg_dbt,
-				    HKEYDATA_DATA(hk), key->size);
-				if (t->h_compare(
-				    dbp, key, &pg_dbt) != 0)
-					break;
+				/*
+				 * Compare against the stored key at its own
+				 * length -- as __ham_getindex_sorted does --
+				 * and record the result: a 0 return means the
+				 * keys are equal and the search is done.
+				 */
+				DB_INIT_DBT(pg_dbt, HKEYDATA_DATA(hk),
+				    LEN_HKEY(dbp, p, dbp->pgsize, i));
+				res = t->h_compare(dbp, key, &pg_dbt);
 			} else if (key->size ==
 			    LEN_HKEY(dbp, p, dbp->pgsize, i))
 				res = memcmp(key->data, HKEYDATA_DATA(hk),

--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -77,6 +77,27 @@ timeout, so they cannot hang:
     current db, because current off-page dups are already stored as a Recno
     tree (P_LRECNO/P_IRECNO), not a flat page chain. A genuine pre-3.1 fixture
     is required.
+- **Legacy unsorted-hash lookup with a custom comparator** —
+  `test/db/run_hash_unsorted_cmp.sh` builds `test/db/hash_unsorted_cmp.c`, the
+  regression test for issue #139. `__ham_getindex_unsorted`
+  (`src/hash/hash_page.c`) is the linear search over a pre-4.6
+  `P_HASH_UNSORTED` page; its `t->h_compare != NULL` inline-key branch was
+  never reached by any test, because the branch needs a legacy page **and** an
+  explicitly configured `DB->set_h_compare` at the same time (`test093` sets a
+  comparator but only over current-format sorted pages, which take
+  `__ham_getindex_sorted`; `run_upgrade.sh` reads legacy pages but never sets a
+  comparator). The branch called the comparator, dropped its result, and built
+  the stored-key DBT with the *search* key's length -- so an equal key was
+  reported absent (`DB->get` → `DB_NOTFOUND`, `DB_NOOVERWRITE` → success plus a
+  duplicate) and a search key that merely prefixed a stored key compared equal.
+  The driver manufactures its legacy fixture the same way `run_upgrade.sh`
+  does, without an old library or a committed blob: it creates a current-format
+  Hash db (small pages, inline + off-page keys), then rewrites each bucket
+  page's `PAGE.type` byte from `P_HASH` to `P_HASH_UNSORTED` and the metadata
+  version back to the 4.5.20 hash version 8 -- exactly what `__ham_getindex`
+  dispatches to the unsorted path. Every check runs twice, with and without the
+  comparator, so a failure is attributable to the comparator path and not to
+  the fixture.
 - **Async I/O backends (os_aio)** — `test/os/run_os_aio.sh` builds
   `test/os/os_aio_direct.c`, which links the internal libdb symbols and drives
   the async-I/O abstraction (`src/os/os_aio.c`) and its backends

--- a/test/coverage/full_run3_combined.sh
+++ b/test/coverage/full_run3_combined.sh
@@ -166,6 +166,7 @@ run_driver db_upgrade  "$R/test/db/run_upgrade.sh"
 run_driver os_aio      "$R/test/os/run_os_aio.sh"
 run_driver backup      "$R/test/backup/run_backup_direct.sh"
 run_driver recd_compact "$R/test/db/run_recd_compact.sh"
+run_driver hash_unsorted_cmp "$R/test/db/run_hash_unsorted_cmp.sh"
 log "  .gcda after C drivers: $(find .libs -name '*.gcda' | wc -l)"
 
 # COV_DEAD_REG: deadlock detector + DB_REGISTER (driver-per-test)

--- a/test/coverage/run_coverage.sh
+++ b/test/coverage/run_coverage.sh
@@ -347,6 +347,16 @@ if [ "${COV_BACKUP:-1}" = 1 ]; then
   else
     echo "FAIL recd_handlers (rc=$?)"; tail -5 /tmp/cov-recdhandlers.log
   fi
+  # Legacy P_HASH_UNSORTED lookup with a custom DB->set_h_compare: the
+  # h_compare branch of __ham_getindex_unsorted needs a pre-4.6 page AND an
+  # explicit comparator at the same time, which no Tcl test arranges
+  # (test093 sets a comparator over sorted pages; run_upgrade.sh reads legacy
+  # pages without one).  Regression gate for issue #139.
+  if sh "$root/test/db/run_hash_unsorted_cmp.sh" >/tmp/cov-hashunsorted.log 2>&1; then
+    echo "PASS hash_unsorted_cmp"
+  else
+    echo "FAIL hash_unsorted_cmp (rc=$?)"; tail -5 /tmp/cov-hashunsorted.log
+  fi
   echo "  .gcda files after backup/compact: $(find . -name '*.gcda' | wc -l)"
 fi
 

--- a/test/db/hash_unsorted_cmp.c
+++ b/test/db/hash_unsorted_cmp.c
@@ -1,0 +1,550 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * Copyright (c) 2026 Oracle and/or its affiliates.  All rights reserved.
+ *
+ * hash_unsorted_cmp.c --
+ *	Regression driver for the Hash lookup defect reported as
+ *	https://github.com/berkeleydb/libdb/issues/139:
+ *	__ham_getindex_unsorted() (src/hash/hash_page.c) called the
+ *	application's DB->set_h_compare comparator for an inline (H_KEYDATA)
+ *	key but discarded its result, so an equal key on a legacy
+ *	P_HASH_UNSORTED page was reported as absent.  DB->get returned
+ *	DB_NOTFOUND for a key that was present, and DB->put(DB_NOOVERWRITE)
+ *	returned success and stored a second record with identical key bytes
+ *	in a database where duplicates are disabled.
+ *
+ *	The defect needs three things at once, which is why it hid: a Hash
+ *	database with a page still in the pre-4.6 P_HASH_UNSORTED format (5.3
+ *	reads those without requiring DB->upgrade), an inline key on that
+ *	page, and an explicitly configured custom comparator (a new handle's
+ *	h_compare is NULL, so simply opening an old file is not enough).
+ *	Modern sorted pages take __ham_getindex_sorted, which does record its
+ *	comparison result.
+ *
+ * The legacy fixture is built synthetically -- no old library and no
+ * committed binary blob.  A P_HASH_UNSORTED page and a P_HASH page have
+ * identical byte layouts; the only difference is that P_HASH keeps its
+ * key/data pairs in comparison order, which is a *subset* of what
+ * P_HASH_UNSORTED allows.  So a current-format Hash file whose bucket pages
+ * have their PAGE.type byte (offset 25) rewritten from P_HASH (13) to
+ * P_HASH_UNSORTED (2), and whose metadata version (offset 16) is set back to
+ * the 4.5.20 hash version 8, is a legitimate legacy file: it is exactly what
+ * __ham_getindex dispatches to __ham_getindex_unsorted.  (This is the same
+ * technique test/db/run_upgrade.sh uses to build old-format fixtures.)
+ *
+ * Checks, each run with the comparator (trigger) and without it (control),
+ * so a failure is attributable to the comparator path and not the fixture:
+ *	1. DB->get of a stored inline key must succeed and return its value.
+ *	2. DB->get of a stored off-page key must succeed (the H_OFFPAGE
+ *	   branch next door, which passes &res to __db_moff, must stay right).
+ *	3. DB->put(DB_NOOVERWRITE) for a stored key must return DB_KEYEXIST
+ *	   and must not add a record.
+ *	4. A search key that merely PREFIXES a stored key, and one that
+ *	   EXTENDS it, must both be reported absent.  The old code built the
+ *	   stored-key DBT with the *search* key's length instead of the stored
+ *	   key's, so the comparator saw a truncated or over-long view of the
+ *	   page item: a prefix key compared equal (a false match returning
+ *	   another record's data), and an over-long key made the comparator
+ *	   read past the stored item.
+ * Before the fix, every "trigger" case failed; the controls passed.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "db.h"
+
+#define	HOME		"HASH_UNSORTED_TESTDIR"
+#define	PAGESIZE	512		/* Small pages: many bucket pages. */
+#define	NRECS		20
+#define	PAGE_TYPE_OFF	25		/* PAGE.type. */
+#define	META_VERSION_OFF 16		/* DBMETA.version. */
+#define	P_HASH_UNSORTED_T 2		/* Pre-4.6 hash page. */
+#define	P_HASH_T	13		/* Sorted hash page. */
+#define	HASH_VERSION_45	8		/* On-disk hash version of 4.5.20. */
+#define	BIGKEYLEN	200		/* > PAGESIZE/4 => off-page key. */
+#define	ALARM_SECS	120
+
+static int fails = 0;
+static unsigned long cmp_calls, cmp_equalities;
+
+#define	CHK0(call) do {							\
+	int _r = (call);						\
+	if (_r != 0) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s => %d (%s)\n",		\
+		    __FILE__, __LINE__, #call, _r, db_strerror(_r));	\
+		fails++;						\
+	}								\
+} while (0)
+
+#define	CHKEQ(got, want, what) do {					\
+	if ((got) != (want)) {						\
+		fprintf(stderr, "FAIL: %s:%d: %s: got %d, want %d\n",	\
+		    __FILE__, __LINE__, (what), (int)(got), (int)(want));\
+		fails++;						\
+	}								\
+} while (0)
+
+/*
+ * byte_compare --
+ *	The comparison Berkeley DB itself used before 4.6 introduced
+ *	DB->set_h_compare: unsigned byte order, shorter key first on a
+ *	common prefix.  DB->set_h_compare on an existing database requires
+ *	exactly this -- a comparator that reproduces the ordering the
+ *	database was created with.
+ */
+static int
+byte_compare(DB *dbp, const DBT *a, const DBT *b)
+{
+	size_t len;
+	int ret;
+
+	(void)dbp;
+	cmp_calls++;
+	len = a->size < b->size ? a->size : b->size;
+	if ((ret = memcmp(a->data, b->data, len)) == 0)
+		ret = a->size < b->size ? -1 : (a->size > b->size ? 1 : 0);
+	if (ret == 0)
+		cmp_equalities++;
+	return (ret);
+}
+
+static void
+inline_key(char *buf, int n)
+{
+	(void)snprintf(buf, 16, "acct%04d", n);
+}
+
+static void
+big_key(char *buf)
+{
+	memset(buf, 'K', BIGKEYLEN);
+	memcpy(buf, "offpage", 7);
+	buf[BIGKEYLEN] = '\0';
+}
+
+static void
+set_dbt(DBT *dbt, void *data, u_int32_t size)
+{
+	memset(dbt, 0, sizeof(*dbt));
+	dbt->data = data;
+	dbt->size = size;
+}
+
+/*
+ * open_db --
+ *	Open the Hash database, optionally configuring the comparator.
+ */
+static int
+open_db(DB **dbpp, const char *path, int custom, u_int32_t flags)
+{
+	DB *dbp;
+	int ret;
+
+	if ((ret = db_create(&dbp, NULL, 0)) != 0) {
+		fprintf(stderr, "db_create: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	if (custom && (ret = dbp->set_h_compare(dbp, byte_compare)) != 0) {
+		fprintf(stderr, "set_h_compare: %s\n", db_strerror(ret));
+		(void)dbp->close(dbp, 0);
+		return (ret);
+	}
+	if ((ret = dbp->open(dbp,
+	    NULL, path, NULL, DB_HASH, flags, 0644)) != 0) {
+		fprintf(stderr, "open %s: %s\n", path, db_strerror(ret));
+		(void)dbp->close(dbp, 0);
+		return (ret);
+	}
+	*dbpp = dbp;
+	return (0);
+}
+
+/*
+ * produce --
+ *	Build a current-format Hash database with inline and off-page keys.
+ */
+static int
+produce(const char *path)
+{
+	DB *dbp;
+	DBT key, data;
+	char kbuf[16], vbuf[32], bkbuf[BIGKEYLEN + 1];
+	int i;
+
+	(void)unlink(path);
+	if (db_create(&dbp, NULL, 0) != 0)
+		return (1);
+	CHK0(dbp->set_pagesize(dbp, PAGESIZE));
+	CHK0(dbp->open(dbp,
+	    NULL, path, NULL, DB_HASH, DB_CREATE | DB_EXCL, 0644));
+	for (i = 0; i < NRECS; i++) {
+		inline_key(kbuf, i);
+		(void)snprintf(vbuf, sizeof(vbuf), "balance=%d", 100 * i);
+		set_dbt(&key, kbuf, (u_int32_t)strlen(kbuf));
+		set_dbt(&data, vbuf, (u_int32_t)strlen(vbuf));
+		CHK0(dbp->put(dbp, NULL, &key, &data, 0));
+	}
+	big_key(bkbuf);
+	set_dbt(&key, bkbuf, (u_int32_t)BIGKEYLEN);
+	set_dbt(&data, "offpage-value", 13);
+	CHK0(dbp->put(dbp, NULL, &key, &data, 0));
+	CHK0(dbp->close(dbp, 0));
+	return (fails);
+}
+
+/*
+ * make_legacy --
+ *	Rewrite every sorted hash page into the pre-4.6 unsorted page type
+ *	and set the metadata version back to the 4.5.20 hash version.
+ *	Returns the number of pages converted, -1 on error.
+ */
+static int
+make_legacy(const char *path)
+{
+	struct stat sb;
+	off_t off;
+	u_int32_t pagesize, version;
+	int converted, fd;
+	u_int8_t type;
+
+	if ((fd = open(path, O_RDWR)) < 0) {
+		perror("open fixture");
+		return (-1);
+	}
+	if (fstat(fd, &sb) != 0) {
+		perror("fstat fixture");
+		(void)close(fd);
+		return (-1);
+	}
+	if (pread(fd, &pagesize, sizeof(pagesize), 20) !=
+	    (ssize_t)sizeof(pagesize) || pagesize == 0 ||
+	    sb.st_size % (off_t)pagesize != 0) {
+		fprintf(stderr, "fixture is not page aligned\n");
+		(void)close(fd);
+		return (-1);
+	}
+	version = HASH_VERSION_45;
+	if (pwrite(fd, &version, sizeof(version), META_VERSION_OFF) !=
+	    (ssize_t)sizeof(version)) {
+		perror("pwrite version");
+		(void)close(fd);
+		return (-1);
+	}
+	converted = 0;
+	for (off = 0; off < sb.st_size; off += (off_t)pagesize) {
+		if (pread(fd, &type, 1, off + PAGE_TYPE_OFF) != 1) {
+			perror("pread page type");
+			(void)close(fd);
+			return (-1);
+		}
+		if (type != P_HASH_T)
+			continue;
+		type = P_HASH_UNSORTED_T;
+		if (pwrite(fd, &type, 1, off + PAGE_TYPE_OFF) != 1) {
+			perror("pwrite page type");
+			(void)close(fd);
+			return (-1);
+		}
+		converted++;
+	}
+	if (close(fd) != 0) {
+		perror("close fixture");
+		return (-1);
+	}
+	return (converted);
+}
+
+/*
+ * count_unsorted --
+ *	How many P_HASH_UNSORTED pages does the file still hold?
+ */
+static int
+count_unsorted(const char *path)
+{
+	struct stat sb;
+	off_t off;
+	u_int32_t pagesize;
+	int count, fd;
+	u_int8_t type;
+
+	if ((fd = open(path, O_RDONLY)) < 0 || fstat(fd, &sb) != 0 ||
+	    pread(fd, &pagesize, sizeof(pagesize), 20) !=
+	    (ssize_t)sizeof(pagesize) || pagesize == 0) {
+		perror("inspect fixture");
+		if (fd >= 0)
+			(void)close(fd);
+		return (-1);
+	}
+	for (count = 0, off = 0; off < sb.st_size; off += (off_t)pagesize)
+		if (pread(fd, &type, 1, off + PAGE_TYPE_OFF) == 1 &&
+		    type == P_HASH_UNSORTED_T)
+			count++;
+	(void)close(fd);
+	return (count);
+}
+
+static int
+copy_file(const char *src, const char *dst)
+{
+	FILE *in, *out;
+	char buf[4096];
+	size_t n;
+
+	if ((in = fopen(src, "rb")) == NULL)
+		return (1);
+	if ((out = fopen(dst, "wb")) == NULL) {
+		(void)fclose(in);
+		return (1);
+	}
+	while ((n = fread(buf, 1, sizeof(buf), in)) > 0)
+		if (fwrite(buf, 1, n, out) != n) {
+			(void)fclose(in);
+			(void)fclose(out);
+			return (1);
+		}
+	(void)fclose(in);
+	return (fclose(out) != 0);
+}
+
+/*
+ * count_records --
+ *	Total records, and how many carry the target key bytes.  Read with
+ *	the built-in comparison so the count is independent of the code
+ *	under test.
+ */
+static void
+count_records(const char *path, int *records, int *dups)
+{
+	DB *dbp;
+	DBC *dbc;
+	DBT key, data;
+	char kbuf[16];
+	int ret;
+
+	*records = *dups = 0;
+	if (open_db(&dbp, path, 0, DB_RDONLY) != 0) {
+		fails++;
+		return;
+	}
+	CHK0(dbp->cursor(dbp, NULL, &dbc, 0));
+	inline_key(kbuf, 0);
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	while ((ret = dbc->get(dbc, &key, &data, DB_NEXT)) == 0) {
+		(*records)++;
+		if (key.size == strlen(kbuf) &&
+		    memcmp(key.data, kbuf, key.size) == 0)
+			(*dups)++;
+	}
+	if (ret != DB_NOTFOUND)
+		CHK0(ret);
+	CHK0(dbc->close(dbc));
+	CHK0(dbp->close(dbp, 0));
+}
+
+/*
+ * check_get --
+ *	DB->get must find a key that is on the legacy page.
+ */
+static void
+check_get(const char *path, int custom, int big)
+{
+	DB *dbp;
+	DBT key, data;
+	char kbuf[BIGKEYLEN + 1], vbuf[32];
+	const char *label;
+	u_int32_t ksize;
+	int ret;
+
+	label = custom ? "trigger" : "control";
+	cmp_calls = cmp_equalities = 0;
+	if (count_unsorted(path) < 1) {
+		fprintf(stderr,
+		    "FAIL: %s: no P_HASH_UNSORTED page left in %s\n",
+		    label, path);
+		fails++;
+		return;
+	}
+	if (open_db(&dbp, path, custom, DB_RDONLY) != 0) {
+		fails++;
+		return;
+	}
+	if (big) {
+		big_key(kbuf);
+		ksize = BIGKEYLEN;
+		(void)snprintf(vbuf, sizeof(vbuf), "offpage-value");
+	} else {
+		inline_key(kbuf, 0);
+		ksize = (u_int32_t)strlen(kbuf);
+		(void)snprintf(vbuf, sizeof(vbuf), "balance=0");
+	}
+	set_dbt(&key, kbuf, ksize);
+	memset(&data, 0, sizeof(data));
+	ret = dbp->get(dbp, NULL, &key, &data, 0);
+	printf("  get %s %s key: ret=%d (%s) cmp_calls=%lu equal=%lu\n",
+	    label, big ? "off-page" : "inline", ret,
+	    ret == 0 ? "success" : db_strerror(ret), cmp_calls,
+	    cmp_equalities);
+	CHKEQ(ret, 0, "DB->get of a stored key");
+	if (ret == 0 && (data.size != strlen(vbuf) ||
+	    memcmp(data.data, vbuf, data.size) != 0)) {
+		fprintf(stderr, "FAIL: %s: wrong value for stored key\n",
+		    label);
+		fails++;
+	}
+	if (custom && cmp_calls == 0) {
+		fprintf(stderr, "FAIL: %s: comparator was never called\n",
+		    label);
+		fails++;
+	}
+	CHK0(dbp->close(dbp, 0));
+}
+
+/*
+ * check_missing --
+ *	A key that is not stored must be reported absent.  "prefix" asks for
+ *	a proper prefix of a stored key, otherwise for a stored key with
+ *	extra bytes appended.  Both probe whether the stored-key DBT handed
+ *	to the comparator carries the stored item's real length.
+ */
+static void
+check_missing(const char *path, int custom, int prefix)
+{
+	DB *dbp;
+	DBT key, data;
+	char kbuf[32];
+	const char *label;
+	u_int32_t ksize;
+	int ret;
+
+	label = custom ? "trigger" : "control";
+	cmp_calls = cmp_equalities = 0;
+	if (open_db(&dbp, path, custom, DB_RDONLY) != 0) {
+		fails++;
+		return;
+	}
+	inline_key(kbuf, 0);			/* "acct0000" */
+	if (prefix)
+		ksize = 4;			/* "acct" */
+	else {
+		(void)strncat(kbuf, "XXXX", sizeof(kbuf) - strlen(kbuf) - 1);
+		ksize = (u_int32_t)strlen(kbuf);
+	}
+	set_dbt(&key, kbuf, ksize);
+	memset(&data, 0, sizeof(data));
+	ret = dbp->get(dbp, NULL, &key, &data, 0);
+	printf("  get %s %s key (%.*s): ret=%d (%s) cmp_calls=%lu equal=%lu\n",
+	    label, prefix ? "prefix-of-stored" : "extends-stored",
+	    (int)ksize, kbuf, ret,
+	    ret == 0 ? "success" : db_strerror(ret), cmp_calls,
+	    cmp_equalities);
+	CHKEQ(ret, DB_NOTFOUND, "DB->get of a key that is not stored");
+	CHK0(dbp->close(dbp, 0));
+}
+
+/*
+ * check_nooverwrite --
+ *	DB->put(DB_NOOVERWRITE) for a key that is present must return
+ *	DB_KEYEXIST and leave the record count alone.
+ */
+static void
+check_nooverwrite(const char *base, int custom)
+{
+	DB *dbp;
+	DBT key, data;
+	char path[256], kbuf[16];
+	const char *label;
+	int dups, records, ret;
+
+	label = custom ? "trigger" : "control";
+	(void)snprintf(path, sizeof(path), "%s/put_%s.db", HOME, label);
+	if (copy_file(base, path) != 0) {
+		fprintf(stderr, "FAIL: %s: cannot copy fixture\n", label);
+		fails++;
+		return;
+	}
+	cmp_calls = cmp_equalities = 0;
+	if (count_unsorted(path) < 1) {
+		fprintf(stderr,
+		    "FAIL: %s: no P_HASH_UNSORTED page in the copy\n", label);
+		fails++;
+		return;
+	}
+	if (open_db(&dbp, path, custom, 0) != 0) {
+		fails++;
+		return;
+	}
+	inline_key(kbuf, 0);
+	set_dbt(&key, kbuf, (u_int32_t)strlen(kbuf));
+	set_dbt(&data, "balance=999999", 14);
+	ret = dbp->put(dbp, NULL, &key, &data, DB_NOOVERWRITE);
+	CHK0(dbp->close(dbp, 0));
+	count_records(path, &records, &dups);
+	printf("  put(DB_NOOVERWRITE) %s: ret=%d (%s) records=%d "
+	    "with_target_key=%d cmp_calls=%lu equal=%lu\n", label, ret,
+	    ret == 0 ? "success" : db_strerror(ret), records, dups,
+	    cmp_calls, cmp_equalities);
+	CHKEQ(ret, DB_KEYEXIST, "DB->put(DB_NOOVERWRITE) over a live key");
+	CHKEQ(records, NRECS + 1, "record count after DB_NOOVERWRITE");
+	CHKEQ(dups, 1, "records carrying the target key");
+}
+
+int
+main(int argc, char *argv[])
+{
+	char base[256];
+	int converted;
+
+	(void)argc;
+	(void)argv;
+
+	(void)signal(SIGALRM, SIG_DFL);
+	(void)alarm(ALARM_SECS);
+
+	(void)mkdir(HOME, 0755);
+	(void)snprintf(base, sizeof(base), "%s/legacy.db", HOME);
+	(void)unlink(base);
+
+	if (produce(base) != 0) {
+		fprintf(stderr, "FAIL: could not build the base database\n");
+		return (EXIT_FAILURE);
+	}
+	if ((converted = make_legacy(base)) < 1) {
+		fprintf(stderr,
+		    "FAIL: no hash page converted to P_HASH_UNSORTED\n");
+		return (EXIT_FAILURE);
+	}
+	printf("legacy fixture: %s (%d page(s) -> P_HASH_UNSORTED, "
+	    "hash version %d)\n", base, converted, HASH_VERSION_45);
+
+	/* Controls first: they prove the fixture itself is sound. */
+	check_get(base, 0, 0);
+	check_get(base, 0, 1);
+	check_missing(base, 0, 1);
+	check_missing(base, 0, 0);
+	check_nooverwrite(base, 0);
+
+	/* Triggers: the same operations with a custom comparator. */
+	check_get(base, 1, 0);
+	check_get(base, 1, 1);
+	check_missing(base, 1, 1);
+	check_missing(base, 1, 0);
+	check_nooverwrite(base, 1);
+
+	if (fails != 0) {
+		fprintf(stderr,
+		    "hash_unsorted_cmp: %d check(s) FAILED\n", fails);
+		return (EXIT_FAILURE);
+	}
+	printf("hash_unsorted_cmp: PASS\n");
+	return (EXIT_SUCCESS);
+}

--- a/test/db/run_hash_unsorted_cmp.sh
+++ b/test/db/run_hash_unsorted_cmp.sh
@@ -1,0 +1,57 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_hash_unsorted_cmp.sh --
+#	Build and run hash_unsorted_cmp.c, the regression test for
+#	https://github.com/berkeleydb/libdb/issues/139 --
+#	__ham_getindex_unsorted() (src/hash/hash_page.c) called the
+#	application's DB->set_h_compare comparator for an inline key on a
+#	legacy P_HASH_UNSORTED page but dropped its result, so an equal key
+#	was reported as absent: DB->get returned DB_NOTFOUND for a key that
+#	was present and DB->put(DB_NOOVERWRITE) returned success and stored a
+#	second record with identical key bytes in a no-duplicates database.
+#
+#	The driver builds its own legacy fixture (no old library, no committed
+#	binary blob): it creates a current-format Hash database, then rewrites
+#	each bucket page's PAGE.type byte from P_HASH to P_HASH_UNSORTED and
+#	the metadata version back to the 4.5.20 hash version 8 -- the same
+#	technique test/db/run_upgrade.sh uses for its old-format fixtures.
+#	Each check runs twice, with and without the comparator, so a failure
+#	is attributable to the comparator path rather than to the fixture.
+#
+# Usage (from build_unix):
+#	sh ../test/db/run_hash_unsorted_cmp.sh
+#
+# Exits non-zero on failure or hang.
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/db/hash_unsorted_cmp.c}
+HOME_DIR=${HOME_DIR:-HASH_UNSORTED_TESTDIR}
+TIMEOUT=${TIMEOUT:-180}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+
+echo "Compiling hash_unsorted_cmp against $LIB"
+gcc -g -O1 ${CFLAGS:-} -I"$BUILD" "$SRC" "$LIB" \
+    -lpthread -Wl,-rpath,"$(cd "$BUILD/.libs" && pwd)" \
+    -o "$BUILD/hash_unsorted_cmp"
+
+rm -f "$HOME_DIR"/*.db 2>/dev/null || true
+mkdir -p "$HOME_DIR"
+
+echo "Running hash_unsorted_cmp (timeout ${TIMEOUT}s)"
+if timeout "$TIMEOUT" "$BUILD/hash_unsorted_cmp"; then
+	echo "run_hash_unsorted_cmp.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_hash_unsorted_cmp.sh: FAIL (rc=$rc)"
+	exit $rc
+fi


### PR DESCRIPTION
Fixes #139

## The defect

`__ham_getindex_unsorted()` (`src/hash/hash_page.c`) is the linear search over a pre-4.6 `P_HASH_UNSORTED` page, a format 5.3 still reads without requiring `DB->upgrade`. Its inline-key (`H_KEYDATA`) branch had **two** defects, and they masked each other:

```c
if (t->h_compare != NULL) {
        DB_INIT_DBT(pg_dbt, HKEYDATA_DATA(hk), key->size);
        if (t->h_compare(dbp, key, &pg_dbt) != 0)
                break;                  /* equal -> falls out, res untouched */
}
```

1. **The comparator's result was discarded.** `res` is initialized to 1 (not-equal). On equality the `if` is false and control reaches the trailing `break` without ever assigning `res = 0`, so the `if (res == 0) break;` after the switch never fires and `*match` is set to 1 (not found). `DB->get` returned `DB_NOTFOUND` for a key that was present, and `DB->put(DB_NOOVERWRITE)` returned success and stored a second record with identical key bytes although duplicates are disabled — silently breaking key uniqueness. (This is what the report describes.)

2. **The stored-key DBT carried the wrong length.** It was built with `key->size`, the length of the *search* key, not the length of the item on the page. The comparator therefore saw a truncated or over-long view of the stored key. Defect 1 was hiding this: applying only the reported one-line fix converts the false negative into a **false positive** — `DB->get("acct")` returns `acct0000`'s data, because "acct" compares equal against a 4-byte-truncated view of the stored key. An over-long search key also made the comparator read past the stored item. Both are demonstrated in the test evidence below.

The `memcmp` path was always correct: it length-checks first and assigns its result.

## The fix

```c
 		case H_KEYDATA:
 			if (t->h_compare != NULL) {
-				DB_INIT_DBT(pg_dbt,
-				    HKEYDATA_DATA(hk), key->size);
-				if (t->h_compare(
-				    dbp, key, &pg_dbt) != 0)
-					break;
+				DB_INIT_DBT(pg_dbt, HKEYDATA_DATA(hk),
+				    LEN_HKEY(dbp, p, dbp->pgsize, i));
+				res = t->h_compare(dbp, key, &pg_dbt);
 			} else if (key->size ==
```

This is the established idiom in the same file: `__ham_getindex_sorted`'s equivalent case does `itemlen = LEN_HKEYDATA(dbp, p, dbp->pgsize, indx); ... res = t->h_compare(dbp, key, &tmp_dbt);`, and the `H_OFFPAGE` case immediately above passes `t->h_compare` **and** `&res` through to `__db_moff`.

## Audit: every comparator call site in `src/hash/`

| Site | Verdict |
|---|---|
| `hash_page.c:679` `__ham_getindex_unsorted`, `H_OFFPAGE` | **OK.** Passes `&res` to `__db_moff`, which assigns `*cmpp` on every path including the `cmpfunc != NULL` one. Only reached when `tlen == key->size`; that is a length *pre-filter*, not a substitute for the comparator, and it is conservative for equality under the documented `set_h_compare` contract (a comparator for an existing db must reproduce the ordering it was built with, so different-length keys the built-in call unequal cannot be equal). Covered by a positive check in the new test. |
| `hash_page.c:693` `__ham_getindex_unsorted`, `H_KEYDATA` | **THE BUG. Fixed here.** |
| `hash_page.c:787` `__ham_getindex_sorted`, case 1 (offpage/offpage) | **OK.** `__db_coff(..., t->h_compare, &res)`; the short-circuit above it (`koff_pgno == off_pgno → res = 0`) is same-page identity, correct. |
| `hash_page.c:795` `__ham_getindex_sorted`, case 2 (offpage key, on-page probe) | **OK.** `__db_moff(..., &res)`. |
| `hash_page.c:810` `__ham_getindex_sorted`, case 3 (on-page key, offpage probe) | **OK.** `__db_moff(..., &res)`, then `res = -res` because the arguments were swapped. |
| `hash_page.c:821` `__ham_getindex_sorted`, case 4 (on-page/on-page) | **OK, and the model for the fix.** `itemlen = LEN_HKEYDATA(...)`, then `res = t->h_compare(dbp, key, &tmp_dbt)` — the true stored length, result captured. |
| `hash_page.c:882`–`922` `__ham_verify_sorted_page` | **OK / not applicable.** Returns early (line 882) when `t->h_compare != NULL` — sort order under a user comparator is deliberately not verified — so the three `__db_coff`/`__db_moff` calls below only ever run with `cmpfunc == NULL`. All three pass `&res` anyway. |
| `hash.c:1548` `__ham_lookup` `DB_GET_BOTH`, off-page data | **OK.** `__db_moff(..., dbp->dup_compare, &cmp)`, then `cmp = -cmp` for the swapped arguments; `cmp` is tested. This is `dup_compare` (data), not `h_compare`. |
| `hash.c:1559-1561` same, on-page data | **OK.** `cmp = ... dup_compare(...)` — result assigned and tested. |
| `hash.c:1767`, `hash.c:1812` `__ham_overwrite` sort-order guards | **OK by design.** These are *assertions*, not searches: a non-zero result means the caller is corrupting the dup sort order, and the non-zero case is the one handled (`__db_duperr` / `EINVAL`). Nothing depends on recording equality; equality is the pass case. |
| `hash_dup.c:174` | **OK.** Reads `cmp` set by `__ham_dsearch` (below). |
| `hash_dup.c:780`,`800` `__ham_dsearch` | **OK.** `*cmpp = func(dbp, dbt, &cur)` on every iteration, and `func` falls back to `__bam_defcmp` when `dup_compare` is NULL, so `*cmpp` is always written. |
| `hash_dup.c:281`,`842`, `hash_open.c:220`-`305` | **Not comparisons** — `dup_compare == NULL` used as a "sorted dups?" predicate to pick a page type / set `DB_AM_DUPSORT`. Correct as written. |
| `hash_verify.c:1137` `__ham_dups_unsorted` | **OK.** `func(...) > 0` is the whole decision (is this dup set out of order?); the boolean is the result. |

**Verdict: `__ham_getindex_unsorted`'s `H_KEYDATA` branch was the only site that dropped a comparison result.** It is also the only site that built a comparison DBT from the search key's length instead of the stored item's.

## Regression test

`test/db/hash_unsorted_cmp.c` + `test/db/run_hash_unsorted_cmp.sh`.

The branch needs a legacy `P_HASH_UNSORTED` page **and** an explicit `DB->set_h_compare` *at the same time*, which is why nothing caught it: `test093` sets a comparator but only over current-format sorted pages (→ `__ham_getindex_sorted`), and `run_upgrade.sh` reads legacy pages but never sets a comparator.

**Fixture, built synthetically — no old library, no committed binary blob.** Approach (a) from the report, using the technique `test/db/run_upgrade.sh` already uses for old-format fixtures. A `P_HASH_UNSORTED` page and a `P_HASH` page have identical byte layouts; `P_HASH` merely *additionally* keeps its pairs in comparison order, which is a subset of what `P_HASH_UNSORTED` permits. So the driver creates a current-format Hash db (512-byte pages, 20 inline keys + one 200-byte off-page key → 2 bucket pages), then rewrites each bucket page's `PAGE.type` byte (offset 25) from `P_HASH` (13) to `P_HASH_UNSORTED` (2) and the metadata version (offset 16) back to the 4.5.20 hash version 8. That file is exactly what `__ham_getindex` dispatches to `__ham_getindex_unsorted`. Deterministic and self-contained.

Every check runs twice, with the comparator (trigger) and without (control), so a failure is attributable to the comparator path and not to the fixture. The comparator is `byte_compare`, the comparison BDB itself used before 4.6 added `set_h_compare` — which is what the API docs require for an existing database.

**Before the fix** (`--enable-debug`):

```
FAIL: DB->get of a stored key: got -30988, want 0
FAIL: DB->put(DB_NOOVERWRITE) over a live key: got 0, want -30994
FAIL: record count after DB_NOOVERWRITE: got 22, want 21
FAIL: records carrying the target key: got 2, want 1
hash_unsorted_cmp: 4 check(s) FAILED
legacy fixture: HASH_UNSORTED_TESTDIR/legacy.db (2 page(s) -> P_HASH_UNSORTED, hash version 8)
  get control inline key: ret=0 (success) cmp_calls=0 equal=0
  get control off-page key: ret=0 (success) cmp_calls=0 equal=0
  get control prefix-of-stored key (acct): ret=-30988 (DB_NOTFOUND) cmp_calls=0 equal=0
  get control extends-stored key (acct0000XXXX): ret=-30988 (DB_NOTFOUND) cmp_calls=0 equal=0
  put(DB_NOOVERWRITE) control: ret=-30994 (DB_KEYEXIST) records=21 with_target_key=1
  get trigger inline key: ret=-30988 (DB_NOTFOUND) cmp_calls=10 equal=1     <-- false miss
  get trigger off-page key: ret=0 (success) cmp_calls=11 equal=1
  get trigger prefix-of-stored key (acct): ret=-30988 cmp_calls=10 equal=10 <-- 10 bogus "equal"s, swallowed
  get trigger extends-stored key (acct0000XXXX): ret=-30988 cmp_calls=10 equal=0
  put(DB_NOOVERWRITE) trigger: ret=0 (success) records=22 with_target_key=2 <-- duplicate persisted
run_hash_unsorted_cmp.sh: FAIL (rc=1)
```

Note `equal=1` on the false miss (the comparator *did* report equality and it was dropped) and `equal=10` on the prefix probe (defect 2, invisible only because defect 1 discarded it).

**With only the reported one-line change** (`res = t->h_compare(...)`, still `key->size`) — this is why the fix is two changes, not one:

```
FAIL: DB->get of a key that is not stored: got 0, want -30988
  get control prefix-of-stored key (acct): ret=-30988 (DB_NOTFOUND) cmp_calls=0 equal=0
  get trigger prefix-of-stored key (acct): ret=0 (success) cmp_calls=1 equal=1   <-- FALSE POSITIVE
```

`DB->get("acct")` now returns `acct0000`'s data: a wrong-record read instead of a missed read.

**After the fix** (both `--enable-debug` and release):

```
legacy fixture: HASH_UNSORTED_TESTDIR/legacy.db (2 page(s) -> P_HASH_UNSORTED, hash version 8)
  get control inline key: ret=0 (success) cmp_calls=0 equal=0
  get control off-page key: ret=0 (success) cmp_calls=0 equal=0
  get control prefix-of-stored key (acct): ret=-30988 (DB_NOTFOUND) cmp_calls=0 equal=0
  get control extends-stored key (acct0000XXXX): ret=-30988 (DB_NOTFOUND) cmp_calls=0 equal=0
  put(DB_NOOVERWRITE) control: ret=-30994 (DB_KEYEXIST) records=21 with_target_key=1
  get trigger inline key: ret=0 (success) cmp_calls=1 equal=1
  get trigger off-page key: ret=0 (success) cmp_calls=11 equal=1
  get trigger prefix-of-stored key (acct): ret=-30988 (DB_NOTFOUND) cmp_calls=10 equal=0
  get trigger extends-stored key (acct0000XXXX): ret=-30988 (DB_NOTFOUND) cmp_calls=10 equal=0
  put(DB_NOOVERWRITE) trigger: ret=-30994 (DB_KEYEXIST) records=21 with_target_key=1
hash_unsorted_cmp: PASS
run_hash_unsorted_cmp.sh: PASS
```

`cmp_calls` also drops 10 → 1 on the successful lookup: the search now stops at the match instead of scanning the whole page.

## Validation

- **Builds clean, 0 errors**: `--enable-debug --enable-test --with-tcl=...` and a plain release build (`../dist/configure`). New test passes under both.
- **Tcl, hash**: `test001` `test003` `test011` `test093` (the existing `set_h_compare` test) — 0 failures. Plus `test006 test017 test024 test025 test029 test031 test032 test038 test039 test044 test046 test048 test051 hsearch` on hash — 0 failures.
- **Tcl, btree** (comparator path shares `__db_moff`/`__db_coff`): `test001` `test093` — 0 failures.
- **Fuzz gate**: `test/fuzz/check-crashes.sh` → **9/9 PASS** (includes the hash OOB seed), ASan-instrumented libdb.
- **`test/db/run_upgrade.sh`**: reaches a pre-existing failure at `h_v5.db` (`db_verify: BDB1101 Page 0: spares array entry 1 is invalid`). **Confirmed pre-existing and unrelated**: byte-identical output with this commit's `hash_page.c` reverted to master. Not touched here — the whole diff sits inside `if (t->h_compare != NULL)`, and `db_upgrade` never sets a comparator, so it is inert on that path.

Registered in the coverage harness (`test/coverage/run_coverage.sh`, `full_run3_combined.sh`) and documented in `test/coverage/README.md`.
