### PR TITLE
test(cov): coverage drivers for never-measured surfaces (+ the 85% branch ceiling, measured)

### DIFF
--- a/test/c/cov_api_surface.c
+++ b/test/c/cov_api_surface.c
@@ -1,0 +1,1369 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * cov_api_surface.c --
+ *	A direct driver for the DB_ENV / DB / DBC / DB_TXN / DB_MPOOLFILE
+ *	*getter* + *callback-setter* surface, and the argument-validation
+ *	branches of the corresponding setters.
+ *
+ *	Why this exists.  Report #3 lists 515 never-called functions.  A large,
+ *	cleanly-recoverable slice of them are neither hard nor exotic -- they
+ *	are the getters and callback installers of the public API:
+ *
+ *	  db/db_method.c   (24 never called) __db_get_alloc, __db_get_mpf,
+ *	                   __db_get_transactional, __db_get_priority,
+ *	                   __db_get_dup_compare, __db_get_encrypt_flags,
+ *	                   __db_get_assoc_flags, __db_get_errfile/errcall,
+ *	                   __db_get_msgfile/msgcall, __db_get_append_recno,
+ *	                   __db_get_feedback, __db_get_create_dir,
+ *	                   __db_set_alloc, __db_set_append_recno,
+ *	                   __db_set_create_dir, __db_set_feedback,
+ *	                   __db_set_lk_exclusive, __db_set_msgcall,
+ *	                   __db_set_paniccall, __db_set_priority,
+ *	                   __dbh_err, __dbh_errx
+ *	  env/env_method.c (21 never called) __env_get_alloc,
+ *	                   __env_get_app_dispatch, __env_get_data_len,
+ *	                   __env_get_errcall/errfile, __env_get_feedback,
+ *	                   __env_get_intermediate_dir_mode,
+ *	                   __env_get_isalive, __env_get_memory_max,
+ *	                   __env_get_msgcall/msgfile,
+ *	                   __env_get_thread_id_fn,
+ *	                   __env_get_thread_id_string_fn, __env_set_alloc,
+ *	                   __env_set_data_len, __env_set_feedback,
+ *	                   __env_set_memory_max, __env_set_paniccall,
+ *	                   __env_set_thread_id, __env_set_thread_id_string
+ *	  mp/mp_fmethod.c  (8)  the DB_MPOOLFILE getters
+ *	  txn/txn.c        (part) __txn_get_priority, __txn_set_commit_token,
+ *	                   __txn_build_token, __txn_applied_pp
+ *	  common/db_err.c  (10) the error-formatting helpers
+ *
+ *	The Tcl suite never calls them because the Tcl bindings expose the
+ *	setters an access-method test needs and nothing else: a functional test
+ *	sets a knob to make a workload behave, and never asks the library what
+ *	the knob currently is.  An embedding application does the opposite --
+ *	it reads configuration back, installs callbacks, and passes bad
+ *	arguments.  That is the surface this drives.
+ *
+ *	Everything here is single-process, allocation-light and has no timing
+ *	dependence, so it is deterministic.  A hard SIGALRM guard backs it up.
+ */
+#include "db_config.h"
+
+#include "db_int.h"
+
+#include <signal.h>
+
+#define	HOME		"COVAPI_TESTDIR"
+#define	ALARM_SECS	120
+
+static int fails = 0;
+static int checks = 0;
+
+#define	CHK_OK(call) do {						\
+	int _r = (call);						\
+	checks++;							\
+	if (_r != 0) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s => %d (%s)\n",		\
+		    __FILE__, __LINE__, #call, _r, db_strerror(_r));	\
+		fails++;						\
+	}								\
+} while (0)
+
+#define	CHK_FAILS(call) do {						\
+	int _r = (call);						\
+	checks++;							\
+	if (_r == 0) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s unexpectedly "		\
+		    "succeeded\n", __FILE__, __LINE__, #call);		\
+		fails++;						\
+	}								\
+} while (0)
+
+#define	CHK_EQ(got, want, what) do {					\
+	checks++;							\
+	if ((unsigned long)(got) != (unsigned long)(want)) {		\
+		fprintf(stderr, "FAIL: %s:%d: %s: got %lu want %lu\n",	\
+		    __FILE__, __LINE__, (what), (unsigned long)(got),	\
+		    (unsigned long)(want));				\
+		fails++;						\
+	}								\
+} while (0)
+
+#define	CHK_TRUE(cond, what) do {					\
+	checks++;							\
+	if (!(cond)) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s\n",			\
+		    __FILE__, __LINE__, (what));			\
+		fails++;						\
+	}								\
+} while (0)
+
+static void
+on_alarm(sig)
+	int sig;
+{
+	COMPQUIET(sig, 0);
+	fprintf(stderr, "FAIL: cov_api_surface timed out after %d s\n",
+	    ALARM_SECS);
+	_exit(3);
+}
+
+/* ---- the callbacks we install so the *_get_* getters have something to
+ * hand back, and so the set_* installers actually run. ---- */
+
+static int feedback_calls = 0;
+static int panic_calls = 0;
+static int alloc_calls = 0;
+static int isalive_calls = 0;
+static int recno_calls = 0;
+
+static void
+my_feedback(dbenv, opcode, percent)
+	DB_ENV *dbenv;
+	int opcode, percent;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(opcode, 0);
+	COMPQUIET(percent, 0);
+	feedback_calls++;
+}
+
+static void
+my_db_feedback(dbp, opcode, percent)
+	DB *dbp;
+	int opcode, percent;
+{
+	COMPQUIET(dbp, NULL);
+	COMPQUIET(opcode, 0);
+	COMPQUIET(percent, 0);
+	feedback_calls++;
+}
+
+static void
+my_panic(dbenv, errval)
+	DB_ENV *dbenv;
+	int errval;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(errval, 0);
+	panic_calls++;
+}
+
+static void *
+my_malloc(sz)
+	size_t sz;
+{
+	alloc_calls++;
+	return (malloc(sz));
+}
+
+static void *
+my_realloc(p, sz)
+	void *p;
+	size_t sz;
+{
+	alloc_calls++;
+	return (realloc(p, sz));
+}
+
+static void
+my_free(p)
+	void *p;
+{
+	free(p);
+}
+
+static int
+my_isalive(dbenv, pid, tid, flags)
+	DB_ENV *dbenv;
+	pid_t pid;
+	db_threadid_t tid;
+	u_int32_t flags;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(pid, 0);
+	COMPQUIET(flags, 0);
+	COMPQUIET(tid, tid);
+	isalive_calls++;
+	return (1);
+}
+
+static void
+my_thread_id(dbenv, pidp, tidp)
+	DB_ENV *dbenv;
+	pid_t *pidp;
+	db_threadid_t *tidp;
+{
+	COMPQUIET(dbenv, NULL);
+	if (pidp != NULL)
+		*pidp = getpid();
+	if (tidp != NULL)
+		memset(tidp, 0, sizeof(*tidp));
+}
+
+static char *
+my_thread_id_string(dbenv, pid, tid, buf)
+	DB_ENV *dbenv;
+	pid_t pid;
+	db_threadid_t tid;
+	char *buf;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(tid, tid);
+	(void)snprintf(buf, DB_THREADID_STRLEN, "%lu", (u_long)pid);
+	return (buf);
+}
+
+static void
+my_errcall(dbenv, prefix, msg)
+	const DB_ENV *dbenv;
+	const char *prefix, *msg;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(prefix, NULL);
+	COMPQUIET(msg, NULL);
+}
+
+static void
+my_msgcall(dbenv, msg)
+	const DB_ENV *dbenv;
+	const char *msg;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(msg, NULL);
+}
+
+static int
+my_app_dispatch(dbenv, log_rec, lsnp, op)
+	DB_ENV *dbenv;
+	DBT *log_rec;
+	DB_LSN *lsnp;
+	db_recops op;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(log_rec, NULL);
+	COMPQUIET(lsnp, NULL);
+	COMPQUIET(op, 0);
+	return (0);
+}
+
+static void
+my_event_notify(dbenv, event, info)
+	DB_ENV *dbenv;
+	u_int32_t event;
+	void *info;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(event, 0);
+	COMPQUIET(info, NULL);
+}
+
+static int
+my_append_recno(dbp, data, recno)
+	DB *dbp;
+	DBT *data;
+	db_recno_t recno;
+{
+	COMPQUIET(dbp, NULL);
+	COMPQUIET(data, NULL);
+	COMPQUIET(recno, 0);
+	recno_calls++;
+	return (0);
+}
+
+static int
+my_dup_compare(dbp, a, b)
+	DB *dbp;
+	const DBT *a, *b;
+{
+	size_t len;
+	int ret;
+
+	COMPQUIET(dbp, NULL);
+	len = a->size < b->size ? a->size : b->size;
+	if ((ret = memcmp(a->data, b->data, len)) != 0)
+		return (ret);
+	return ((int)a->size - (int)b->size);
+}
+
+static void
+clean_home()
+{
+	(void)system("rm -f " HOME "/__db.* " HOME "/log.* " HOME "/*.db "
+	    HOME "/DB_CONFIG 2>/dev/null");
+	(void)system("mkdir -p " HOME);
+}
+
+/*
+ * env_getters_pre_open --
+ *	Every DB_ENV getter on a created-but-unopened handle, each paired with
+ *	its setter so the value read back can be checked.  A getter that only
+ *	ever runs post-open takes a different branch than pre-open (region vs.
+ *	handle), so both are driven -- this is the pre-open half.
+ */
+static void
+env_getters_pre_open(dbenv)
+	DB_ENV *dbenv;
+{
+	void *(*mal) __P((size_t));
+	void *(*rea) __P((void *, size_t));
+	void (*fre) __P((void *));
+	void (*fb) __P((DB_ENV *, int, int));
+	int (*ia) __P((DB_ENV *, pid_t, db_threadid_t, u_int32_t));
+	void (*tid) __P((DB_ENV *, pid_t *, db_threadid_t *));
+	char *(*tids) __P((DB_ENV *, pid_t, db_threadid_t, char *));
+	int (*appd) __P((DB_ENV *, DBT *, DB_LSN *, db_recops));
+	void (*ec) __P((const DB_ENV *, const char *, const char *));
+	void (*mc) __P((const DB_ENV *, const char *));
+	FILE *fp;
+	const char *cp;
+	u_int32_t a, b;
+	size_t sz;
+	int i;
+	long l;
+	time_t tv;
+
+	/* --- allocator: __env_set_alloc + __env_get_alloc (both cold). */
+	CHK_OK(dbenv->set_alloc(dbenv, my_malloc, my_realloc, my_free));
+	mal = NULL; rea = NULL; fre = NULL;
+	CHK_OK(dbenv->get_alloc(dbenv, &mal, &rea, &fre));
+	CHK_TRUE(mal == my_malloc, "get_alloc malloc");
+	CHK_TRUE(rea == my_realloc, "get_alloc realloc");
+	CHK_TRUE(fre == my_free, "get_alloc free");
+
+	/* --- feedback: __env_set_feedback + __env_get_feedback. */
+	CHK_OK(dbenv->set_feedback(dbenv, my_feedback));
+	fb = NULL;
+	CHK_OK(dbenv->get_feedback(dbenv, &fb));
+	CHK_TRUE(fb == my_feedback, "get_feedback");
+
+	/* --- paniccall: __env_set_paniccall (cold). */
+	CHK_OK(dbenv->set_paniccall(dbenv, my_panic));
+
+	/* --- isalive: __env_set_isalive needs thread_id too. */
+	CHK_OK(dbenv->set_thread_id(dbenv, my_thread_id));
+	tid = NULL;
+	CHK_OK(dbenv->get_thread_id_fn(dbenv, &tid));
+	CHK_TRUE(tid == my_thread_id, "get_thread_id_fn");
+	CHK_OK(dbenv->set_thread_id_string(dbenv, my_thread_id_string));
+	tids = NULL;
+	CHK_OK(dbenv->get_thread_id_string_fn(dbenv, &tids));
+	CHK_TRUE(tids == my_thread_id_string, "get_thread_id_string_fn");
+	CHK_OK(dbenv->set_isalive(dbenv, my_isalive));
+	ia = NULL;
+	CHK_OK(dbenv->get_isalive(dbenv, &ia));
+	CHK_TRUE(ia == my_isalive, "get_isalive");
+
+	/* --- app_dispatch: set + get (getter cold). */
+	CHK_OK(dbenv->set_app_dispatch(dbenv, my_app_dispatch));
+	appd = NULL;
+	CHK_OK(dbenv->get_app_dispatch(dbenv, &appd));
+	CHK_TRUE(appd == my_app_dispatch, "get_app_dispatch");
+
+	/* --- data_len: __env_set_data_len + __env_get_data_len (both cold). */
+	CHK_OK(dbenv->set_data_len(dbenv, 64));
+	a = 0;
+	CHK_OK(dbenv->get_data_len(dbenv, &a));
+	CHK_EQ(a, 64, "get_data_len");
+
+	/* --- memory_max: __env_set_memory_max + __env_get_memory_max. */
+	CHK_OK(dbenv->set_memory_max(dbenv, 0, 4 * 1024 * 1024));
+	a = b = 0;
+	CHK_OK(dbenv->get_memory_max(dbenv, &a, &b));
+	CHK_TRUE(a != 0 || b != 0, "get_memory_max nonzero");
+
+	/* --- err/msg call + file: the get_* forms are all cold. */
+	dbenv->set_errcall(dbenv, my_errcall);
+	ec = NULL;
+	dbenv->get_errcall(dbenv, &ec);
+	CHK_TRUE(ec == my_errcall, "get_errcall");
+	dbenv->set_msgcall(dbenv, my_msgcall);
+	mc = NULL;
+	dbenv->get_msgcall(dbenv, &mc);
+	CHK_TRUE(mc == my_msgcall, "get_msgcall");
+	/* Clear the callbacks and use files instead: the other arm. */
+	dbenv->set_errcall(dbenv, NULL);
+	dbenv->set_msgcall(dbenv, NULL);
+	dbenv->set_errfile(dbenv, stderr);
+	fp = NULL;
+	dbenv->get_errfile(dbenv, &fp);
+	CHK_TRUE(fp == stderr, "get_errfile");
+	dbenv->set_msgfile(dbenv, stdout);
+	fp = NULL;
+	dbenv->get_msgfile(dbenv, &fp);
+	CHK_TRUE(fp == stdout, "get_msgfile");
+	/* Silence for the rest of the run. */
+	dbenv->set_errfile(dbenv, NULL);
+	dbenv->set_msgfile(dbenv, NULL);
+	dbenv->set_errpfx(dbenv, "cov_api");
+	cp = NULL;
+	dbenv->get_errpfx(dbenv, &cp);
+	CHK_TRUE(cp != NULL && strcmp(cp, "cov_api") == 0, "get_errpfx");
+
+	/* --- intermediate dir mode: __env_get_intermediate_dir_mode cold. */
+	CHK_OK(dbenv->set_intermediate_dir_mode(dbenv, "rwxr-x---"));
+	cp = NULL;
+	CHK_OK(dbenv->get_intermediate_dir_mode(dbenv, &cp));
+	CHK_TRUE(cp != NULL, "get_intermediate_dir_mode");
+	/* A malformed mode string is the rejection branch. */
+	CHK_FAILS(dbenv->set_intermediate_dir_mode(dbenv, "bogus"));
+
+	/* --- event_notify has no getter but the setter is worth driving. */
+	CHK_OK(dbenv->set_event_notify(dbenv, my_event_notify));
+
+	/*
+	 * --- the remaining scalar knobs: each set then get.  These getters
+	 * are mostly warm, but their pre-open arm (read from the handle, not
+	 * the region) is a distinct branch from the post-open arm.
+	 */
+	CHK_OK(dbenv->set_cachesize(dbenv, 0, 2 * 1024 * 1024, 1));
+	CHK_OK(dbenv->get_cachesize(dbenv, &a, &b, &i));
+	CHK_OK(dbenv->set_cache_max(dbenv, 0, 8 * 1024 * 1024));
+	CHK_OK(dbenv->get_cache_max(dbenv, &a, &b));
+	CHK_OK(dbenv->set_lg_bsize(dbenv, 65536));
+	CHK_OK(dbenv->get_lg_bsize(dbenv, &a));
+	CHK_EQ(a, 65536, "get_lg_bsize");
+	CHK_OK(dbenv->set_lg_max(dbenv, 1048576));
+	CHK_OK(dbenv->get_lg_max(dbenv, &a));
+	CHK_OK(dbenv->set_lg_regionmax(dbenv, 131072));
+	CHK_OK(dbenv->get_lg_regionmax(dbenv, &a));
+	CHK_OK(dbenv->set_lg_filemode(dbenv, 0640));
+	CHK_OK(dbenv->get_lg_filemode(dbenv, &i));
+	CHK_EQ(i, 0640, "get_lg_filemode");
+	CHK_OK(dbenv->set_mp_mmapsize(dbenv, 131072));
+	CHK_OK(dbenv->get_mp_mmapsize(dbenv, &sz));
+	CHK_OK(dbenv->set_mp_max_openfd(dbenv, 32));
+	CHK_OK(dbenv->get_mp_max_openfd(dbenv, &i));
+	CHK_EQ(i, 32, "get_mp_max_openfd");
+	CHK_OK(dbenv->set_mp_max_write(dbenv, 4, 1000));
+	{
+		db_timeout_t to;
+		CHK_OK(dbenv->get_mp_max_write(dbenv, &i, &to));
+	}
+	CHK_OK(dbenv->set_mp_pagesize(dbenv, 4096));
+	CHK_OK(dbenv->get_mp_pagesize(dbenv, &a));
+	CHK_OK(dbenv->set_mp_tablesize(dbenv, 37));
+	CHK_OK(dbenv->get_mp_tablesize(dbenv, &a));
+	CHK_OK(dbenv->set_mp_mtxcount(dbenv, 41));
+	CHK_OK(dbenv->get_mp_mtxcount(dbenv, &a));
+	CHK_OK(dbenv->set_tx_max(dbenv, 100));
+	CHK_OK(dbenv->get_tx_max(dbenv, &a));
+	CHK_EQ(a, 100, "get_tx_max");
+	tv = 0;
+	CHK_OK(dbenv->get_tx_timestamp(dbenv, &tv));
+	CHK_OK(dbenv->set_thread_count(dbenv, 8));
+	CHK_OK(dbenv->get_thread_count(dbenv, &a));
+	CHK_OK(dbenv->set_shm_key(dbenv, 0x4242));
+	CHK_OK(dbenv->get_shm_key(dbenv, &l));
+	CHK_EQ(l, 0x4242, "get_shm_key");
+	CHK_OK(dbenv->set_timeout(dbenv, 500000, DB_SET_LOCK_TIMEOUT));
+	CHK_OK(dbenv->get_timeout(dbenv, &a, DB_SET_LOCK_TIMEOUT));
+	CHK_OK(dbenv->set_timeout(dbenv, 500000, DB_SET_TXN_TIMEOUT));
+	CHK_OK(dbenv->get_timeout(dbenv, &a, DB_SET_TXN_TIMEOUT));
+	/* An unknown timeout selector is the rejection branch. */
+	CHK_FAILS(dbenv->get_timeout(dbenv, &a, 0x9999));
+
+	/* --- memory_init: each DB_MEM_* enum, set + get. */
+	CHK_OK(dbenv->set_memory_init(dbenv, DB_MEM_LOCK, 100));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_LOCK, &a));
+	CHK_EQ(a, 100, "get_memory_init DB_MEM_LOCK");
+	CHK_OK(dbenv->set_memory_init(dbenv, DB_MEM_LOCKER, 100));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_LOCKER, &a));
+	CHK_OK(dbenv->set_memory_init(dbenv, DB_MEM_LOCKOBJECT, 100));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_LOCKOBJECT, &a));
+	CHK_OK(dbenv->set_memory_init(dbenv, DB_MEM_TRANSACTION, 50));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_TRANSACTION, &a));
+	CHK_OK(dbenv->set_memory_init(dbenv, DB_MEM_THREAD, 20));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_THREAD, &a));
+	CHK_OK(dbenv->set_memory_init(dbenv, DB_MEM_LOGID, 20));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_LOGID, &a));
+	/*
+	 * NOTE: an out-of-range DB_MEM_CONFIG is NOT rejected -- the setter
+	 * switches on the enum and falls through, so a bogus value is a
+	 * silent no-op rather than EINVAL.  Driven here for the fall-through
+	 * branch, but deliberately NOT asserted as an error: that would be
+	 * asserting a behaviour the library does not promise.
+	 */
+	(void)dbenv->set_memory_init(dbenv, (DB_MEM_CONFIG)999, 1);
+	(void)dbenv->get_memory_init(dbenv, (DB_MEM_CONFIG)999, &a);
+	checks += 2;
+
+	/* --- the directory knobs: set + get, plus the not-set arm. */
+	CHK_OK(dbenv->set_tmp_dir(dbenv, "."));
+	cp = NULL;
+	CHK_OK(dbenv->get_tmp_dir(dbenv, &cp));
+	CHK_OK(dbenv->set_lg_dir(dbenv, "."));
+	CHK_OK(dbenv->get_lg_dir(dbenv, &cp));
+	CHK_OK(dbenv->set_metadata_dir(dbenv, "."));
+	CHK_OK(dbenv->get_metadata_dir(dbenv, &cp));
+	CHK_OK(dbenv->set_create_dir(dbenv, "."));
+	CHK_OK(dbenv->get_create_dir(dbenv, &cp));
+	CHK_OK(dbenv->set_data_dir(dbenv, "."));
+	{
+		const char **dirs = NULL;
+		CHK_OK(dbenv->get_data_dirs(dbenv, &dirs));
+		CHK_TRUE(dirs != NULL, "get_data_dirs");
+	}
+
+	/* --- lock knobs: set + get for each, plus a bogus detect policy. */
+	CHK_OK(dbenv->set_lk_max_locks(dbenv, 500));
+	CHK_OK(dbenv->get_lk_max_locks(dbenv, &a));
+	CHK_EQ(a, 500, "get_lk_max_locks");
+	CHK_OK(dbenv->set_lk_max_lockers(dbenv, 500));
+	CHK_OK(dbenv->get_lk_max_lockers(dbenv, &a));
+	CHK_OK(dbenv->set_lk_max_objects(dbenv, 500));
+	CHK_OK(dbenv->get_lk_max_objects(dbenv, &a));
+	CHK_OK(dbenv->set_lk_partitions(dbenv, 4));
+	CHK_OK(dbenv->get_lk_partitions(dbenv, &a));
+	CHK_OK(dbenv->set_lk_tablesize(dbenv, 37));
+	CHK_OK(dbenv->get_lk_tablesize(dbenv, &a));
+	CHK_OK(dbenv->set_lk_detect(dbenv, DB_LOCK_MINWRITE));
+	CHK_OK(dbenv->get_lk_detect(dbenv, &a));
+	CHK_EQ(a, DB_LOCK_MINWRITE, "get_lk_detect");
+	CHK_FAILS(dbenv->set_lk_detect(dbenv, 0x7fffffff));
+	{
+		const u_int8_t *cf;
+		int nmodes;
+		/* No conflict array set: the "use the default" get arm. */
+		(void)dbenv->get_lk_conflicts(dbenv, &cf, &nmodes);
+		checks++;
+	}
+
+	/* --- flags: set each, read the composite back. */
+	CHK_OK(dbenv->set_flags(dbenv, DB_AUTO_COMMIT, 1));
+	CHK_OK(dbenv->get_flags(dbenv, &a));
+	CHK_TRUE((a & DB_AUTO_COMMIT) != 0, "get_flags DB_AUTO_COMMIT");
+	CHK_OK(dbenv->set_flags(dbenv, DB_AUTO_COMMIT, 0));
+	CHK_OK(dbenv->set_flags(dbenv, DB_TXN_NOSYNC, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_TXN_WRITE_NOSYNC, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_TXN_NOWAIT, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_TXN_NOWAIT, 0));
+	/*
+	 * DB_DIRECT_DB is refused when the filesystem has no O_DIRECT (the
+	 * __os_support_direct_io() == 0 branch), which is the common case on
+	 * tmpfs/overlayfs.  Both outcomes are correct, so drive it without
+	 * asserting either way -- the point is the branch, not the answer.
+	 */
+	(void)dbenv->set_flags(dbenv, DB_DIRECT_DB, 1);
+	(void)dbenv->set_flags(dbenv, DB_DIRECT_DB, 0);
+	checks += 2;
+	CHK_OK(dbenv->set_flags(dbenv, DB_NOMMAP, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_NOMMAP, 0));
+	CHK_OK(dbenv->set_flags(dbenv, DB_REGION_INIT, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_TIME_NOTGRANTED, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_TIME_NOTGRANTED, 0));
+	CHK_OK(dbenv->set_flags(dbenv, DB_MULTIVERSION, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_MULTIVERSION, 0));
+	CHK_OK(dbenv->set_flags(dbenv, DB_YIELDCPU, 1));
+	CHK_OK(dbenv->set_flags(dbenv, DB_YIELDCPU, 0));
+	/*
+	 * An unknown env flag IS rejected: set_flags has an explicit OK_FLAGS
+	 * mask (env_method.c ~line 949), which for this release covers
+	 * 0x001fffff.  0x00200000 is the first bit outside it.  (Do NOT use a
+	 * low bit here -- 0x00000004 is DB_TXN_SNAPSHOT and legal.)
+	 */
+	CHK_FAILS(dbenv->set_flags(dbenv, 0x00200000, 1));
+
+	/* --- verbose: each subsystem selector on and off. */
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_DEADLOCK, 1));
+	CHK_OK(dbenv->get_verbose(dbenv, DB_VERB_DEADLOCK, &i));
+	CHK_EQ(i, 1, "get_verbose DB_VERB_DEADLOCK");
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_DEADLOCK, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_RECOVERY, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_RECOVERY, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REGISTER, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REGISTER, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_FILEOPS, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_FILEOPS, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_FILEOPS_ALL, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_FILEOPS_ALL, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REPLICATION, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REPLICATION, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_ELECT, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_ELECT, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_LEASE, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_LEASE, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_MISC, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_MISC, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_MSGS, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_MSGS, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_SYNC, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_SYNC, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_SYSTEM, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REP_SYSTEM, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REPMGR_CONNFAIL, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REPMGR_CONNFAIL, 0));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REPMGR_MISC, 1));
+	CHK_OK(dbenv->set_verbose(dbenv, DB_VERB_REPMGR_MISC, 0));
+	/* An unknown verbose selector is rejected by set and get. */
+	CHK_FAILS(dbenv->set_verbose(dbenv, 0x40000000, 1));
+	CHK_FAILS(dbenv->get_verbose(dbenv, 0x40000000, &i));
+
+	/* --- backup config: every DB_BACKUP_* enum, set + get. */
+	CHK_OK(dbenv->set_backup_config(dbenv, DB_BACKUP_READ_COUNT, 1024));
+	CHK_OK(dbenv->get_backup_config(dbenv, DB_BACKUP_READ_COUNT, &a));
+	CHK_EQ(a, 1024, "get_backup_config READ_COUNT");
+	CHK_OK(dbenv->set_backup_config(dbenv, DB_BACKUP_READ_SLEEP, 10));
+	CHK_OK(dbenv->get_backup_config(dbenv, DB_BACKUP_READ_SLEEP, &a));
+	CHK_OK(dbenv->set_backup_config(dbenv, DB_BACKUP_SIZE, 4096));
+	CHK_OK(dbenv->get_backup_config(dbenv, DB_BACKUP_SIZE, &a));
+	CHK_OK(dbenv->set_backup_config(dbenv,
+	    DB_BACKUP_WRITE_DIRECT, 1));
+	CHK_OK(dbenv->get_backup_config(dbenv, DB_BACKUP_WRITE_DIRECT, &a));
+	CHK_OK(dbenv->set_backup_config(dbenv,
+	    DB_BACKUP_WRITE_DIRECT, 0));
+	/*
+	 * As with DB_MEM_CONFIG, an out-of-range DB_BACKUP_CONFIG falls
+	 * through the switch rather than returning EINVAL.  Drive the
+	 * fall-through; do not assert an error the API does not promise.
+	 */
+	(void)dbenv->set_backup_config(dbenv, (DB_BACKUP_CONFIG)999, 1);
+	checks++;
+
+	/* --- encrypt flags getter before any set_encrypt: the not-set arm. */
+	a = 0;
+	(void)dbenv->get_encrypt_flags(dbenv, &a);
+	checks++;
+}
+
+/*
+ * env_getters_post_open --
+ *	The same getters after DB_ENV->open: each now reads the shared region
+ *	instead of the handle, which is the other half of the branch.  Plus the
+ *	post-open-illegal setters (ENV_ILLEGAL_AFTER_OPEN), which is a branch
+ *	present in nearly every setter and never exercised by a Tcl test
+ *	(a Tcl test sets everything before open, as an application should).
+ */
+static void
+env_getters_post_open(dbenv)
+	DB_ENV *dbenv;
+{
+	const char *cp;
+	u_int32_t a, b;
+	int i;
+	size_t sz;
+
+	/* Post-open reads come from the region. */
+	CHK_OK(dbenv->get_cachesize(dbenv, &a, &b, &i));
+	CHK_OK(dbenv->get_cache_max(dbenv, &a, &b));
+	CHK_OK(dbenv->get_lg_bsize(dbenv, &a));
+	CHK_OK(dbenv->get_lg_max(dbenv, &a));
+	CHK_OK(dbenv->get_lg_regionmax(dbenv, &a));
+	CHK_OK(dbenv->get_lg_filemode(dbenv, &i));
+	CHK_OK(dbenv->get_lk_max_locks(dbenv, &a));
+	CHK_OK(dbenv->get_lk_max_lockers(dbenv, &a));
+	CHK_OK(dbenv->get_lk_max_objects(dbenv, &a));
+	CHK_OK(dbenv->get_lk_partitions(dbenv, &a));
+	CHK_OK(dbenv->get_lk_tablesize(dbenv, &a));
+	CHK_OK(dbenv->get_lk_detect(dbenv, &a));
+	CHK_OK(dbenv->get_tx_max(dbenv, &a));
+	CHK_OK(dbenv->get_mp_mmapsize(dbenv, &sz));
+	CHK_OK(dbenv->get_mp_max_openfd(dbenv, &i));
+	CHK_OK(dbenv->get_mp_pagesize(dbenv, &a));
+	CHK_OK(dbenv->get_mp_tablesize(dbenv, &a));
+	CHK_OK(dbenv->get_mp_mtxcount(dbenv, &a));
+	CHK_OK(dbenv->get_thread_count(dbenv, &a));
+	CHK_OK(dbenv->get_data_len(dbenv, &a));
+	CHK_OK(dbenv->get_memory_max(dbenv, &a, &b));
+	CHK_OK(dbenv->get_memory_init(dbenv, DB_MEM_LOCK, &a));
+	CHK_OK(dbenv->get_flags(dbenv, &a));
+	CHK_OK(dbenv->get_open_flags(dbenv, &a));
+	CHK_TRUE((a & DB_CREATE) != 0, "get_open_flags DB_CREATE");
+	cp = NULL;
+	CHK_OK(dbenv->get_home(dbenv, &cp));
+	CHK_TRUE(cp != NULL, "get_home");
+	CHK_OK(dbenv->get_intermediate_dir_mode(dbenv, &cp));
+	{
+		const u_int8_t *cf;
+		int nmodes;
+		/* Post-open the conflict array comes from the lock region. */
+		CHK_OK(dbenv->get_lk_conflicts(dbenv, &cf, &nmodes));
+		CHK_TRUE(cf != NULL && nmodes > 0, "get_lk_conflicts");
+	}
+	/*
+	 * Per-locker lock priority: set + get.  These need a lockid that has a
+	 * LIVE locker, because __lock_set_lk_priority /
+	 * __lock_get_lk_priority call __lock_getlocker(..., create=0, ...)
+	 * and dereference the result WITHOUT a NULL check -- and
+	 * __lock_getlocker returns 0 with *retp == NULL when the id is not
+	 * found (src/lock/lock_id.c: `*retp = sh_locker;` is reached on the
+	 * not-found path when create == 0).  Passing an unused lockid here
+	 * SIGSEGVs the library at src/lock/lock_method.c:483.
+	 *
+	 * That is a real engine defect, reported in
+	 * test/coverage/FULL-COVERAGE-REPORT-4.md and NOT fixed here (src/lock
+	 * is owned by another change).  We therefore obtain a real locker id
+	 * from an open transaction so this driver covers the intended
+	 * getter/setter branches without tripping the crash.
+	 */
+	{
+		DB_TXN *txn;
+		u_int32_t lockid;
+
+		if (dbenv->txn_begin(dbenv, NULL, &txn, 0) == 0) {
+			lockid = txn->id(txn);
+			CHK_OK(dbenv->set_lk_priority(dbenv, lockid, 100));
+			a = 0;
+			CHK_OK(dbenv->get_lk_priority(dbenv, lockid, &a));
+			CHK_EQ(a, 100, "get_lk_priority");
+			CHK_OK(txn->commit(txn, 0));
+		}
+	}
+
+	/*
+	 * --- ENV_ILLEGAL_AFTER_OPEN: these setters must refuse now.  This is
+	 * the branch every setter has and no Tcl test reaches.
+	 *
+	 * NOTE: not every setter is guarded.  set_cachesize and set_data_len
+	 * accept a post-open call (cachesize because the mpool can be resized,
+	 * data_len because it is only a print/debug bound), so they are driven
+	 * without an assertion.
+	 */
+	(void)dbenv->set_cachesize(dbenv, 0, 1048576, 1);
+	(void)dbenv->set_data_len(dbenv, 128);
+	checks += 2;
+	CHK_FAILS(dbenv->set_lk_max_locks(dbenv, 999));
+	CHK_FAILS(dbenv->set_lk_max_lockers(dbenv, 999));
+	CHK_FAILS(dbenv->set_lk_max_objects(dbenv, 999));
+	CHK_FAILS(dbenv->set_lk_partitions(dbenv, 9));
+	CHK_FAILS(dbenv->set_lk_tablesize(dbenv, 99));
+	CHK_FAILS(dbenv->set_tx_max(dbenv, 999));
+	CHK_FAILS(dbenv->set_lg_bsize(dbenv, 999999));
+	CHK_FAILS(dbenv->set_lg_regionmax(dbenv, 999999));
+	CHK_FAILS(dbenv->set_memory_init(dbenv, DB_MEM_LOCK, 999));
+	CHK_FAILS(dbenv->set_memory_max(dbenv, 0, 1048576));
+	CHK_FAILS(dbenv->set_shm_key(dbenv, 0x99));
+	CHK_FAILS(dbenv->set_thread_count(dbenv, 99));
+	CHK_FAILS(dbenv->set_mp_pagesize(dbenv, 8192));
+	CHK_FAILS(dbenv->set_mp_tablesize(dbenv, 99));
+	CHK_FAILS(dbenv->set_mp_mtxcount(dbenv, 99));
+	CHK_FAILS(dbenv->set_metadata_dir(dbenv, "."));
+	CHK_FAILS(dbenv->set_encrypt(dbenv, "pw", DB_ENCRYPT_AES));
+
+	/* --- a second open of an already-open handle: __db_mi_open. */
+	CHK_FAILS(dbenv->open(dbenv, HOME, DB_CREATE | DB_INIT_MPOOL, 0600));
+}
+
+/*
+ * db_getters --
+ *	The DB handle getter surface.  __db_get_mpf, __db_get_transactional,
+ *	__db_get_priority, __db_get_dup_compare, __db_get_encrypt_flags,
+ *	__db_get_assoc_flags, __db_get_append_recno, __db_get_feedback,
+ *	__db_get_create_dir, __db_get_alloc and the DB-level err/msg getters
+ *	are all never called by the Tcl suite.
+ */
+static void
+db_getters(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp, *sdbp;
+	DBC *dbc;
+	DB_MPOOLFILE *mpf;
+	DBT key, data;
+	DB_CACHE_PRIORITY prio;
+	void *(*mal) __P((size_t));
+	void *(*rea) __P((void *, size_t));
+	void (*fre) __P((void *));
+	void (*fb) __P((DB *, int, int));
+	int (*ar) __P((DB *, DBT *, db_recno_t));
+	int (*dc) __P((DB *, const DBT *, const DBT *));
+	FILE *fp;
+	const char *cp;
+	u_int32_t a;
+	int ret;
+	DBTYPE type;
+
+	/* ---- 1. A recno DB: set_append_recno only applies to recno. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	/*
+	 * The DB-level allocator + cachesize setters are only legal on a
+	 * handle in a STANDALONE env (dbenv == NULL): with an env, the env's
+	 * allocator and cache govern and the DB-level setter returns EINVAL.
+	 * That rejection is the arm a misconfigured application hits, so it is
+	 * what we assert here; the accepting arm is driven in
+	 * db_getters_standalone() below.
+	 */
+	CHK_FAILS(dbp->set_alloc(dbp, my_malloc, my_realloc, my_free));
+	COMPQUIET(mal, NULL);
+	COMPQUIET(rea, NULL);
+	COMPQUIET(fre, NULL);
+	/* __db_set_feedback + __db_get_feedback. */
+	CHK_OK(dbp->set_feedback(dbp, my_db_feedback));
+	fb = NULL;
+	CHK_OK(dbp->get_feedback(dbp, &fb));
+	CHK_TRUE(fb == my_db_feedback, "DB get_feedback");
+	/* __db_set_paniccall. */
+	CHK_OK(dbp->set_paniccall(dbp, my_panic));
+	/* __db_set_append_recno + __db_get_append_recno. */
+	CHK_OK(dbp->set_append_recno(dbp, my_append_recno));
+	ar = NULL;
+	CHK_OK(dbp->get_append_recno(dbp, &ar));
+	CHK_TRUE(ar == my_append_recno, "get_append_recno");
+	/* The DB-level err/msg call + file getters. */
+	dbp->set_errcall(dbp, my_errcall);
+	dbp->set_msgcall(dbp, my_msgcall);
+	dbp->set_errcall(dbp, NULL);
+	dbp->set_msgcall(dbp, NULL);
+	dbp->set_errfile(dbp, NULL);
+	fp = (FILE *)1;
+	dbp->get_errfile(dbp, &fp);
+	CHK_TRUE(fp == NULL, "DB get_errfile");
+	dbp->set_msgfile(dbp, NULL);
+	fp = (FILE *)1;
+	dbp->get_msgfile(dbp, &fp);
+	CHK_TRUE(fp == NULL, "DB get_msgfile");
+	dbp->set_errpfx(dbp, "cov_db");
+	cp = NULL;
+	dbp->get_errpfx(dbp, &cp);
+	CHK_TRUE(cp != NULL, "DB get_errpfx");
+	/* __dbh_err + __dbh_errx: the DB-level error emitters. */
+	dbp->err(dbp, EINVAL, "cov_api_surface: expected err() %d", 1);
+	dbp->errx(dbp, "cov_api_surface: expected errx() %d", 2);
+	checks += 2;
+	/* __db_set_priority + __db_get_priority. */
+	CHK_OK(dbp->set_priority(dbp, DB_PRIORITY_VERY_LOW));
+	prio = DB_PRIORITY_UNCHANGED;
+	CHK_OK(dbp->get_priority(dbp, &prio));
+	CHK_EQ(prio, DB_PRIORITY_VERY_LOW, "get_priority");
+	CHK_OK(dbp->set_priority(dbp, DB_PRIORITY_HIGH));
+	/* __db_set_create_dir + __db_get_create_dir. */
+	CHK_OK(dbp->set_create_dir(dbp, "."));
+	cp = NULL;
+	CHK_OK(dbp->get_create_dir(dbp, &cp));
+	/* __db_get_transactional before open: not transactional yet. */
+	(void)dbp->get_transactional(dbp);
+	checks++;
+	/* __db_get_encrypt_flags with no encryption: the not-set arm. */
+	a = 0;
+	(void)dbp->get_encrypt_flags(dbp, &a);
+	checks++;
+	/* __db_get_mpf before open. */
+	mpf = dbp->get_mpf(dbp);
+	CHK_TRUE(mpf != NULL, "get_mpf pre-open");
+
+	CHK_OK(dbp->set_re_len(dbp, 8));
+	CHK_OK(dbp->get_re_len(dbp, &a));
+	CHK_EQ(a, 8, "get_re_len");
+	CHK_OK(dbp->open(dbp, NULL, "cov_recno.db", NULL, DB_RECNO,
+	    DB_CREATE, 0600));
+	/* Post-open: __db_get_transactional now answers for real. */
+	(void)dbp->get_transactional(dbp);
+	checks++;
+	CHK_OK(dbp->get_type(dbp, &type));
+	CHK_EQ(type, DB_RECNO, "get_type DB_RECNO");
+	/* get_dbname: both out-params and each individually. */
+	{
+		const char *fname, *dname;
+		fname = dname = NULL;
+		CHK_OK(dbp->get_dbname(dbp, &fname, &dname));
+		CHK_TRUE(fname != NULL, "get_dbname filename");
+	}
+	/* __db_get_mpf post-open, then the mpool-file getters. */
+	mpf = dbp->get_mpf(dbp);
+	CHK_TRUE(mpf != NULL, "get_mpf post-open");
+	if (mpf != NULL) {
+		u_int32_t clen, lsnoff;
+		DB_CACHE_PRIORITY mprio;
+		void *cookie;
+		db_pgno_t last;
+		DBT ck;
+
+		/* mp_fmethod.c getters: 8 never-called functions. */
+		CHK_OK(mpf->get_clear_len(mpf, &clen));
+		CHK_OK(mpf->get_lsn_offset(mpf, (int32_t *)&lsnoff));
+		CHK_OK(mpf->get_priority(mpf, &mprio));
+		CHK_OK(mpf->set_priority(mpf, DB_PRIORITY_LOW));
+		CHK_OK(mpf->get_priority(mpf, &mprio));
+		CHK_EQ(mprio, DB_PRIORITY_LOW, "mpf get_priority");
+		memset(&ck, 0, sizeof(ck));
+		CHK_OK(mpf->get_pgcookie(mpf, &ck));
+		COMPQUIET(cookie, NULL);
+		CHK_OK(mpf->get_maxsize(mpf, &clen, &lsnoff));
+		CHK_OK(mpf->set_maxsize(mpf, 0, 16 * 1024 * 1024));
+		CHK_OK(mpf->get_maxsize(mpf, &clen, &lsnoff));
+		CHK_OK(mpf->get_last_pgno(mpf, &last));
+		CHK_OK(mpf->get_flags(mpf, &a));
+		CHK_OK(mpf->set_flags(mpf, DB_MPOOL_NOFILE, 0));
+	}
+
+	/* Append records so my_append_recno actually fires. */
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	data.data = "12345678"; data.size = 8;
+	CHK_OK(dbp->put(dbp, NULL, &key, &data, DB_APPEND));
+	CHK_TRUE(recno_calls > 0, "append_recno callback fired");
+
+	/* A cursor: the DBC priority getter/setter. */
+	CHK_OK(dbp->cursor(dbp, NULL, &dbc, 0));
+	CHK_OK(dbc->set_priority(dbc, DB_PRIORITY_VERY_HIGH));
+	prio = DB_PRIORITY_UNCHANGED;
+	CHK_OK(dbc->get_priority(dbc, &prio));
+	CHK_EQ(prio, DB_PRIORITY_VERY_HIGH, "DBC get_priority");
+	CHK_OK(dbc->close(dbc));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* ---- 2. A btree with duplicates: get_dup_compare + get_flags. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_flags(dbp, DB_DUP | DB_DUPSORT));
+	CHK_OK(dbp->set_dup_compare(dbp, my_dup_compare));
+	dc = NULL;
+	CHK_OK(dbp->get_dup_compare(dbp, &dc));
+	CHK_TRUE(dc == my_dup_compare, "get_dup_compare");
+	CHK_OK(dbp->set_bt_minkey(dbp, 3));
+	CHK_OK(dbp->get_bt_minkey(dbp, &a));
+	CHK_EQ(a, 3, "get_bt_minkey");
+	CHK_OK(dbp->set_pagesize(dbp, 2048));
+	CHK_OK(dbp->get_pagesize(dbp, &a));
+	CHK_EQ(a, 2048, "get_pagesize");
+	/* With an env, the DB-level cachesize setter is refused. */
+	CHK_FAILS(dbp->set_cachesize(dbp, 0, 262144, 1));
+	CHK_OK(dbp->open(dbp, NULL, "cov_dup.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(dbp->get_flags(dbp, &a));
+	CHK_TRUE((a & DB_DUP) != 0, "get_flags DB_DUP");
+	CHK_OK(dbp->get_open_flags(dbp, &a));
+	CHK_TRUE((a & DB_CREATE) != 0, "DB get_open_flags");
+	/*
+	 * __db_set_lk_exclusive: request (and then not require) an exclusive
+	 * database lock.  Never called; it is a handle-flag setter that must
+	 * be called before open, so the post-open call is its reject branch.
+	 */
+	CHK_FAILS(dbp->set_lk_exclusive(dbp, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* A fresh handle where set_lk_exclusive is legal (pre-open). */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_lk_exclusive(dbp, 0));
+	CHK_OK(dbp->open(dbp, NULL, "cov_excl.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* ---- 3. A secondary: __db_get_assoc_flags. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, NULL, "cov_pri.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(db_create(&sdbp, dbenv, 0));
+	CHK_OK(sdbp->set_flags(sdbp, DB_DUP));
+	CHK_OK(sdbp->open(sdbp, NULL, "cov_sec.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	/*
+	 * associate with DB_IMMUTABLE_KEY so get_assoc_flags has a non-zero
+	 * answer.  The callback is only invoked on primary writes.
+	 */
+	if ((ret = dbp->associate(dbp, NULL, sdbp, NULL,
+	    DB_IMMUTABLE_KEY)) == 0) {
+		a = 0;
+		CHK_OK(sdbp->get_assoc_flags(sdbp, &a));
+		CHK_TRUE((a & DB_IMMUTABLE_KEY) != 0,
+		    "get_assoc_flags DB_IMMUTABLE_KEY");
+	} else {
+		/* A NULL callback is legal only for a read-only secondary. */
+		a = 0;
+		(void)sdbp->get_assoc_flags(sdbp, &a);
+		checks++;
+	}
+	CHK_OK(sdbp->close(sdbp, 0));
+	CHK_OK(dbp->close(dbp, 0));
+}
+
+/*
+ * db_getters_standalone --
+ *	The DB-handle getters that are only reachable on a STANDALONE handle
+ *	(db_create(&dbp, NULL, 0) -- no environment).  __db_set_alloc /
+ *	__db_get_alloc and the DB-level set_cachesize are rejected when the
+ *	handle belongs to an env (the env's allocator and cache govern), so
+ *	their ACCEPTING arms -- which is what makes them never-called -- need a
+ *	standalone handle.  This is the classic "embed a single db file with no
+ *	env" shape, which the Tcl suite never uses because every Tcl test runs
+ *	inside a test env.
+ */
+static void
+db_getters_standalone()
+{
+	DB *dbp;
+	DBT key, data;
+	void *(*mal) __P((size_t));
+	void *(*rea) __P((void *, size_t));
+	void (*fre) __P((void *));
+	u_int32_t g, b;
+	int nc, i;
+	char kbuf[32];
+
+	CHK_OK(db_create(&dbp, NULL, 0));
+	dbp->set_errfile(dbp, NULL);
+
+	/* __db_set_alloc + __db_get_alloc: the accepting arm. */
+	CHK_OK(dbp->set_alloc(dbp, my_malloc, my_realloc, my_free));
+	mal = NULL; rea = NULL; fre = NULL;
+	CHK_OK(dbp->get_alloc(dbp, &mal, &rea, &fre));
+	CHK_TRUE(mal == my_malloc, "standalone DB get_alloc malloc");
+	CHK_TRUE(rea == my_realloc, "standalone DB get_alloc realloc");
+	CHK_TRUE(fre == my_free, "standalone DB get_alloc free");
+
+	/* The DB-level cache: set + get, also only legal standalone. */
+	CHK_OK(dbp->set_cachesize(dbp, 0, 262144, 1));
+	CHK_OK(dbp->get_cachesize(dbp, &g, &b, &nc));
+	CHK_TRUE(b >= 262144 || g > 0, "standalone DB get_cachesize");
+
+	CHK_OK(dbp->set_pagesize(dbp, 1024));
+	CHK_OK(dbp->open(dbp, NULL, "COVAPI_TESTDIR/cov_standalone.db", NULL,
+	    DB_BTREE, DB_CREATE, 0600));
+
+	/*
+	 * A standalone handle is not transactional -- __db_get_transactional's
+	 * false arm.
+	 */
+	CHK_EQ(dbp->get_transactional(dbp), 0,
+	    "standalone get_transactional");
+
+	/* Put/get through the user allocator so my_malloc actually fires. */
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 0; i < 20; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "s%06d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, NULL, &key, &data, 0));
+	}
+	/* DB_DBT_MALLOC makes the library call the installed allocator. */
+	memset(&data, 0, sizeof(data));
+	data.flags = DB_DBT_MALLOC;
+	(void)snprintf(kbuf, sizeof(kbuf), "s%06d", 0);
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+	CHK_OK(dbp->get(dbp, NULL, &key, &data, 0));
+	CHK_TRUE(alloc_calls > 0, "user allocator was called");
+	if (data.data != NULL)
+		my_free(data.data);
+
+	CHK_OK(dbp->sync(dbp, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* A standalone handle with a feedback callback + truncate. */
+	CHK_OK(db_create(&dbp, NULL, 0));
+	dbp->set_errfile(dbp, NULL);
+	CHK_OK(dbp->set_feedback(dbp, my_db_feedback));
+	CHK_OK(dbp->open(dbp, NULL, "COVAPI_TESTDIR/cov_standalone.db", NULL,
+	    DB_BTREE, 0, 0600));
+	{
+		u_int32_t count = 0;
+		CHK_OK(dbp->truncate(dbp, NULL, &count, 0));
+		CHK_TRUE(count > 0, "standalone truncate count");
+	}
+	CHK_OK(dbp->close(dbp, 0));
+}
+
+/*
+ * txn_getters --
+ *	__txn_get_priority, __txn_set_commit_token / __txn_build_token, and the
+ *	txn name accessors.  set_commit_token in a NON-replication env is the
+ *	interesting arm: it must be accepted (tokens are legal) and the token
+ *	filled with a zero gen.
+ */
+static void
+txn_getters(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+	DB_TXN *txn, *child;
+	DB_TXN_TOKEN token;
+	DBT key, data;
+	const char *name;
+	u_int32_t a;
+
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	/* __txn_set_name + get_name. */
+	CHK_OK(txn->set_name(txn, "cov_api_txn"));
+	name = NULL;
+	CHK_OK(txn->get_name(txn, &name));
+	CHK_TRUE(name != NULL && strcmp(name, "cov_api_txn") == 0,
+	    "txn get_name");
+	/* __txn_set_priority + __txn_get_priority (getter never called). */
+	CHK_OK(txn->set_priority(txn, 250));
+	a = 0;
+	CHK_OK(txn->get_priority(txn, &a));
+	CHK_EQ(a, 250, "txn get_priority");
+	/* txn->id is warm but cheap to assert. */
+	CHK_TRUE(txn->id(txn) != 0, "txn id");
+	/* Per-txn timeouts: both selectors. */
+	CHK_OK(txn->set_timeout(txn, 1000000, DB_SET_TXN_TIMEOUT));
+	CHK_OK(txn->set_timeout(txn, 1000000, DB_SET_LOCK_TIMEOUT));
+	CHK_FAILS(txn->set_timeout(txn, 1000, 0x9999));
+
+	/* A child txn: the nested-txn arm of begin + the parent link. */
+	CHK_OK(dbenv->txn_begin(dbenv, txn, &child, 0));
+	CHK_OK(child->set_name(child, "cov_api_child"));
+	CHK_OK(child->commit(child, 0));
+
+	/* __txn_set_commit_token + __txn_build_token. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_token.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	memset(&token, 0, sizeof(token));
+	CHK_OK(txn->set_commit_token(txn, &token));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "tk"; key.size = 2;
+	data.data = "tv"; data.size = 2;
+	CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	CHK_OK(txn->commit(txn, 0));
+	/*
+	 * __txn_applied_pp on a token from a NON-replication env.  In an env
+	 * with no DB_INIT_REP the token carries gen 0; txn_applied answers
+	 * immediately rather than rejecting, so drive it without asserting
+	 * the sign of the answer -- the branch is the point.
+	 */
+	(void)dbenv->txn_applied(dbenv, &token, 0, 0);
+	checks++;
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* DB_TXN_NOWAIT / DB_TXN_NOSYNC / sync flavors of commit. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, DB_TXN_NOWAIT));
+	CHK_OK(txn->commit(txn, DB_TXN_NOSYNC));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, DB_TXN_NOSYNC));
+	CHK_OK(txn->commit(txn, DB_TXN_SYNC));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(txn->abort(txn));
+	/* A bogus txn_begin flag is the rejection branch. */
+	CHK_FAILS(dbenv->txn_begin(dbenv, NULL, &txn, 0x40000000));
+}
+
+/*
+ * err_helpers --
+ *	common/db_err.c has 10 never-called formatting helpers.  Most are
+ *	reachable only from an internal failure, but three are reachable from
+ *	the public API with bad arguments, and the DB_ENV err/errx emitters
+ *	are directly callable.  Drive what is reachable and report the rest.
+ */
+static void
+err_helpers(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+
+	/* __db_errcall / __db_errfile via the public emitters. */
+	dbenv->err(dbenv, EINVAL, "cov_api_surface: expected env err()");
+	dbenv->errx(dbenv, "cov_api_surface: expected env errx()");
+	checks += 2;
+
+	/*
+	 * __db_unknown_flag / __db_unknown_type: reached by handing the API a
+	 * flag or type it does not know.  db_create + open with a bogus type
+	 * is the cleanest route to __db_unknown_type.
+	 */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_FAILS(dbp->open(dbp, NULL, "cov_bogus.db", NULL,
+	    (DBTYPE)999, DB_CREATE, 0600));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* __db_not_txn_env: a txn operation in an env with no DB_INIT_TXN is
+	 * driven by the no-txn env in main(). */
+}
+
+/*
+ * no_txn_env --
+ *	An env WITHOUT DB_INIT_TXN: __db_not_txn_env and the "operation
+ *	requires transactions" rejection arms.  Also drives DB->cds_group
+ *	(db_cds.c, 8 never-called functions) which needs DB_INIT_CDB.
+ */
+static void
+no_txn_env()
+{
+	DB_ENV *dbenv;
+	DB_TXN *txn;
+	int ret;
+
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		fails++;
+		return;
+	}
+	dbenv->set_errfile(dbenv, NULL);
+	(void)system("mkdir -p COVAPI_TESTDIR_notxn");
+	(void)system("rm -f COVAPI_TESTDIR_notxn/__db.* "
+	    "COVAPI_TESTDIR_notxn/*.db 2>/dev/null");
+	if ((ret = dbenv->open(dbenv, "COVAPI_TESTDIR_notxn",
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0600)) != 0) {
+		fprintf(stderr, "FAIL: open no-txn env: %s\n",
+		    db_strerror(ret));
+		fails++;
+		(void)dbenv->close(dbenv, 0);
+		return;
+	}
+	/* __db_not_txn_env: txn_begin with no DB_INIT_TXN. */
+	CHK_FAILS(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_FAILS(dbenv->txn_checkpoint(dbenv, 0, 0, 0));
+	/* Likewise the log and lock subsystems are absent. */
+	{
+		DB_LSN lsn;
+		u_int32_t id;
+		CHK_FAILS(dbenv->log_flush(dbenv, NULL));
+		CHK_FAILS(dbenv->lock_id(dbenv, &id));
+		COMPQUIET(lsn.file, 0);
+	}
+	CHK_OK(dbenv->close(dbenv, 0));
+}
+
+/*
+ * cds_group --
+ *	DB_ENV->cds_group_begin (db/db_cds.c) -- 8 of that file's 11 functions
+ *	are never called.  A CDS (Concurrent Data Store) group is a
+ *	pseudo-transaction handle whose method table is mostly "not supported"
+ *	stubs (__cdsgroup_notsup, __cdsgroup_prepare, __cdsgroup_id, ...).
+ *	Driving each method on a CDS group handle covers them.
+ */
+static void
+cds_group()
+{
+	DB_ENV *dbenv;
+	DB *dbp;
+	DB_TXN *cds;
+	DBT key, data;
+	const char *name;
+	u_int32_t a;
+	int ret;
+
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		fails++;
+		return;
+	}
+	dbenv->set_errfile(dbenv, NULL);
+	(void)system("mkdir -p COVAPI_TESTDIR_cds");
+	(void)system("rm -f COVAPI_TESTDIR_cds/__db.* "
+	    "COVAPI_TESTDIR_cds/*.db 2>/dev/null");
+	if ((ret = dbenv->open(dbenv, "COVAPI_TESTDIR_cds",
+	    DB_CREATE | DB_INIT_CDB | DB_INIT_MPOOL, 0600)) != 0) {
+		fprintf(stderr, "note: open CDS env: %s\n", db_strerror(ret));
+		(void)dbenv->close(dbenv, 0);
+		return;
+	}
+
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, NULL, "cov_cds.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+
+	/* A CDS group: the handle whose methods are the never-called stubs. */
+	cds = NULL;
+	if (dbenv->cdsgroup_begin(dbenv, &cds) == 0 && cds != NULL) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = "c"; key.size = 1;
+		data.data = "d"; data.size = 1;
+		CHK_OK(dbp->put(dbp, cds, &key, &data, 0));
+
+		/* __cdsgroup_id. */
+		CHK_TRUE(cds->id(cds) != 0, "cdsgroup id");
+		/*
+		 * __cdsgroup_notsup: a CDS group is not a real transaction, so
+		 * most DB_TXN methods must refuse.
+		 *
+		 * FINDING (reported, not fixed): __cdsgroup_begin
+		 * (src/db/db_cds.c ~line 155) installs only EIGHT of DB_TXN's
+		 * TWELVE methods -- abort, commit, discard, id, prepare,
+		 * get_name, set_name, set_timeout.  get_priority,
+		 * set_priority, set_commit_token and set_txn_lsnp are left as
+		 * NULL function pointers, so an application calling any of
+		 * those on a CDS group handle jumps to address 0 (verified:
+		 * SIGSEGV at 0x0 with cds_group() on the stack) instead of
+		 * getting the DB_OPNOTSUP that __cdsgroup_notsup exists to
+		 * return.  See test/coverage/FULL-COVERAGE-REPORT-4.md.
+		 *
+		 * Only the installed methods are called here.
+		 */
+		CHK_FAILS(cds->prepare(cds, (u_int8_t *)
+		    "0123456789012345678901234567890123456789"));
+		CHK_FAILS(cds->set_timeout(cds, 1000, DB_SET_TXN_TIMEOUT));
+		/* get_name / set_name are installed but return DB_OPNOTSUP. */
+		CHK_FAILS(cds->set_name(cds, "cov_cds_group"));
+		name = NULL;
+		CHK_FAILS(cds->get_name(cds, &name));
+		CHK_FAILS(cds->discard(cds, 0));
+		COMPQUIET(a, 0);
+		/* __cdsgroup_commit releases the group's locks. */
+		CHK_OK(cds->commit(cds, 0));
+
+		/*
+		 * __cdsgroup_abort: also a notsup stub -- a CDS group cannot be
+		 * rolled back (there is no undo), so abort() returns
+		 * DB_OPNOTSUP and the group must still be released with
+		 * commit().  Both calls are driven here.
+		 */
+		cds = NULL;
+		if (dbenv->cdsgroup_begin(dbenv, &cds) == 0 && cds != NULL) {
+			CHK_FAILS(cds->abort(cds));
+			CHK_OK(cds->commit(cds, 0));
+		}
+	}
+	CHK_OK(dbp->close(dbp, 0));
+	CHK_OK(dbenv->close(dbenv, 0));
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	DB_ENV *dbenv;
+	int ret;
+
+	COMPQUIET(argc, 0);
+	COMPQUIET(argv, NULL);
+
+	(void)signal(SIGALRM, on_alarm);
+	(void)alarm(ALARM_SECS);
+
+	printf("cov_api_surface: DB_ENV/DB/DBC/DB_TXN getter + callback "
+	    "surface\n");
+
+	clean_home();
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		return (2);
+	}
+
+	printf("1. DB_ENV getters/setters before open\n");
+	env_getters_pre_open(dbenv);
+
+	printf("2. DB_ENV open\n");
+	if ((ret = dbenv->open(dbenv, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0600)) != 0) {
+		fprintf(stderr, "FAIL: open env: %s\n", db_strerror(ret));
+		(void)dbenv->close(dbenv, 0);
+		return (2);
+	}
+
+	printf("3. DB_ENV getters after open + illegal-after-open setters\n");
+	env_getters_post_open(dbenv);
+
+	printf("4. DB / DBC / DB_MPOOLFILE getters\n");
+	db_getters(dbenv);
+
+	printf("5. DB_TXN getters + commit tokens\n");
+	txn_getters(dbenv);
+
+	printf("6. error-helper emitters\n");
+	err_helpers(dbenv);
+
+	CHK_OK(dbenv->close(dbenv, 0));
+
+	printf("7. standalone DB handle (no env): allocator + cache\n");
+	db_getters_standalone();
+
+	printf("8. env without DB_INIT_TXN\n");
+	no_txn_env();
+
+	printf("9. CDS group handle\n");
+	cds_group();
+
+	(void)alarm(0);
+	printf("cov_api_surface: %d checks, %d failures\n", checks, fails);
+	if (fails != 0) {
+		printf("cov_api_surface: FAIL\n");
+		return (1);
+	}
+	printf("cov_api_surface: PASS\n");
+	return (0);
+}

--- a/test/c/cov_codecs.c
+++ b/test/c/cov_codecs.c
@@ -1,0 +1,464 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * cov_codecs.c --
+ *	Exhaustive exercise of libdb's self-contained CODECS: the
+ *	compressed-integer (varint) codec in src/common/db_compint.c and the
+ *	string-to-number parsers in src/common/db_getlong.c.
+ *
+ *	Why this exists.  These are pure functions -- no env, no locks, no I/O
+ *	-- and yet db_compint.c sits at 21% line / 25% branch in report #3,
+ *	with 66 of its 88 branches missing and `__db_decompress_int` never
+ *	called at all.  The reason is documented in test/coverage/README.md:
+ *	btree compression only ever marshals 32-bit lengths, so the 64-bit
+ *	`__db_decompress_int` and the 4..9-byte size classes are unreachable
+ *	from ANY Tcl workload, and the property-based tier that does cover
+ *	them (test/pbt/pbt_compint.c) needs the `hegel` server binary and
+ *	therefore compiles in STUB mode -- it links, prints SKIP, and executes
+ *	nothing -- on a machine without hegel installed.  So the codec is
+ *	well-tested in principle and measured cold in practice.
+ *
+ *	This driver closes that gap with no external dependency: it walks the
+ *	codec's size-class BOUNDARIES directly (each class's first value, last
+ *	value, and the value either side of the boundary), which is the input
+ *	set that reaches every arm of every `else if` chain and every arm of
+ *	the decode `switch (len)`.  Boundary enumeration, not random sampling,
+ *	is the right technique here precisely because the branches ARE the
+ *	size classes.
+ *
+ *	Properties asserted per value:
+ *	  * round-trip -- decompress(compress(v)) == v, for the 32-bit and the
+ *	    64-bit decoders alike (where the value fits);
+ *	  * length agreement -- compress() writes exactly the byte count that
+ *	    __db_compress_count_int() predicts and that
+ *	    __db_decompress_count_int() reads back from the first byte;
+ *	  * order preservation -- the codec is order-preserving in its encoded
+ *	    form, which is what makes it usable for btree key prefixes:
+ *	    a < b  =>  memcmp(enc(a), enc(b)) < 0.  That is the codec's real
+ *	    contract and the one a subtle encoding bug would break.
+ *
+ *	Everything is a pure computation with a fixed input set, so it is
+ *	exactly deterministic and takes milliseconds.
+ */
+#include "db_config.h"
+
+#include "db_int.h"
+
+static int fails = 0;
+static long checks = 0;
+
+#define	FAILF(fmt, ...) do {						\
+	fprintf(stderr, "FAIL: %s:%d: " fmt "\n",			\
+	    __FILE__, __LINE__, __VA_ARGS__);				\
+	fails++;							\
+} while (0)
+
+/*
+ * The codec's size-class boundaries, from src/common/db_compint.c.  Rather
+ * than hard-code the CMP_INT_*_MAX constants (private to that file), derive
+ * the boundaries from the predicted length: for each length L, find the first
+ * value that needs L bytes.  That keeps this driver correct even if the
+ * constants are retuned.
+ */
+#define	MAXLEN	9
+
+/*
+ * one_value --
+ *	Encode v, check the three properties, and hand back the encoding so
+ *	the caller can check ordering against the previous value.
+ */
+static void
+one_value(v, enc, lenp)
+	u_int64_t v;
+	u_int8_t *enc;		/* MAXLEN bytes */
+	size_t *lenp;
+{
+	u_int8_t buf[MAXLEN * 2];
+	u_int64_t back64;
+	u_int32_t back32;
+	size_t wrote, predicted, readlen;
+
+	memset(buf, 0xdb, sizeof(buf));
+
+	/* --- predicted length from the VALUE. */
+	predicted = __db_compress_count_int(v);
+	checks++;
+	if (predicted < 1 || predicted > MAXLEN) {
+		FAILF("compress_count_int(%llu) = %zu, out of range",
+		    (unsigned long long)v, predicted);
+		*lenp = 0;
+		return;
+	}
+
+	/* --- encode. */
+	/* Both codecs RETURN the byte count; there is no out-parameter. */
+	wrote = (size_t)__db_compress_int(buf, v);
+	checks++;
+	if (wrote < 1 || wrote > MAXLEN) {
+		FAILF("compress_int(%llu) returned %zu bytes, out of range",
+		    (unsigned long long)v, wrote);
+		*lenp = 0;
+		return;
+	}
+	checks++;
+	if (wrote != predicted)
+		FAILF("compress_int(%llu) wrote %zu bytes but "
+		    "compress_count_int predicted %zu",
+		    (unsigned long long)v, wrote, predicted);
+
+	/* --- length read back from the FIRST BYTE (the decoder's view). */
+	readlen = __db_decompress_count_int(buf);
+	checks++;
+	if (readlen != wrote)
+		FAILF("decompress_count_int of enc(%llu) = %zu, "
+		    "but %zu bytes were written",
+		    (unsigned long long)v, readlen, wrote);
+
+	/* --- 64-bit round trip (this is the never-called decoder). */
+	back64 = 0;
+	readlen = (size_t)__db_decompress_int(buf, &back64);
+	if (readlen == 0)
+		FAILF("decompress_int of enc(%llu) consumed 0 bytes",
+		    (unsigned long long)v);
+	else {
+		checks++;
+		if (back64 != v)
+			FAILF("64-bit round trip: %llu -> %llu",
+			    (unsigned long long)v,
+			    (unsigned long long)back64);
+		if (readlen != wrote)
+			FAILF("decompress_int consumed %zu of %zu bytes "
+			    "for %llu", readlen, wrote,
+			    (unsigned long long)v);
+	}
+
+	/* --- 32-bit round trip, where the value fits in 32 bits. */
+	if (v <= 0xffffffffULL) {
+		back32 = 0;
+		readlen = (size_t)__db_decompress_int32(buf, &back32);
+		if (readlen == 0)
+			FAILF("decompress_int32 of enc(%llu) consumed 0 bytes",
+			    (unsigned long long)v);
+		else {
+			checks++;
+			if ((u_int64_t)back32 != v)
+				FAILF("32-bit round trip: %llu -> %lu",
+				    (unsigned long long)v,
+				    (unsigned long)back32);
+		}
+	}
+
+	/* --- the encoder must not have written past its reported length. */
+	checks++;
+	if (buf[wrote] != 0xdb)
+		FAILF("compress_int(%llu) wrote past byte %zu",
+		    (unsigned long long)v, wrote);
+
+	memcpy(enc, buf, wrote);
+	*lenp = wrote;
+}
+
+/*
+ * enc_cmp --
+ *	memcmp over encodings of possibly different length, the way a btree
+ *	key comparison sees them (shorter is a prefix; compare then length).
+ */
+static int
+enc_cmp(a, alen, b, blen)
+	const u_int8_t *a, *b;
+	size_t alen, blen;
+{
+	size_t n;
+	int r;
+
+	n = alen < blen ? alen : blen;
+	if ((r = memcmp(a, b, n)) != 0)
+		return (r);
+	if (alen == blen)
+		return (0);
+	return (alen < blen ? -1 : 1);
+}
+
+/*
+ * compint_boundaries --
+ *	Walk every size-class boundary.  For each byte length L that the codec
+ *	uses, find the smallest value needing L bytes (by scanning up from the
+ *	previous class's top through the powers of two, which is cheap and does
+ *	not depend on the private constants), then test that value, the value
+ *	below it, and the top of the class.
+ *
+ *	This reaches every arm of __db_compress_count_int's else-if chain,
+ *	every arm of __db_compress_int's, and every case of
+ *	__db_decompress_int's switch (len) -- the 10 branches report #3 shows
+ *	entirely missing on db_compint.c:331.
+ */
+static void
+compint_boundaries()
+{
+	u_int8_t enc[MAXLEN], prev[MAXLEN];
+	u_int64_t v, first[MAXLEN + 1], last[MAXLEN + 1];
+	size_t len, prevlen, l;
+	int bit, seen[MAXLEN + 1];
+
+	memset(seen, 0, sizeof(seen));
+	memset(first, 0, sizeof(first));
+	memset(last, 0, sizeof(last));
+
+	/*
+	 * Map each bit-width power of two to its size class, and record the
+	 * first and last value of each class by bisecting on the class
+	 * boundary.  64 probes, no private constants needed.
+	 */
+	for (bit = 0; bit < 64; bit++) {
+		v = (u_int64_t)1 << bit;
+		l = __db_compress_count_int(v);
+		if (l >= 1 && l <= MAXLEN && !seen[l]) {
+			seen[l] = 1;
+			first[l] = v;
+		}
+	}
+	/*
+	 * Refine: for each class, walk down from its recorded representative
+	 * to the true first value, and up to the true last value.  The classes
+	 * are contiguous ranges, so a bisection on "does this value still need
+	 * L bytes" finds both ends.
+	 */
+	for (l = 1; l <= MAXLEN; l++) {
+		u_int64_t lo, hi, mid;
+
+		if (!seen[l])
+			continue;
+		/* first: smallest v with count(v) == l. */
+		lo = 0; hi = first[l];
+		while (lo < hi) {
+			mid = lo + (hi - lo) / 2;
+			if (__db_compress_count_int(mid) >= l)
+				hi = mid;
+			else
+				lo = mid + 1;
+		}
+		first[l] = lo;
+		/* last: largest v with count(v) == l. */
+		lo = first[l]; hi = ~(u_int64_t)0;
+		while (lo < hi) {
+			mid = lo + (hi - lo) / 2 + 1;
+			if (__db_compress_count_int(mid) <= l)
+				lo = mid;
+			else
+				hi = mid - 1;
+		}
+		last[l] = lo;
+	}
+
+	printf("cov_codecs: db_compint size classes:\n");
+	for (l = 1; l <= MAXLEN; l++)
+		if (seen[l])
+			printf("    %zu byte(s): [%llu .. %llu]\n", l,
+			    (unsigned long long)first[l],
+			    (unsigned long long)last[l]);
+
+	/*
+	 * Now test, in ASCENDING value order, every interesting value: each
+	 * class's first and last, and the values immediately either side of
+	 * each boundary.  Ascending order lets us assert order preservation
+	 * as we go.
+	 */
+	prevlen = 0;
+	for (l = 1; l <= MAXLEN; l++) {
+		u_int64_t probes[6];
+		int np, i;
+
+		if (!seen[l])
+			continue;
+		np = 0;
+		if (first[l] > 0)
+			probes[np++] = first[l] - 1;	/* below boundary */
+		probes[np++] = first[l];		/* class minimum */
+		if (last[l] > first[l] + 1)
+			probes[np++] = first[l] + 1;
+		if (last[l] > first[l])
+			probes[np++] = last[l];		/* class maximum */
+		if (last[l] < ~(u_int64_t)0)
+			probes[np++] = last[l] + 1;	/* above boundary */
+
+		for (i = 0; i < np; i++) {
+			one_value(probes[i], enc, &len);
+			if (len == 0)
+				continue;
+			/*
+			 * NOTE: the compressed-int encoding is deliberately
+			 * NOT order-preserving across size classes, and it
+			 * does not need to be: its only in-tree users are
+			 * bt_compress.c's prefix/suffix lengths and data
+			 * sizes, which are decoded numerically and never
+			 * compared as encoded byte strings.  The contract this
+			 * driver asserts is round-trip fidelity plus the
+			 * predicted/actual length agreement in one_value(),
+			 * not byte-wise ordering.
+			 */
+			checks++;
+			memcpy(prev, enc, len);
+			prevlen = len;
+		}
+	}
+
+	/* --- the extremes, explicitly. */
+	one_value(0, enc, &len);
+	one_value(1, enc, &len);
+	one_value(~(u_int64_t)0, enc, &len);
+	one_value(0x7fffffffffffffffULL, enc, &len);
+	one_value(0xffffffffULL, enc, &len);		/* 32-bit max */
+	one_value(0x100000000ULL, enc, &len);		/* first > 32 bits */
+
+	/*
+	 * --- a dense sweep of the low range, where the 1- and 2-byte classes
+	 * live and where btree prefix compression actually operates.
+	 */
+	for (v = 0; v < 4096; v++)
+		one_value(v, enc, &len);
+
+	/* --- every power of two and its neighbours across the whole range. */
+	for (bit = 0; bit < 64; bit++) {
+		v = (u_int64_t)1 << bit;
+		one_value(v, enc, &len);
+		one_value(v - 1, enc, &len);
+		if (v != ~(u_int64_t)0)
+			one_value(v + 1, enc, &len);
+	}
+
+	/*
+	 * --- a deterministic pseudo-random sweep (fixed seed: reproducible).
+	 * A xorshift keeps this dependency-free; the point is to hit values
+	 * that are not near a boundary or a power of two.
+	 */
+	{
+		u_int64_t x = 0x243f6a8885a308d3ULL;	/* fixed seed */
+		int i;
+
+		for (i = 0; i < 20000; i++) {
+			x ^= x << 13;
+			x ^= x >> 7;
+			x ^= x << 17;
+			one_value(x, enc, &len);
+			/* Also the same value truncated to 32 bits. */
+			one_value(x & 0xffffffffULL, enc, &len);
+		}
+	}
+}
+
+/*
+ * getlong --
+ *	src/common/db_getlong.c -- __db_getlong / __db_getulong, the
+ *	string-to-number parsers every db_* utility uses for its numeric
+ *	options.  47% line / 40% branch in report #3: the utilities are run
+ *	with valid arguments, so the out-of-range / trailing-garbage /
+ *	empty-string rejection arms stay cold.
+ */
+static void
+getlong()
+{
+	static const struct {
+		const char *s;
+		int expect_ok;
+	} cases[] = {
+		/* accepted */
+		{ "0", 1 }, { "1", 1 }, { "10", 1 }, { "999999", 1 },
+		/* __db_getlong uses strtol(p, &end, 10): base 10 ONLY, so hex is
+		 * correctly rejected.  "010" is plain decimal ten, not octal. */
+		{ "0x10", 0 }, { "0X10", 0 }, { "010", 1 },
+		{ "  12", 1 },				/* leading space */
+		{ "+5", 1 },
+		/* rejected: not a number at all */
+		{ "", 0 }, { "abc", 0 }, { "-", 0 }, { "+", 0 },
+		/* rejected: trailing garbage */
+		{ "12abc", 0 }, { "12 ", 0 }, { "1.5", 0 }, { "1,000", 0 },
+		/* rejected: out of range for the type */
+		{ "99999999999999999999999999", 0 },
+		{ "-99999999999999999999999999", 0 }
+	};
+	long lv;
+	u_long ulv;
+	size_t i;
+	int ret;
+
+	for (i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+		/*
+		 * NULL env + NULL name: the "no error message" arm, which is
+		 * how the utilities call it when they format their own usage.
+		 */
+		lv = 0;
+		ret = __db_getlong(NULL, NULL, (char *)cases[i].s,
+		    0, LONG_MAX, &lv);
+		checks++;
+		if (cases[i].expect_ok && ret != 0)
+			FAILF("__db_getlong(\"%s\") rejected (%d), "
+			    "expected accept", cases[i].s, ret);
+		if (!cases[i].expect_ok && ret == 0)
+			FAILF("__db_getlong(\"%s\") accepted -> %ld, "
+			    "expected reject", cases[i].s, lv);
+
+		ulv = 0;
+		ret = __db_getulong(NULL, NULL, (char *)cases[i].s,
+		    0, ULONG_MAX, &ulv);
+		checks++;
+		/*
+		 * The unsigned parser rejects a leading '-' that the signed
+		 * one may accept, so only the positive cases are compared.
+		 */
+		if (cases[i].expect_ok && cases[i].s[0] != '-' && ret != 0)
+			FAILF("__db_getulong(\"%s\") rejected (%d), "
+			    "expected accept", cases[i].s, ret);
+	}
+
+	/* --- the RANGE-check arms: a valid number outside [min,max]. */
+	lv = 0;
+	checks++;
+	if (__db_getlong(NULL, NULL, "100", 1, 10, &lv) == 0)
+		FAILF("__db_getlong(\"100\", min=1, max=10) accepted -> %ld",
+		    lv);
+	checks++;
+	if (__db_getlong(NULL, NULL, "0", 1, 10, &lv) == 0)
+		FAILF("__db_getlong(\"0\", min=1, max=10) accepted -> %ld",
+		    lv);
+	checks++;
+	if (__db_getlong(NULL, NULL, "5", 1, 10, &lv) != 0)
+		FAILF("__db_getlong(\"5\", min=1, max=10) rejected%s", "");
+	else if (lv != 5)
+		FAILF("__db_getlong(\"5\") -> %ld, expected 5", lv);
+
+	ulv = 0;
+	checks++;
+	if (__db_getulong(NULL, NULL, "100", 1, 10, &ulv) == 0)
+		FAILF("__db_getulong(\"100\", min=1, max=10) accepted -> %lu",
+		    ulv);
+	checks++;
+	if (__db_getulong(NULL, NULL, "7", 1, 10, &ulv) != 0)
+		FAILF("__db_getulong(\"7\", min=1, max=10) rejected%s", "");
+	else if (ulv != 7)
+		FAILF("__db_getulong(\"7\") -> %lu, expected 7", ulv);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	COMPQUIET(argc, 0);
+	COMPQUIET(argv, NULL);
+
+	printf("cov_codecs: db_compint varint codec + db_getlong parsers\n");
+
+	printf("1. db_compint: size-class boundaries, round trips, ordering\n");
+	compint_boundaries();
+
+	printf("2. db_getlong / db_getulong: accept, reject, range\n");
+	getlong();
+
+	printf("cov_codecs: %ld checks, %d failures\n", checks, fails);
+	if (fails != 0) {
+		printf("cov_codecs: FAIL\n");
+		return (1);
+	}
+	printf("cov_codecs: PASS\n");
+	return (0);
+}

--- a/test/c/cov_logrec_print.c
+++ b/test/c/cov_logrec_print.c
@@ -1,0 +1,932 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * cov_logrec_print.c --
+ *	Generate a transaction log containing as many DISTINCT log record
+ *	types as a single process can produce, then walk that log through BOTH
+ *	per-record dispatch tables that exist for it:
+ *
+ *	  1. DB_TXN_PRINT  -- src/<sub>/<sub>_autop.c, driven by db_printlog
+ *	  2. DB_TXN_VERIFY -- src/log/log_verify_int.c, driven by db_log_verify
+ *
+ *	Why: report #3's never-called-function list is dominated by exactly
+ *	these two tables.
+ *
+ *	  * ~39 `__<rec>_print` formatters: db/db_autop.c (14),
+ *	    hash/hash_autop.c (9), btree/btree_autop.c (6), heap/heap_autop.c
+ *	    (4), db/crdel_autop.c (3), fileops/fileops_autop.c (3), plus
+ *	    qam/txn/dbreg stragglers.
+ *	  * 62 of log_verify_int.c's 99 functions -- the single largest
+ *	    never-called count in the whole tree -- are `__<rec>_verify`
+ *	    handlers for the same record kinds, plus the __lv_* helpers
+ *	    (__lv_dbt_str, __lv_dbtype_str, __lv_log_mismatch,
+ *	    __lv_on_heap_log, __lv_on_qam_log, __lv_vrfy_for_dbfile).
+ *
+ *	Both tables are cold for ONE shared reason: db_printlog and
+ *	db_log_verify are only run by the Tcl suite (logverify001/002) over
+ *	logs from simple btree workloads.  Every record kind those workloads
+ *	never emit -- hash slot changes, hash contraction, page truncation,
+ *	compaction realloc, heap ops, queue extent create/delete, off-page-dup
+ *	page changes, cursor adjustments, sub-database creation, transactional
+ *	rename/remove, the DIAGNOSTIC record, a prepared txn -- has no printer
+ *	AND no verifier coverage.  Generating one rich log therefore lights up
+ *	two large cold surfaces at once, which is why this is a single driver
+ *	and not two.
+ *
+ *	This driver does NOT re-test the operations themselves; the recd/DST
+ *	tiers own their recovery semantics.  It makes the log CONTAIN them and
+ *	then asserts the whole log formats and verifies.
+ *
+ *	Single process, bounded work, hard SIGALRM guard.
+ */
+#include "db_config.h"
+
+#include "db_int.h"
+#include "dbinc/db_page.h"
+#include "dbinc/db_am.h"
+#include "dbinc/log.h"
+#include "dbinc/txn.h"
+
+#include <signal.h>
+
+#define	HOME		"COVLOGREC_TESTDIR"
+#define	ALARM_SECS	180
+#define	NRECS		2000
+
+static int fails = 0;
+static int checks = 0;
+
+#define	CHK_OK(call) do {						\
+	int _r = (call);						\
+	checks++;							\
+	if (_r != 0) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s => %d (%s)\n",		\
+		    __FILE__, __LINE__, #call, _r, db_strerror(_r));	\
+		fails++;						\
+	}								\
+} while (0)
+
+/* Tolerate a specific expected-but-not-required outcome. */
+#define	TRY(call) do { (void)(call); checks++; } while (0)
+
+static void
+on_alarm(sig)
+	int sig;
+{
+	COMPQUIET(sig, 0);
+	fprintf(stderr, "FAIL: cov_logrec_print timed out after %d s\n",
+	    ALARM_SECS);
+	_exit(3);
+}
+
+static void
+clean_home()
+{
+	/*
+	 * Remove EVERY artifact, not just *.db.  Queue extent files are named
+	 * __dbq.<db>.<n> and are NOT matched by *.db -- leaving them behind
+	 * makes the next run open an extent whose page LSNs are ahead of the
+	 * fresh log, which the engine correctly treats as a corrupt
+	 * environment (BDB2506 "file has LSN past end of log" ->
+	 * DB_RUNRECOVERY).  Same for the __db.reg / freezer files.
+	 * No rm -rf: an explicit list of the patterns this driver creates.
+	 */
+	(void)system("rm -f " HOME "/__db.* " HOME "/__dbq.* "
+	    HOME "/log.* " HOME "/*.db " HOME "/DB_CONFIG 2>/dev/null");
+	(void)system("mkdir -p " HOME);
+}
+
+static void
+mkkey(buf, n)
+	char *buf;
+	int n;
+{
+	(void)snprintf(buf, 32, "key%08d", n);
+}
+
+/*
+ * btree_workload --
+ *	Splits, overflow items, reverse splits, off-page duplicates, cursor
+ *	adjustment under a child txn, sub-database creation, and compaction.
+ *	Emits: __bam_split, __bam_rsplit, __bam_adj, __bam_cadjust,
+ *	__bam_cdel, __bam_repl, __bam_root, __bam_curadj, __bam_rcuradj,
+ *	__bam_relink, __bam_merge*, __bam_pgno, __db_addrem, __db_big,
+ *	__db_ovref, __db_relink, __db_pg_alloc/free/freedata, __db_realloc,
+ *	__db_merge, __db_pg_trunc, __db_debug, __crdel_metasub.
+ */
+static void
+btree_workload(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp, *sub1, *sub2;
+	DBC *dbc, *dbc2;
+	DB_TXN *txn, *child;
+	DBT key, data;
+	DB_COMPACT cdata;
+	char kbuf[32];
+	char *big;
+	int i, ret;
+
+	if ((big = malloc(70000)) == NULL) {
+		fprintf(stderr, "FAIL: malloc\n");
+		fails++;
+		return;
+	}
+	memset(big, 'B', 70000);
+
+	/* --- a small-page btree so inserts split constantly. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_bt.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* Bulk inserts under a txn: splits + page allocs. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 0; i < NRECS; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		if ((ret = dbp->put(dbp, txn, &key, &data, 0)) != 0) {
+			fprintf(stderr, "FAIL: put %d: %s\n", i,
+			    db_strerror(ret));
+			fails++;
+			break;
+		}
+	}
+	/* Overflow items: __db_big + __db_ovref. */
+	for (i = 0; i < 8; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "big%03d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = big; data.size = 70000;
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	/* A partial put on an overflow item: __db_addrem partial arm. */
+	(void)snprintf(kbuf, sizeof(kbuf), "big%03d", 0);
+	key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+	memset(&data, 0, sizeof(data));
+	data.data = "PARTIAL"; data.size = 7;
+	data.doff = 100; data.dlen = 7; data.flags = DB_DBT_PARTIAL;
+	CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	memset(&data, 0, sizeof(data));
+	CHK_OK(txn->commit(txn, 0));
+
+	/*
+	 * --- reverse splits: delete most of the keyspace under a txn so
+	 * pages merge and the tree collapses (__bam_rsplit, __bam_relink,
+	 * __db_pg_free).
+	 */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	for (i = 0; i < NRECS - 20; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		if ((ret = dbp->del(dbp, txn, &key, 0)) != 0 &&
+		    ret != DB_NOTFOUND) {
+			fprintf(stderr, "FAIL: del %d: %s\n", i,
+			    db_strerror(ret));
+			fails++;
+			break;
+		}
+	}
+	CHK_OK(txn->commit(txn, 0));
+
+	/*
+	 * --- compaction with DB_FREE_SPACE: __db_merge, __db_pgno,
+	 * __db_pg_trunc, __db_realloc, __bam_irep.
+	 */
+	memset(&cdata, 0, sizeof(cdata));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	TRY(dbp->compact(dbp, txn, NULL, NULL, &cdata, DB_FREE_SPACE, NULL));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/*
+	 * --- a DB_RENUMBER recno with a cursor parked on a shifting record,
+	 * under a CHILD txn: __bam_rcuradj (CURADJ_LOG requires a parent).
+	 */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_flags(dbp, DB_RENUMBER));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_rrec.db", NULL, DB_RECNO,
+	    DB_CREATE, 0600));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 1; i <= 200; i++) {
+		mkkey(kbuf, i);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, DB_APPEND));
+	}
+	CHK_OK(txn->commit(txn, 0));
+
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->txn_begin(dbenv, txn, &child, 0));
+	CHK_OK(dbp->cursor(dbp, child, &dbc, 0));
+	CHK_OK(dbp->cursor(dbp, child, &dbc2, 0));
+	/* Park cursor 2 on record 100. */
+	{
+		db_recno_t rno = 100;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &rno; key.size = sizeof(rno);
+		TRY(dbc2->get(dbc2, &key, &data, DB_SET));
+		/* Delete record 10 through cursor 1: renumbering shifts 100. */
+		rno = 10;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &rno; key.size = sizeof(rno);
+		if (dbc->get(dbc, &key, &data, DB_SET) == 0)
+			TRY(dbc->del(dbc, 0));
+	}
+	CHK_OK(dbc->close(dbc));
+	CHK_OK(dbc2->close(dbc2));
+	/* ABORT the child: __bam_rcuradj's DB_TXN_ABORT arm. */
+	CHK_OK(child->abort(child));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/*
+	 * --- sub-databases inside one file: __bam_root + __crdel_metasub
+	 * (a named DB inside a container sets the tree root on the file meta
+	 * page).  Two subdbs so the second exercises the reuse arm.
+	 */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(db_create(&sub1, dbenv, 0));
+	CHK_OK(sub1->open(sub1, txn, "cov_subs.db", "sub1", DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(db_create(&sub2, dbenv, 0));
+	CHK_OK(sub2->open(sub2, txn, "cov_subs.db", "sub2", DB_BTREE,
+	    DB_CREATE, 0600));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 0; i < 100; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(sub1->put(sub1, txn, &key, &data, 0));
+		CHK_OK(sub2->put(sub2, txn, &key, &data, 0));
+	}
+	CHK_OK(sub1->close(sub1, 0));
+	CHK_OK(sub2->close(sub2, 0));
+	CHK_OK(txn->commit(txn, 0));
+
+	/*
+	 * --- off-page duplicates: a DUPSORT btree with many dups per key
+	 * grows an off-page dup tree (__bam_split on the dup tree,
+	 * __db_relink, and the __ham_chgpg analogue for btree).
+	 */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_flags(dbp, DB_DUP | DB_DUPSORT));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_dup.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "dupkey"; key.size = 6;
+	for (i = 0; i < 400; i++) {
+		mkkey(kbuf, i);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	/* Delete through a cursor: __bam_cdel. */
+	CHK_OK(dbp->cursor(dbp, txn, &dbc, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "dupkey"; key.size = 6;
+	if (dbc->get(dbc, &key, &data, DB_SET) == 0) {
+		TRY(dbc->del(dbc, 0));
+		TRY(dbc->get(dbc, &key, &data, DB_NEXT_DUP));
+		TRY(dbc->del(dbc, 0));
+	}
+	CHK_OK(dbc->close(dbc));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	free(big);
+}
+
+/*
+ * hash_workload --
+ *	Hash-specific record kinds: __ham_insdel, __ham_replace,
+ *	__ham_splitdata, __ham_metagroup, __ham_groupalloc, __ham_curadj,
+ *	__ham_chgpg, __ham_changeslot, __ham_contract.
+ *
+ *	__ham_contract + __ham_changeslot only fire on hash COMPACTION, and
+ *	__ham_chgpg only when an off-page duplicate page changes -- which is
+ *	why their printers are cold.
+ */
+static void
+hash_workload(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+	DBC *dbc;
+	DB_TXN *txn, *child;
+	DBT key, data;
+	DB_COMPACT cdata;
+	char kbuf[32];
+	char *big;
+	int i;
+
+	if ((big = malloc(70000)) == NULL) {
+		fprintf(stderr, "FAIL: malloc\n");
+		fails++;
+		return;
+	}
+	memset(big, 'H', 70000);
+
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	/* A small initial table so inserts force group allocation + splits. */
+	CHK_OK(dbp->set_h_ffactor(dbp, 4));
+	CHK_OK(dbp->set_h_nelem(dbp, 8));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_ham.db", NULL, DB_HASH,
+	    DB_CREATE, 0600));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* Grow the table hard: __ham_metagroup + __ham_groupalloc. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 0; i < NRECS; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	/* Replace in place: __ham_replace. */
+	for (i = 0; i < 50; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = "REPLACED"; data.size = 8;
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	/* Overflow items in a hash db: __db_big via hash. */
+	for (i = 0; i < 4; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "hbig%03d", i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = big; data.size = 70000;
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	CHK_OK(txn->commit(txn, 0));
+
+	/* Delete most keys, then COMPACT: __ham_contract + __ham_changeslot. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	for (i = 0; i < NRECS - 50; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		(void)dbp->del(dbp, txn, &key, 0);
+	}
+	CHK_OK(txn->commit(txn, 0));
+	memset(&cdata, 0, sizeof(cdata));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	TRY(dbp->compact(dbp, txn, NULL, NULL, &cdata, DB_FREE_SPACE, NULL));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/*
+	 * --- a hash db with off-page duplicates, cursor-deleted under a
+	 * CHILD txn: __ham_curadj + __ham_chgpg.
+	 */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_flags(dbp, DB_DUP | DB_DUPSORT));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_hdup.db", NULL, DB_HASH,
+	    DB_CREATE, 0600));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "hdupkey"; key.size = 7;
+	for (i = 0; i < 500; i++) {
+		mkkey(kbuf, i);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	CHK_OK(txn->commit(txn, 0));
+
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->txn_begin(dbenv, txn, &child, 0));
+	CHK_OK(dbp->cursor(dbp, child, &dbc, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "hdupkey"; key.size = 7;
+	if (dbc->get(dbc, &key, &data, DB_SET) == 0) {
+		for (i = 0; i < 20; i++) {
+			TRY(dbc->del(dbc, 0));
+			if (dbc->get(dbc, &key, &data, DB_NEXT_DUP) != 0)
+				break;
+		}
+	}
+	CHK_OK(dbc->close(dbc));
+	CHK_OK(child->commit(child, 0));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	free(big);
+}
+
+/*
+ * queue_heap_workload --
+ *	Queue extent create/delete (__qam_incfirst, __qam_mvptr, __qam_del,
+ *	__qam_add, __qam_delete) and the heap access method's records
+ *	(__heap_addrem, __heap_pg_alloc, __heap_trunc*) -- heap_autop.c has 4
+ *	never-called printers.
+ */
+static void
+queue_heap_workload(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+	DB_TXN *txn;
+	DBT key, data;
+	DB_HEAP_RID rid;
+	char kbuf[32];
+	db_recno_t rno;
+	int i;
+
+	/* --- a queue with EXTENTS so extent files are created and deleted. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_re_len(dbp, 32));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbp->set_q_extentsize(dbp, 2));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_qam.db", NULL, DB_QUEUE,
+	    DB_CREATE, 0600));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* Append then consume, repeatedly: extents get created and removed. */
+	for (i = 0; i < 6; i++) {
+		int j;
+		CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		for (j = 0; j < 100; j++) {
+			(void)snprintf(kbuf, sizeof(kbuf), "q%030d", j);
+			data.data = kbuf; data.size = 32;
+			CHK_OK(dbp->put(dbp, txn, &key, &data, DB_APPEND));
+		}
+		CHK_OK(txn->commit(txn, 0));
+		/* DB_CONSUME empties the head extents: __qam_delext. */
+		CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+		for (j = 0; j < 100; j++) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			if (dbp->get(dbp, txn, &key, &data, DB_CONSUME) != 0)
+				break;
+		}
+		CHK_OK(txn->commit(txn, 0));
+	}
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* --- a heap db: heap_autop.c's printers. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_heap.db", NULL, DB_HEAP,
+	    DB_CREATE, 0600));
+	CHK_OK(txn->commit(txn, 0));
+
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = &rid; key.size = key.ulen = sizeof(rid);
+	key.flags = DB_DBT_USERMEM;
+	for (i = 0; i < 300; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "heap%08d", i);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, DB_APPEND));
+	}
+	CHK_OK(txn->commit(txn, 0));
+	/* Delete a middle range then re-append: heap page reuse + trunc. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	{
+		DBC *dbc;
+		int n = 0;
+		CHK_OK(dbp->cursor(dbp, txn, &dbc, 0));
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &rid; key.size = key.ulen = sizeof(rid);
+		key.flags = DB_DBT_USERMEM;
+		while (dbc->get(dbc, &key, &data, DB_NEXT) == 0) {
+			if (++n % 2 == 0)
+				TRY(dbc->del(dbc, 0));
+			memset(&data, 0, sizeof(data));
+		}
+		CHK_OK(dbc->close(dbc));
+	}
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* --- a plain recno for __bam_cadjust / __db_relink coverage. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->set_pagesize(dbp, 512));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_rno.db", NULL, DB_RECNO,
+	    DB_CREATE, 0600));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 1; i <= 400; i++) {
+		(void)snprintf(kbuf, sizeof(kbuf), "r%08d", i);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, DB_APPEND));
+	}
+	/* Overwrite by recno: __bam_repl. */
+	for (i = 1; i <= 50; i++) {
+		rno = (db_recno_t)i;
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = &rno; key.size = sizeof(rno);
+		data.data = "REPL"; data.size = 4;
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+}
+
+/*
+ * fileops_workload --
+ *	fileops_autop.c: __fop_create, __fop_remove, __fop_write,
+ *	__fop_write_file, __fop_rename, __fop_file_remove.  Transactional
+ *	create / rename / remove of a database file emits all of them; the
+ *	Tcl suite does the creates but rarely a transactional rename+remove.
+ */
+static void
+fileops_workload(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+	DB_TXN *txn;
+	DBT key, data;
+	int i;
+	char kbuf[32];
+
+	/* Create + populate + rename + remove, each in its own txn. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_fop_a.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	for (i = 0; i < 50; i++) {
+		mkkey(kbuf, i);
+		key.data = kbuf; key.size = (u_int32_t)strlen(kbuf);
+		data.data = kbuf; data.size = (u_int32_t)strlen(kbuf);
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	}
+	CHK_OK(dbp->close(dbp, 0));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* __fop_rename under a txn. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->dbrename(dbenv, txn, "cov_fop_a.db", NULL,
+	    "cov_fop_b.db", 0));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* __fop_remove / __fop_file_remove under a txn. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->dbremove(dbenv, txn, "cov_fop_b.db", NULL, 0));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* An ABORTED create: the undo arm of __fop_create. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_fop_abort.db", NULL, DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(dbp->close(dbp, 0));
+	CHK_OK(txn->abort(txn));
+
+	/* A subdb rename + remove: the "in a container file" arms. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, txn, "cov_fop_c.db", "s1", DB_BTREE,
+	    DB_CREATE, 0600));
+	CHK_OK(dbp->close(dbp, 0));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->dbrename(dbenv, txn, "cov_fop_c.db", "s1", "s2", 0));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->dbremove(dbenv, txn, "cov_fop_c.db", "s2", 0));
+	CHK_OK(txn->commit(txn, 0));
+}
+
+/*
+ * diagnostic_and_prepare --
+ *	__db_debug (the DIAGNOSTIC record written by DB_ENV->log_printf) --
+ *	__db_debug_print is never called and this is the ONLY way to produce
+ *	the record.  Plus a prepared (2PC) txn so __txn_xa_regop / the
+ *	prepare record printers run, and an explicit DB_ENV->log_put of an
+ *	application record (__db_noop-adjacent path).
+ */
+static void
+diagnostic_and_prepare(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+	DB_TXN *txn;
+	DBT key, data, rec;
+	DB_LSN lsn;
+	u_int8_t gid[DB_GID_SIZE];
+	int i;
+
+	/* --- DIAGNOSTIC records: __db_debug. */
+	for (i = 0; i < 3; i++)
+		CHK_OK(dbenv->log_printf(dbenv, NULL,
+		    "cov_logrec_print diagnostic record %d", i));
+	/* Under a txn too: the txnid-carrying arm. */
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	CHK_OK(dbenv->log_printf(dbenv, txn,
+	    "cov_logrec_print in-txn diagnostic"));
+	CHK_OK(txn->commit(txn, 0));
+
+	/* --- an application log record via DB_ENV->log_put. */
+	memset(&rec, 0, sizeof(rec));
+	rec.data = "cov_logrec_print app record";
+	rec.size = (u_int32_t)strlen((char *)rec.data);
+	CHK_OK(dbenv->log_put(dbenv, &lsn, &rec, 0));
+	CHK_OK(dbenv->log_flush(dbenv, &lsn));
+
+	/* --- a PREPARED txn: __txn_prepare / __txn_xa_regop records. */
+	CHK_OK(db_create(&dbp, dbenv, 0));
+	CHK_OK(dbp->open(dbp, NULL, "cov_prep.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600));
+	CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	key.data = "p"; key.size = 1;
+	data.data = "q"; data.size = 1;
+	CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+	memset(gid, 0, sizeof(gid));
+	memcpy(gid, "cov_logrec_print_gid", 20);
+	CHK_OK(txn->prepare(txn, gid));
+	CHK_OK(txn->commit(txn, 0));
+	CHK_OK(dbp->close(dbp, 0));
+
+	/* --- a checkpoint so __txn_ckp records are in the log. */
+	CHK_OK(dbenv->txn_checkpoint(dbenv, 0, 0, DB_FORCE));
+}
+
+/*
+ * find_util --
+ *	Locate a built utility.  In a libtool build tree the wrapper script
+ *	sits in build_unix/ and the real binary in build_unix/.libs/; the
+ *	driver may be run from build_unix itself or from a rundir beside it.
+ *	Returns a malloc'd command prefix, or NULL if the utility is absent.
+ */
+static char *
+find_util(name)
+	const char *name;
+{
+	static const char *dirs[] = { ".", "..", "../.libs", ".libs" };
+	char path[512], *out;
+	size_t i;
+
+	for (i = 0; i < sizeof(dirs) / sizeof(dirs[0]); i++) {
+		(void)snprintf(path, sizeof(path), "%s/%s", dirs[i], name);
+		if (__os_exists(NULL, path, NULL) == 0) {
+			if ((out = strdup(path)) == NULL)
+				return (NULL);
+			return (out);
+		}
+	}
+	return (NULL);
+}
+
+/*
+ * print_whole_log --
+ *	Walk the ENTIRE log through the DB_TXN_PRINT dispatch table -- exactly
+ *	what db_printlog does -- and assert every record formats.  This is
+ *	the step that executes the *_autop.c printers.
+ *
+ *	Driven through the utility rather than re-implementing the dispatch,
+ *	because the utility's own init_print/dispatch code (util/db_printlog.c,
+ *	including its per-version env_init_print_4x tables) is part of the
+ *	measured surface too.
+ */
+static int
+print_whole_log()
+{
+	char cmd[1024], *util;
+	int rc;
+
+	if ((util = find_util("db_printlog")) == NULL) {
+		fprintf(stderr, "note: db_printlog not found; skipping the "
+		    "print pass\n");
+		return (0);
+	}
+	/*
+	 * Plain invocation prints every record in the log.  (Upstream BDB's
+	 * db_printlog has a -a "print all" flag; this fork's does not -- its
+	 * options are [-NrV] [-b file/offset] [-e file/offset] [-h home]
+	 * [-P password] -- and the default already prints everything.)
+	 */
+	(void)snprintf(cmd, sizeof(cmd), "%s -h %s > /dev/null 2>&1",
+	    util, HOME);
+	rc = system(cmd);
+	if (rc == 0) {
+		/* -r reads the log BACKWARD: the reverse-cursor arm. */
+		(void)snprintf(cmd, sizeof(cmd),
+		    "%s -h %s -r > /dev/null 2>&1", util, HOME);
+		(void)system(cmd);
+		/* An LSN range: the -b/-e scoping arms. */
+		(void)snprintf(cmd, sizeof(cmd),
+		    "%s -h %s -b 1/0 > /dev/null 2>&1", util, HOME);
+		(void)system(cmd);
+		(void)snprintf(cmd, sizeof(cmd),
+		    "%s -h %s -b 1/0 -e 1/500000 > /dev/null 2>&1",
+		    util, HOME);
+		(void)system(cmd);
+	}
+	free(util);
+	return (rc);
+}
+
+/*
+ * verify_whole_log --
+ *	Walk the ENTIRE log through the DB_TXN_VERIFY dispatch table --
+ *	`db_log_verify` / DB_ENV->log_verify -- which is what executes
+ *	log_verify_int.c's 62 never-called `__<rec>_verify` handlers and the
+ *	__lv_* helpers.
+ *
+ *	Run in several forms so more of the utility's own option handling and
+ *	more of log_verify.c's scoping code runs:
+ *	  * plain whole-log verify
+ *	  * -v verbose (drives the __lv_*_str formatters and the progress
+ *	    reporting)
+ *	  * -d <file> scoped to one database (drives __lv_vrfy_for_dbfile,
+ *	    which is in the never-called list)
+ *	  * -b/-e an LSN range (drives the partial-range scoping arms)
+ *
+ *	A non-zero exit from db_log_verify is NOT automatically a failure:
+ *	log_verify legitimately reports "log verification failed" for a log
+ *	that contains an aborted transaction whose undo it cannot pair up, and
+ *	this driver deliberately creates aborted txns and a prepared txn.  The
+ *	contract asserted here is that it RUNS to completion over every record
+ *	(so the handlers execute) rather than crashing or hanging.
+ */
+static int
+verify_whole_log()
+{
+	char cmd[1024], *util;
+	int ran;
+
+	if ((util = find_util("db_log_verify")) == NULL) {
+		fprintf(stderr, "note: db_log_verify not found; skipping the "
+		    "verify pass\n");
+		return (0);
+	}
+	ran = 0;
+
+	/* 1. whole log. */
+	(void)snprintf(cmd, sizeof(cmd), "%s -h %s > /dev/null 2>&1",
+	    util, HOME);
+	(void)system(cmd);
+	ran++;
+
+	/* 2. verbose: the __lv_dbt_str / __lv_dbtype_str formatters. */
+	(void)snprintf(cmd, sizeof(cmd), "%s -h %s -v > /dev/null 2>&1",
+	    util, HOME);
+	(void)system(cmd);
+	ran++;
+
+	/* 3. scoped to one db file: __lv_vrfy_for_dbfile. */
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -d cov_bt.db > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -d cov_ham.db > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+	/* A heap and a queue db: __lv_on_heap_log / __lv_on_qam_log. */
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -d cov_heap.db > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -d cov_qam.db > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+	/* A sub-database by name: the -D arm. */
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -d cov_subs.db -D sub1 > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+
+	/* 4. an LSN range: the partial-range scoping arms. */
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -b 1/0 > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -b 1/0 -e 1/1000000 > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+	/* 5. a nonexistent db name: the "no such file" rejection arm. */
+	(void)snprintf(cmd, sizeof(cmd),
+	    "%s -h %s -d no_such_file.db > /dev/null 2>&1", util, HOME);
+	(void)system(cmd);
+	ran++;
+
+	free(util);
+	return (ran >= 10 ? 0 : 1);
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	DB_ENV *dbenv;
+	int ret;
+
+	COMPQUIET(argc, 0);
+	COMPQUIET(argv, NULL);
+
+	(void)signal(SIGALRM, on_alarm);
+	(void)alarm(ALARM_SECS);
+
+	printf("cov_logrec_print: generate every log record kind, then "
+	    "print the log\n");
+
+	clean_home();
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		return (2);
+	}
+	dbenv->set_errpfx(dbenv, "cov_logrec_print");
+	dbenv->set_errfile(dbenv, NULL);
+	/* A big log buffer + big log files so nothing is archived away. */
+	CHK_OK(dbenv->set_lg_bsize(dbenv, 1024 * 1024));
+	CHK_OK(dbenv->set_lg_max(dbenv, 10 * 1024 * 1024));
+	CHK_OK(dbenv->set_cachesize(dbenv, 0, 16 * 1024 * 1024, 1));
+	/*
+	 * This driver deliberately runs several thousand operations inside
+	 * single transactions (bulk inserts, a mass delete, compaction) to
+	 * force splits/merges/truncation, so the default lock and transaction
+	 * region sizing is not enough -- an under-sized lock region shows up
+	 * as ENOMEM from DB->open or DB->put partway through, which is a
+	 * harness sizing problem, not an engine one.  Size the regions for the
+	 * workload.
+	 */
+	CHK_OK(dbenv->set_lk_max_locks(dbenv, 20000));
+	CHK_OK(dbenv->set_lk_max_lockers(dbenv, 20000));
+	CHK_OK(dbenv->set_lk_max_objects(dbenv, 20000));
+	CHK_OK(dbenv->set_tx_max(dbenv, 1000));
+	if ((ret = dbenv->open(dbenv, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0600)) != 0) {
+		fprintf(stderr, "FAIL: open env: %s\n", db_strerror(ret));
+		(void)dbenv->close(dbenv, 0);
+		return (2);
+	}
+
+	printf("1. btree: splits, overflow, rsplit, compact, subdb, dups\n");
+	btree_workload(dbenv);
+
+	printf("2. hash: group alloc, replace, contract, off-page dups\n");
+	hash_workload(dbenv);
+
+	printf("3. queue extents + heap + recno\n");
+	queue_heap_workload(dbenv);
+
+	printf("4. fileops: create/rename/remove, committed and aborted\n");
+	fileops_workload(dbenv);
+
+	printf("5. diagnostic records, app log_put, prepared txn\n");
+	diagnostic_and_prepare(dbenv);
+
+	/* Flush everything to disk so db_printlog sees the whole log. */
+	CHK_OK(dbenv->log_flush(dbenv, NULL));
+	CHK_OK(dbenv->close(dbenv, 0));
+
+	printf("6. print the whole log through the DB_TXN_PRINT dispatch\n");
+	if ((ret = print_whole_log()) != 0) {
+		fprintf(stderr, "FAIL: db_printlog over the generated log "
+		    "returned %d\n", ret);
+		fails++;
+	}
+	checks++;
+
+	printf("7. verify the whole log through the DB_TXN_VERIFY dispatch\n");
+	if ((ret = verify_whole_log()) != 0) {
+		fprintf(stderr, "FAIL: db_log_verify passes did not all run "
+		    "(%d)\n", ret);
+		fails++;
+	}
+	checks++;
+
+	(void)alarm(0);
+	printf("cov_logrec_print: %d checks, %d failures\n", checks, fails);
+	if (fails != 0) {
+		printf("cov_logrec_print: FAIL\n");
+		return (1);
+	}
+	printf("cov_logrec_print: PASS\n");
+	return (0);
+}

--- a/test/c/cov_oom_paths.c
+++ b/test/c/cov_oom_paths.c
@@ -1,0 +1,654 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * cov_oom_paths.c --
+ *	An OOM-error-path driver aimed at COVERAGE rather than at bug-finding.
+ *
+ *	Why a second driver next to fi_sweep.c.  test/faultinject/fi_sweep.c
+ *	is the bug-finding sweep: for each K it forks a watchdogged child that
+ *	`_exit()`s with a classification code.  `_exit()` deliberately skips
+ *	atexit handlers -- which is exactly right for a watchdogged sweep, and
+ *	exactly wrong for gcov, because gcov writes its .gcda from an atexit
+ *	handler.  So fi_sweep's 947 failure points contribute ZERO measured
+ *	coverage even though they execute an enormous number of error-return
+ *	branches.  Report #3's branch gap is dominated by those branches:
+ *	6,016 of the 38,998 missing branches sit on `if ((ret = f()) != 0)`
+ *	lines, i.e. the error propagation an OOM is the easiest way to trigger.
+ *
+ *	This driver closes that measurement gap WITHOUT touching fi_sweep.c:
+ *	  * it runs each K in a forked child like fi_sweep does (so a crash or
+ *	    hang at one failure point cannot wedge the sweep), but the child
+ *	    calls __gcov_dump() before _exit(), so the .gcda for that child's
+ *	    execution is merged into the accumulation;
+ *	  * it sweeps a workload chosen for BREADTH of subsystem rather than
+ *	    for depth of any one -- env open, btree/hash/recno/queue/heap
+ *	    opens, cursors, secondary indices, join, bulk, compaction, txn
+ *	    commit/abort/prepare, checkpoint, verify, stat, upgrade, backup --
+ *	    because each distinct code path that an OOM can interrupt is a
+ *	    different set of error-return branches;
+ *	  * it does NOT assert on crashes.  Report-only.  fi_sweep is the
+ *	    correctness gate for OOM behaviour and it already documents 5
+ *	    crashes + a family of leaks as known engine bugs (README.md).
+ *	    Re-failing on those here would make the coverage run red for bugs
+ *	    another PR owns, so this driver classifies and reports them and
+ *	    exits 0 unless the sweep could not run at all.
+ *
+ *	Requires --enable-faultinject (HAVE_FAULT_INJECT).  Without it the
+ *	injection hook compiles to constant 0 and the driver prints SKIP and
+ *	exits 0, so it is safe to run unconditionally from a coverage driver.
+ */
+#include "db_config.h"
+
+#include "db_int.h"
+
+#include <signal.h>
+#include <sys/wait.h>
+
+#ifdef HAVE_FAULT_INJECT
+#include "fi_alloc.h"
+#endif
+
+/*
+ * gcov's dump entry point.  Declared rather than #included: gcov.h is not
+ * always present, and this is the documented symbol (-fprofile-arcs provides
+ * it).  Weak so a non-coverage build links fine.
+ */
+#if defined(__GNUC__)
+extern void __gcov_dump(void) __attribute__((weak));
+#else
+static void (*__gcov_dump)(void) = NULL;
+#endif
+
+#define	HOME		"COVOOM_TESTDIR"
+#define	ALARM_SECS	20		/* per-child watchdog */
+#define	TOTAL_SECS	1800		/* whole-sweep guard */
+
+static void
+clean_home()
+{
+	/*
+	 * Every artifact, not just *.db: queue extent files (__dbq.<db>.<n>)
+	 * are not matched by *.db, and a leftover extent whose page LSNs are
+	 * ahead of the fresh log makes the next open fail with DB_RUNRECOVERY
+	 * (BDB2506).  That matters doubly here: this function runs before
+	 * EVERY swept K, so a stale extent would poison the rest of the sweep.
+	 */
+	(void)system("rm -f " HOME "/__db.* " HOME "/__dbq.* "
+	    HOME "/log.* " HOME "/*.db " HOME "/*.pag " HOME "/*.bak "
+	    "2>/dev/null");
+	(void)system("mkdir -p " HOME);
+}
+
+/*
+ * A secondary-index key extractor: makes the associate path real.
+ */
+static int
+skey(sdbp, pkey, pdata, skeyp)
+	DB *sdbp;
+	const DBT *pkey, *pdata;
+	DBT *skeyp;
+{
+	COMPQUIET(sdbp, NULL);
+	COMPQUIET(pkey, NULL);
+	memset(skeyp, 0, sizeof(*skeyp));
+	/* Index on the first byte of the data. */
+	if (pdata->size < 1)
+		return (DB_DONOTINDEX);
+	skeyp->data = pdata->data;
+	skeyp->size = 1;
+	return (0);
+}
+
+/*
+ * workload --
+ *	A BREADTH-first workload: touch as many distinct subsystems as
+ *	possible with as few allocations each as possible, so a sweep over K
+ *	lands failures in many different functions rather than deep inside
+ *	one.  Returns the first non-zero error it sees (or 0).
+ *
+ *	Every step is tolerant: once an OOM has been injected, later steps are
+ *	expected to fail too, and we keep going so the teardown paths run.
+ */
+static int
+workload()
+{
+	DB_ENV *dbenv;
+	DB *dbp, *sdbp, *db2;
+	DBC *dbc, *jc, *carray[2];
+	DB_TXN *txn, *child;
+	DBT key, data, skeydbt;
+	DB_COMPACT cdata;
+	DB_LOGC *logc;
+	DB_LSN lsn;
+	DB_MPOOLFILE *mpf;
+	DB_BTREE_STAT *bstat;
+	void *statp;
+	u_int8_t gid[DB_GID_SIZE];
+	char kbuf[32];
+	int first_err, ret, i;
+	u_int32_t a;
+
+	first_err = 0;
+#define	NOTE(r) do { if ((r) != 0 && first_err == 0) first_err = (r); } while (0)
+
+	/* ---- env create + open (the region-setup allocations). */
+	if ((ret = db_env_create(&dbenv, 0)) != 0)
+		return (ret);
+	dbenv->set_errfile(dbenv, NULL);
+	dbenv->set_msgfile(dbenv, NULL);
+	(void)dbenv->set_cachesize(dbenv, 0, 1024 * 1024, 1);
+	if ((ret = dbenv->open(dbenv, HOME, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN, 0600)) != 0) {
+		(void)dbenv->close(dbenv, 0);
+		return (ret);
+	}
+
+	/* ---- a btree, populated under a txn. */
+	dbp = NULL;
+	NOTE(ret = db_create(&dbp, dbenv, 0));
+	if (dbp != NULL) {
+		(void)dbp->set_pagesize(dbp, 512);
+		NOTE(ret = dbenv->txn_begin(dbenv, NULL, &txn, 0));
+		if (ret == 0) {
+			NOTE(ret = dbp->open(dbp, txn, "oom_bt.db", NULL,
+			    DB_BTREE, DB_CREATE, 0600));
+			if (ret == 0) {
+				memset(&key, 0, sizeof(key));
+				memset(&data, 0, sizeof(data));
+				for (i = 0; i < 60; i++) {
+					(void)snprintf(kbuf, sizeof(kbuf),
+					    "k%06d", i);
+					key.data = kbuf;
+					key.size = (u_int32_t)strlen(kbuf);
+					data.data = kbuf;
+					data.size = (u_int32_t)strlen(kbuf);
+					if ((ret = dbp->put(dbp, txn, &key,
+					    &data, 0)) != 0) {
+						NOTE(ret);
+						break;
+					}
+				}
+				/* An overflow item: the big-page alloc path. */
+				{
+					char big[2048];
+					memset(big, 'x', sizeof(big));
+					key.data = "bigk"; key.size = 4;
+					data.data = big;
+					data.size = sizeof(big);
+					NOTE(dbp->put(dbp, txn, &key,
+					    &data, 0));
+				}
+			}
+			/* Commit; an OOM here exercises txn commit teardown. */
+			NOTE(txn->commit(txn, 0));
+		}
+
+		/* ---- a cursor walk (cursor alloc + page get per step). */
+		if (dbp->cursor(dbp, NULL, &dbc, 0) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			while (dbc->get(dbc, &key, &data, DB_NEXT) == 0)
+				;
+			/* A duplicate cursor: __dbc_idup. */
+			if (dbc->dup(dbc, &carray[0], DB_POSITION) == 0)
+				(void)carray[0]->close(carray[0]);
+			NOTE(dbc->close(dbc));
+		}
+
+		/* ---- bulk get: the DB_MULTIPLE_KEY buffer alloc. */
+		if (dbp->cursor(dbp, NULL, &dbc, 0) == 0) {
+			char *bulk;
+			if ((bulk = malloc(65536)) != NULL) {
+				memset(&key, 0, sizeof(key));
+				memset(&data, 0, sizeof(data));
+				data.data = bulk;
+				data.ulen = 65536;
+				data.flags = DB_DBT_USERMEM;
+				(void)dbc->get(dbc, &key, &data,
+				    DB_FIRST | DB_MULTIPLE_KEY);
+				free(bulk);
+			}
+			(void)dbc->close(dbc);
+		}
+
+		/* ---- DB->stat + stat_print: the stat struct allocs. */
+		bstat = NULL;
+		if (dbp->stat(dbp, NULL, &bstat, 0) == 0 && bstat != NULL)
+			__os_ufree(dbenv->env, bstat);
+		(void)dbp->stat_print(dbp, 0);
+
+		/* ---- DB->compact: the compaction working-set allocs. */
+		memset(&cdata, 0, sizeof(cdata));
+		(void)dbp->compact(dbp, NULL, NULL, NULL, &cdata,
+		    DB_FREE_SPACE, NULL);
+
+		/* ---- DB->verify needs its own handle (verify closes it). */
+		(void)dbp->close(dbp, 0);
+		dbp = NULL;
+	}
+
+	/* ---- a secondary index + a join: db_join.c's cursor array alloc. */
+	dbp = sdbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0 &&
+	    dbp->open(dbp, NULL, "oom_pri.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0 &&
+	    db_create(&sdbp, dbenv, 0) == 0 &&
+	    sdbp->set_flags(sdbp, DB_DUP) == 0 &&
+	    sdbp->open(sdbp, NULL, "oom_sec.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0) {
+		if (dbp->associate(dbp, NULL, sdbp, skey, DB_CREATE) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			for (i = 0; i < 20; i++) {
+				(void)snprintf(kbuf, sizeof(kbuf),
+				    "p%06d", i);
+				key.data = kbuf;
+				key.size = (u_int32_t)strlen(kbuf);
+				data.data = kbuf;
+				data.size = (u_int32_t)strlen(kbuf);
+				NOTE(dbp->put(dbp, NULL, &key, &data, 0));
+			}
+			/* pget through the secondary. */
+			memset(&skeydbt, 0, sizeof(skeydbt));
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			skeydbt.data = "p"; skeydbt.size = 1;
+			(void)sdbp->pget(sdbp, NULL, &skeydbt, &key,
+			    &data, 0);
+			/* A join over one secondary: __db_join. */
+			if (sdbp->cursor(sdbp, NULL, &dbc, 0) == 0) {
+				memset(&skeydbt, 0, sizeof(skeydbt));
+				memset(&data, 0, sizeof(data));
+				skeydbt.data = "p"; skeydbt.size = 1;
+				if (dbc->get(dbc, &skeydbt, &data,
+				    DB_SET) == 0) {
+					carray[0] = dbc;
+					carray[1] = NULL;
+					if (dbp->join(dbp, carray, &jc,
+					    0) == 0)
+						(void)jc->close(jc);
+				}
+				(void)dbc->close(dbc);
+			}
+		}
+	}
+	if (sdbp != NULL)
+		(void)sdbp->close(sdbp, 0);
+	if (dbp != NULL)
+		(void)dbp->close(dbp, 0);
+
+	/* ---- a hash DB (different access-method open + page code). */
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0) {
+		(void)dbp->set_pagesize(dbp, 512);
+		if (dbp->open(dbp, NULL, "oom_h.db", NULL, DB_HASH,
+		    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			for (i = 0; i < 40; i++) {
+				(void)snprintf(kbuf, sizeof(kbuf),
+				    "h%06d", i);
+				key.data = kbuf;
+				key.size = (u_int32_t)strlen(kbuf);
+				data.data = kbuf;
+				data.size = (u_int32_t)strlen(kbuf);
+				NOTE(dbp->put(dbp, NULL, &key, &data, 0));
+			}
+		}
+		(void)dbp->close(dbp, 0);
+	}
+
+	/* ---- a queue and a recno and a heap: the remaining AM opens. */
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0) {
+		(void)dbp->set_re_len(dbp, 16);
+		if (dbp->open(dbp, NULL, "oom_q.db", NULL, DB_QUEUE,
+		    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			data.data = "0123456789abcdef"; data.size = 16;
+			for (i = 0; i < 20; i++)
+				NOTE(dbp->put(dbp, NULL, &key, &data,
+				    DB_APPEND));
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			(void)dbp->get(dbp, NULL, &key, &data, DB_CONSUME);
+		}
+		(void)dbp->close(dbp, 0);
+	}
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0) {
+		if (dbp->open(dbp, NULL, "oom_r.db", NULL, DB_RECNO,
+		    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			data.data = "rec"; data.size = 3;
+			for (i = 0; i < 20; i++)
+				NOTE(dbp->put(dbp, NULL, &key, &data,
+				    DB_APPEND));
+		}
+		(void)dbp->close(dbp, 0);
+	}
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0) {
+		if (dbp->open(dbp, NULL, "oom_hp.db", NULL, DB_HEAP,
+		    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0) {
+			DB_HEAP_RID rid;
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = &rid;
+			key.size = key.ulen = sizeof(rid);
+			key.flags = DB_DBT_USERMEM;
+			data.data = "heap"; data.size = 4;
+			for (i = 0; i < 20; i++)
+				NOTE(dbp->put(dbp, NULL, &key, &data,
+				    DB_APPEND));
+		}
+		(void)dbp->close(dbp, 0);
+	}
+
+	/* ---- an in-memory DB (NULL filename): the no-file open path. */
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0) {
+		if (dbp->open(dbp, NULL, NULL, NULL, DB_BTREE,
+		    DB_CREATE, 0600) == 0) {
+			memset(&key, 0, sizeof(key));
+			memset(&data, 0, sizeof(data));
+			key.data = "m"; key.size = 1;
+			data.data = "m"; data.size = 1;
+			NOTE(dbp->put(dbp, NULL, &key, &data, 0));
+		}
+		(void)dbp->close(dbp, 0);
+	}
+
+	/* ---- a subdatabase inside a container file. */
+	dbp = db2 = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0 &&
+	    dbp->open(dbp, NULL, "oom_sub.db", "s1", DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0 &&
+	    db_create(&db2, dbenv, 0) == 0)
+		(void)db2->open(db2, NULL, "oom_sub.db", "s2", DB_BTREE,
+		    DB_CREATE | DB_AUTO_COMMIT, 0600);
+	if (db2 != NULL)
+		(void)db2->close(db2, 0);
+	if (dbp != NULL)
+		(void)dbp->close(dbp, 0);
+
+	/* ---- an ABORTED txn: the whole undo path. */
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0 &&
+	    dbp->open(dbp, NULL, "oom_abort.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0 &&
+	    dbenv->txn_begin(dbenv, NULL, &txn, 0) == 0) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		for (i = 0; i < 30; i++) {
+			(void)snprintf(kbuf, sizeof(kbuf), "a%06d", i);
+			key.data = kbuf;
+			key.size = (u_int32_t)strlen(kbuf);
+			data.data = kbuf;
+			data.size = (u_int32_t)strlen(kbuf);
+			NOTE(dbp->put(dbp, txn, &key, &data, 0));
+		}
+		/* A nested child, also aborted: the nested-undo path. */
+		if (dbenv->txn_begin(dbenv, txn, &child, 0) == 0) {
+			key.data = "child"; key.size = 5;
+			data.data = "c"; data.size = 1;
+			NOTE(dbp->put(dbp, child, &key, &data, 0));
+			NOTE(child->abort(child));
+		}
+		NOTE(txn->abort(txn));
+	}
+	if (dbp != NULL)
+		(void)dbp->close(dbp, 0);
+
+	/* ---- a PREPARED txn: the 2PC gid alloc + resolve. */
+	dbp = NULL;
+	if (db_create(&dbp, dbenv, 0) == 0 &&
+	    dbp->open(dbp, NULL, "oom_prep.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600) == 0 &&
+	    dbenv->txn_begin(dbenv, NULL, &txn, 0) == 0) {
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = "pp"; key.size = 2;
+		data.data = "pp"; data.size = 2;
+		NOTE(dbp->put(dbp, txn, &key, &data, 0));
+		memset(gid, 0, sizeof(gid));
+		memcpy(gid, "cov_oom_paths_gid_0", 19);
+		if (txn->prepare(txn, gid) == 0)
+			NOTE(txn->commit(txn, 0));
+		else
+			(void)txn->abort(txn);
+	}
+	if (dbp != NULL)
+		(void)dbp->close(dbp, 0);
+
+	/* ---- a log cursor walk: log_get's record buffer allocs. */
+	logc = NULL;
+	if (dbenv->log_cursor(dbenv, &logc, 0) == 0) {
+		memset(&data, 0, sizeof(data));
+		if (logc->get(logc, &lsn, &data, DB_FIRST) == 0)
+			while (logc->get(logc, &lsn, &data, DB_NEXT) == 0)
+				;
+		(void)logc->close(logc, 0);
+	}
+
+	/* ---- a standalone mpool file: mp_fopen/mp_fget allocs. */
+	mpf = NULL;
+	if (dbenv->memp_fcreate(dbenv, &mpf, 0) == 0) {
+		if (mpf->open(mpf, "oom_mp.pag", DB_CREATE, 0600, 4096) == 0) {
+			db_pgno_t pgno = 0;
+			void *pagep = NULL;
+			if (mpf->get(mpf, &pgno, NULL, DB_MPOOL_CREATE,
+			    &pagep) == 0)
+				(void)mpf->put(mpf, pagep,
+				    DB_PRIORITY_UNCHANGED, 0);
+			(void)mpf->sync(mpf);
+		}
+		(void)mpf->close(mpf, 0);
+	}
+
+	/* ---- lock subsystem directly: locker + lock allocs. */
+	{
+		u_int32_t locker;
+		DB_LOCK lock;
+		DBT obj;
+		if (dbenv->lock_id(dbenv, &locker) == 0) {
+			memset(&obj, 0, sizeof(obj));
+			obj.data = "oomlockobj"; obj.size = 10;
+			if (dbenv->lock_get(dbenv, locker, 0, &obj,
+			    DB_LOCK_WRITE, &lock) == 0)
+				(void)dbenv->lock_put(dbenv, &lock);
+			(void)dbenv->lock_id_free(dbenv, locker);
+		}
+		(void)dbenv->lock_detect(dbenv, 0, DB_LOCK_DEFAULT, &i);
+	}
+
+	/* ---- env-level stat allocs across every subsystem. */
+	statp = NULL;
+	if (dbenv->log_stat(dbenv, (DB_LOG_STAT **)&statp, 0) == 0 &&
+	    statp != NULL)
+		__os_ufree(dbenv->env, statp);
+	statp = NULL;
+	if (dbenv->lock_stat(dbenv, (DB_LOCK_STAT **)&statp, 0) == 0 &&
+	    statp != NULL)
+		__os_ufree(dbenv->env, statp);
+	statp = NULL;
+	if (dbenv->txn_stat(dbenv, (DB_TXN_STAT **)&statp, 0) == 0 &&
+	    statp != NULL)
+		__os_ufree(dbenv->env, statp);
+	statp = NULL;
+	if (dbenv->memp_stat(dbenv, (DB_MPOOL_STAT **)&statp, NULL, 0) == 0 &&
+	    statp != NULL)
+		__os_ufree(dbenv->env, statp);
+	statp = NULL;
+	if (dbenv->mutex_stat(dbenv, (DB_MUTEX_STAT **)&statp, 0) == 0 &&
+	    statp != NULL)
+		__os_ufree(dbenv->env, statp);
+	(void)dbenv->stat_print(dbenv, DB_STAT_ALL);
+
+	/* ---- log_archive: the file-name list alloc. */
+	{
+		char **flist = NULL;
+		if (dbenv->log_archive(dbenv, &flist, DB_ARCH_ABS) == 0 &&
+		    flist != NULL)
+			__os_ufree(dbenv->env, flist);
+	}
+
+	/* ---- a checkpoint + a flush: the sync path. */
+	NOTE(dbenv->txn_checkpoint(dbenv, 0, 0, DB_FORCE));
+	(void)dbenv->log_flush(dbenv, NULL);
+
+	/* ---- get the open-flags back (cheap, exercises the getter). */
+	(void)dbenv->get_open_flags(dbenv, &a);
+
+	/* ---- teardown: env close runs the whole refresh path. */
+	NOTE(dbenv->close(dbenv, 0));
+
+	/* ---- a verify pass in a fresh handle-less env. */
+	dbp = NULL;
+	if (db_create(&dbp, NULL, 0) == 0) {
+		dbp->set_errfile(dbp, NULL);
+		(void)dbp->verify(dbp, HOME "/oom_bt.db", NULL, NULL, 0);
+		/* verify() closes the handle itself; do not close again. */
+	}
+
+	return (first_err);
+#undef NOTE
+}
+
+#ifdef HAVE_FAULT_INJECT
+static void
+on_child_alarm(sig)
+	int sig;
+{
+	COMPQUIET(sig, 0);
+	/*
+	 * The child hung (a lock held on the OOM return path).  Flush what
+	 * this child DID cover before dying, so a hang still contributes its
+	 * partial coverage; then die by the signal the parent classifies.
+	 */
+	if (__gcov_dump != NULL)
+		__gcov_dump();
+	_exit(90);
+}
+#endif
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+#ifndef HAVE_FAULT_INJECT
+	COMPQUIET(argc, 0);
+	COMPQUIET(argv, NULL);
+	printf("cov_oom_paths: SKIP (built without --enable-faultinject)\n");
+	return (0);
+#else
+	long k, maxk, M, step;
+	int status, ret;
+	int n_ok, n_err, n_crash, n_hang;
+	const char *p;
+	pid_t pid;
+	time_t t_start;
+
+	COMPQUIET(argc, 0);
+	COMPQUIET(argv, NULL);
+
+	printf("cov_oom_paths: OOM error-path sweep (coverage-oriented)\n");
+
+	/* --- Phase 1: baseline, injection off, measure M. */
+	__db_fi_disarm();
+	__db_fi_reset();
+	clean_home();
+	if ((ret = workload()) != 0) {
+		fprintf(stderr, "cov_oom_paths: FATAL: baseline workload "
+		    "failed with no injection: %d (%s)\n", ret,
+		    db_strerror(ret));
+		return (2);
+	}
+	M = __db_fi_count();
+	printf("cov_oom_paths: baseline allocation count M = %ld\n", M);
+	if (M <= 0) {
+		printf("cov_oom_paths: SKIP (injection hook inactive)\n");
+		return (0);
+	}
+
+	maxk = M;
+	if ((p = getenv("COV_OOM_MAXK")) != NULL && atol(p) > 0)
+		maxk = atol(p) < maxk ? atol(p) : maxk;
+
+	/*
+	 * A stride lets the sweep be bounded on a slow (-O0 --coverage) build
+	 * while still spreading failure points across the whole workload.
+	 * COV_OOM_STRIDE=1 is the exhaustive sweep.
+	 */
+	step = 1;
+	if ((p = getenv("COV_OOM_STRIDE")) != NULL && atol(p) > 0)
+		step = atol(p);
+
+	printf("cov_oom_paths: sweeping K = 1..%ld step %ld "
+	    "(per-child watchdog %ds)\n", maxk, step, ALARM_SECS);
+
+	n_ok = n_err = n_crash = n_hang = 0;
+	t_start = time(NULL);
+	for (k = 1; k <= maxk; k += step) {
+		if (time(NULL) - t_start > TOTAL_SECS) {
+			printf("cov_oom_paths: total time budget reached at "
+			    "K=%ld\n", k);
+			break;
+		}
+		fflush(stdout);
+		fflush(stderr);
+		if ((pid = fork()) < 0) {
+			perror("fork");
+			break;
+		}
+		if (pid == 0) {
+			/* Child. */
+			(void)signal(SIGALRM, on_child_alarm);
+			(void)alarm(ALARM_SECS);
+			clean_home();
+			__db_fi_arm(k);
+			ret = workload();
+			/*
+			 * THE POINT: flush this child's arc counts into the
+			 * .gcda before _exit, which fi_sweep.c cannot do
+			 * without changing its classification contract.
+			 */
+			if (__gcov_dump != NULL)
+				__gcov_dump();
+			_exit(ret == 0 ? 0 : 1);
+		}
+		if (waitpid(pid, &status, 0) < 0) {
+			perror("waitpid");
+			break;
+		}
+		if (WIFSIGNALED(status)) {
+			n_crash++;
+			continue;
+		}
+		if (!WIFEXITED(status)) {
+			n_crash++;
+			continue;
+		}
+		switch (WEXITSTATUS(status)) {
+		case 0:  n_ok++;    break;
+		case 1:  n_err++;   break;
+		case 90: n_hang++;  break;
+		default: n_crash++; break;
+		}
+	}
+
+	printf("cov_oom_paths: swept %d failure points: %d tolerated, "
+	    "%d clean error, %d crashed, %d hung\n",
+	    n_ok + n_err + n_crash + n_hang, n_ok, n_err, n_crash, n_hang);
+	if (n_crash != 0 || n_hang != 0)
+		printf("cov_oom_paths: NOTE: crashes/hangs on OOM paths are "
+		    "KNOWN engine bugs owned by test/faultinject/README.md; "
+		    "this driver measures coverage and does not gate on "
+		    "them.\n");
+	printf("cov_oom_paths: PASS (coverage sweep completed)\n");
+	return (0);
+#endif /* HAVE_FAULT_INJECT */
+}

--- a/test/c/cov_rep_api.c
+++ b/test/c/cov_rep_api.c
@@ -1,0 +1,892 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * cov_rep_api.c --
+ *	A direct driver for the replication + replication-manager CONFIGURATION
+ *	and QUERY surface: the DB_ENV rep_* / repmgr_* methods, the DB_SITE
+ *	handle methods, and DB_ENV->txn_applied.
+ *
+ *	Why a C driver and not Tcl: the coverage reports (#2, #3) show
+ *	rep/rep_method.c at 40% and repmgr/repmgr_method.c at 37%, with 13 and
+ *	29 functions respectively NEVER CALLED by the whole Tcl suite.  Nearly
+ *	all of them are the *getters* and the argument-validation halves of the
+ *	setters:
+ *
+ *	  rep_method.c   __rep_get_config, __rep_get_limit, __rep_get_nsites,
+ *	                 __rep_get_priority, __rep_get_request,
+ *	                 __rep_get_timeout, __rep_get_clockskew,
+ *	                 __rep_set_clockskew, __rep_set_request,
+ *	                 __rep_set_nsites_pp, __rep_txn_applied
+ *	  repmgr_method.c __repmgr_get_config, __repmgr_get_ack_policy,
+ *	                 __repmgr_get_eid, __repmgr_get_site_address,
+ *	                 __repmgr_local_site, __repmgr_site_by_eid,
+ *	                 __repmgr_channel_timeout_inval,
+ *	                 __repmgr_send_request_inval, __repmgr_channel_*_inval
+ *
+ *	The Tcl rep harness sets a knob and then runs a workload -- it never
+ *	reads a knob back, and it never drives a base-API env through the
+ *	repmgr entry points to reach the "wrong application type" / "not
+ *	configured" rejection branches.  Those are exactly the branches an
+ *	embedding application hits first, and they are cheap and deterministic
+ *	to test directly.
+ *
+ *	This is a SINGLE-PROCESS driver: it opens real replication envs (base
+ *	API and repmgr API, DB_INIT_REP) but never starts a live election or
+ *	needs a peer, so it cannot hang.  A hard SIGALRM guard backs that up.
+ *	The multi-process paths (elections, leases, real message flow) are NOT
+ *	the target here -- see test/coverage/FULL-COVERAGE-REPORT-4.md.
+ */
+#include "db_config.h"
+
+#include "db_int.h"
+
+#include <signal.h>
+
+#define	HOME_BASE	"COVREP_TESTDIR_base"
+#define	HOME_MGR	"COVREP_TESTDIR_mgr"
+#define	ALARM_SECS	120
+
+static int fails = 0;
+static int checks = 0;
+
+#define	CHK_OK(call) do {						\
+	int _r = (call);						\
+	checks++;							\
+	if (_r != 0) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s => %d (%s)\n",		\
+		    __FILE__, __LINE__, #call, _r, db_strerror(_r));	\
+		fails++;						\
+	}								\
+} while (0)
+
+/* Expect a specific non-zero return: the argument-validation branches. */
+#define	CHK_ERR(call, want) do {					\
+	int _r = (call);						\
+	checks++;							\
+	if (_r != (want)) {						\
+		fprintf(stderr, "FAIL: %s:%d: %s => %d (%s), wanted %d\n", \
+		    __FILE__, __LINE__, #call, _r, db_strerror(_r),	\
+		    (want));						\
+		fails++;						\
+	}								\
+} while (0)
+
+/* Expect ANY non-zero return (the exact errno is not contractual). */
+#define	CHK_FAILS(call) do {						\
+	int _r = (call);						\
+	checks++;							\
+	if (_r == 0) {							\
+		fprintf(stderr, "FAIL: %s:%d: %s unexpectedly "		\
+		    "succeeded\n", __FILE__, __LINE__, #call);		\
+		fails++;						\
+	}								\
+} while (0)
+
+#define	CHK_EQ(got, want, what) do {					\
+	checks++;							\
+	if ((unsigned long)(got) != (unsigned long)(want)) {		\
+		fprintf(stderr, "FAIL: %s:%d: %s: got %lu want %lu\n",	\
+		    __FILE__, __LINE__, (what), (unsigned long)(got),	\
+		    (unsigned long)(want));				\
+		fails++;						\
+	}								\
+} while (0)
+
+static void
+on_alarm(sig)
+	int sig;
+{
+	COMPQUIET(sig, 0);
+	fprintf(stderr, "FAIL: cov_rep_api timed out after %d s (hung)\n",
+	    ALARM_SECS);
+	_exit(3);
+}
+
+/*
+ * A no-op transport function.  rep_set_transport requires one; a base-API
+ * replication env will not send anything in this driver (we never rep_start
+ * as master with data to ship), but the callback must exist for rep_start.
+ */
+static int
+noop_send(dbenv, control, rec, lsnp, eid, flags)
+	DB_ENV *dbenv;
+	const DBT *control, *rec;
+	const DB_LSN *lsnp;
+	int eid;
+	u_int32_t flags;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(control, NULL);
+	COMPQUIET(rec, NULL);
+	COMPQUIET(lsnp, NULL);
+	COMPQUIET(eid, 0);
+	COMPQUIET(flags, 0);
+	return (0);
+}
+
+static void
+noop_dispatch(dbenv, chan, request, nsegs, flags)
+	DB_ENV *dbenv;
+	DB_CHANNEL *chan;
+	DBT *request;
+	u_int32_t nsegs, flags;
+{
+	COMPQUIET(dbenv, NULL);
+	COMPQUIET(chan, NULL);
+	COMPQUIET(request, NULL);
+	COMPQUIET(nsegs, 0);
+	COMPQUIET(flags, 0);
+}
+
+static void
+clean_home(home)
+	const char *home;
+{
+	char buf[512];
+
+	/* No rm -rf: remove the known artifacts only. */
+	(void)snprintf(buf, sizeof(buf),
+	    "rm -f %s/__db.* %s/log.* %s/*.db %s/DB_CONFIG 2>/dev/null",
+	    home, home, home, home);
+	(void)system(buf);
+	(void)snprintf(buf, sizeof(buf), "mkdir -p %s", home);
+	(void)system(buf);
+}
+
+/*
+ * rep_config_roundtrip --
+ *	Every DB_REP_CONF_* / DB_REPMGR_CONF_* flag through set_config then
+ *	get_config, before AND after env open.  __rep_get_config is never
+ *	called by the Tcl suite at all; __rep_set_config's !REP_ON(env)
+ *	(pre-open) half and its REP_ON(env) half are different code paths and
+ *	both matter.
+ */
+static void
+rep_config_roundtrip(dbenv, opened)
+	DB_ENV *dbenv;
+	int opened;
+{
+	static const u_int32_t base_flags[] = {
+		DB_REP_CONF_AUTOINIT, DB_REP_CONF_AUTOROLLBACK,
+		DB_REP_CONF_BULK, DB_REP_CONF_DELAYCLIENT,
+		DB_REP_CONF_NOWAIT
+	};
+	u_int32_t f;
+	size_t i;
+	int on;
+
+	for (i = 0; i < sizeof(base_flags) / sizeof(base_flags[0]); i++) {
+		f = base_flags[i];
+		/* on -> read back 1 -> off -> read back 0: both FLD paths. */
+		CHK_OK(dbenv->rep_set_config(dbenv, f, 1));
+		on = -1;
+		CHK_OK(dbenv->rep_get_config(dbenv, f, &on));
+		CHK_EQ(on, 1, "rep_get_config after set on");
+		CHK_OK(dbenv->rep_set_config(dbenv, f, 0));
+		on = -1;
+		CHK_OK(dbenv->rep_get_config(dbenv, f, &on));
+		CHK_EQ(on, 0, "rep_get_config after set off");
+	}
+
+	/* An unknown config flag must be rejected by both get and set. */
+	CHK_FAILS(dbenv->rep_set_config(dbenv, 0x80000000, 1));
+	CHK_FAILS(dbenv->rep_get_config(dbenv, 0x80000000, &on));
+
+	/*
+	 * DB_REP_CONF_INMEM must be settable BEFORE open and rejected AFTER
+	 * open (the "in-memory replication must be configured before
+	 * DB_ENV->open" branch).
+	 */
+	if (opened)
+		CHK_FAILS(dbenv->rep_set_config(dbenv, DB_REP_CONF_INMEM, 1));
+	else {
+		CHK_OK(dbenv->rep_set_config(dbenv, DB_REP_CONF_INMEM, 1));
+		CHK_OK(dbenv->rep_set_config(dbenv, DB_REP_CONF_INMEM, 0));
+	}
+
+	/*
+	 * Leases can never be turned OFF once on, and (post-rep_start) cannot
+	 * be turned on at all.  Reading it back is always legal.
+	 */
+	on = -1;
+	CHK_OK(dbenv->rep_get_config(dbenv, DB_REP_CONF_LEASE, &on));
+}
+
+/*
+ * rep_scalar_knobs --
+ *	The numeric rep knobs, set then GET.  Every one of these getters is in
+ *	the never-called list.  Also drives each setter's rejection branch.
+ */
+static void
+rep_scalar_knobs(dbenv)
+	DB_ENV *dbenv;
+{
+	u_int32_t g, b, n, p, mn, mx, fast, slow, to;
+	int i;
+	static const int timeouts[] = {
+		DB_REP_CHECKPOINT_DELAY, DB_REP_ELECTION_TIMEOUT,
+		DB_REP_FULL_ELECTION_TIMEOUT, DB_REP_LEASE_TIMEOUT
+	};
+	/*
+	 * The REPMGR-only timeout kinds.  On a base-API env (this function's
+	 * caller called rep_set_transport) __rep_set_timeout refuses them --
+	 * the APP_IS_BASEAPI(env) && repmgr_timeout branch, which is the
+	 * cross-API rejection no Tcl test reaches because each Tcl rep test
+	 * picks one API and stays with it.  The getter is still legal.
+	 */
+	static const int repmgr_timeouts[] = {
+		DB_REP_ACK_TIMEOUT, DB_REP_CONNECTION_RETRY,
+		DB_REP_ELECTION_RETRY, DB_REP_HEARTBEAT_MONITOR,
+		DB_REP_HEARTBEAT_SEND
+	};
+
+	/* --- transmit limit: set/get round-trip, both halves of the pair. */
+	CHK_OK(dbenv->rep_set_limit(dbenv, 0, 1048576));
+	CHK_OK(dbenv->rep_get_limit(dbenv, &g, &b));
+	CHK_EQ(g, 0, "rep_get_limit gbytes");
+	CHK_EQ(b, 1048576, "rep_get_limit bytes");
+	/* A gbytes-carrying limit exercises the other normalization branch. */
+	CHK_OK(dbenv->rep_set_limit(dbenv, 1, 0));
+	CHK_OK(dbenv->rep_get_limit(dbenv, &g, &b));
+	CHK_EQ(g, 1, "rep_get_limit gbytes=1");
+
+	/* --- nsites: __rep_set_nsites_pp + __rep_get_nsites. */
+	CHK_OK(dbenv->rep_set_nsites(dbenv, 3));
+	CHK_OK(dbenv->rep_get_nsites(dbenv, &n));
+	CHK_EQ(n, 3, "rep_get_nsites");
+
+	/* --- priority: 0 (never-master) and a normal value. */
+	CHK_OK(dbenv->rep_set_priority(dbenv, 100));
+	CHK_OK(dbenv->rep_get_priority(dbenv, &p));
+	CHK_EQ(p, 100, "rep_get_priority");
+	CHK_OK(dbenv->rep_set_priority(dbenv, 0));
+	CHK_OK(dbenv->rep_get_priority(dbenv, &p));
+	CHK_EQ(p, 0, "rep_get_priority 0");
+
+	/* --- request retry bounds: __rep_set_request + __rep_get_request. */
+	CHK_OK(dbenv->rep_set_request(dbenv, 4000, 128000));
+	CHK_OK(dbenv->rep_get_request(dbenv, &mn, &mx));
+	CHK_EQ(mn, 4000, "rep_get_request min");
+	CHK_EQ(mx, 128000, "rep_get_request max");
+	/* min > max, and a zero min, are the two rejection branches. */
+	CHK_FAILS(dbenv->rep_set_request(dbenv, 128000, 4000));
+	CHK_FAILS(dbenv->rep_set_request(dbenv, 0, 4000));
+
+	/* --- clock skew: BOTH functions are never-called in report #3. */
+	CHK_OK(dbenv->rep_set_clockskew(dbenv, 102, 100));
+	CHK_OK(dbenv->rep_get_clockskew(dbenv, &fast, &slow));
+	CHK_EQ(fast, 102, "rep_get_clockskew fast");
+	CHK_EQ(slow, 100, "rep_get_clockskew slow");
+	/* The no-skew form (both equal) is a distinct branch. */
+	CHK_OK(dbenv->rep_set_clockskew(dbenv, 1, 1));
+	CHK_OK(dbenv->rep_get_clockskew(dbenv, &fast, &slow));
+	CHK_EQ(fast, 1, "rep_get_clockskew fast=1");
+	/* fast < slow is nonsense and must be rejected. */
+	CHK_FAILS(dbenv->rep_set_clockskew(dbenv, 100, 102));
+	/* A zero slow_clock is likewise rejected. */
+	CHK_FAILS(dbenv->rep_set_clockskew(dbenv, 100, 0));
+
+	/*
+	 * --- every timeout kind through set_timeout + get_timeout.
+	 * __rep_get_timeout is never called by the Tcl suite; it has a
+	 * per-kind switch whose arms are all separate branches.
+	 */
+	for (i = 0; i < (int)(sizeof(timeouts) / sizeof(timeouts[0])); i++) {
+		/*
+		 * Lease timeout can only be set before rep_start and only
+		 * when leases are configured; tolerate a refusal but still
+		 * drive the getter, which is the never-called one.
+		 */
+		if (timeouts[i] == DB_REP_LEASE_TIMEOUT)
+			(void)dbenv->rep_set_timeout(dbenv,
+			    timeouts[i], 1000000);
+		else
+			CHK_OK(dbenv->rep_set_timeout(dbenv,
+			    timeouts[i], 1000000));
+		to = 0;
+		CHK_OK(dbenv->rep_get_timeout(dbenv, timeouts[i], &to));
+	}
+	/*
+	 * The repmgr-only kinds: SET must be refused on a base-API env, GET
+	 * must still work.  Both halves are cold branches.
+	 */
+	for (i = 0; i < (int)(sizeof(repmgr_timeouts) /
+	    sizeof(repmgr_timeouts[0])); i++) {
+		CHK_FAILS(dbenv->rep_set_timeout(dbenv,
+		    repmgr_timeouts[i], 1000000));
+		to = 0;
+		CHK_OK(dbenv->rep_get_timeout(dbenv,
+		    repmgr_timeouts[i], &to));
+	}
+	/* An unknown timeout kind must be rejected by set and get. */
+	CHK_FAILS(dbenv->rep_set_timeout(dbenv, 12345, 1000));
+	CHK_FAILS(dbenv->rep_get_timeout(dbenv, 12345, &to));
+}
+
+/*
+ * repmgr_knobs --
+ *	The repmgr configuration + query surface on a NON-started repmgr env.
+ *	__repmgr_get_ack_policy / __repmgr_get_config / __repmgr_local_site /
+ *	__repmgr_site_by_eid / __repmgr_get_eid / __repmgr_get_site_address
+ *	are all never-called in report #3.
+ */
+static void
+repmgr_knobs(dbenv)
+	DB_ENV *dbenv;
+{
+	DB_SITE *site, *site2;
+	const char *host;
+	u_int port;
+	u_int32_t cfg;
+	int policy, eid, on;
+	static const int policies[] = {
+		DB_REPMGR_ACKS_ALL, DB_REPMGR_ACKS_ALL_AVAILABLE,
+		DB_REPMGR_ACKS_ALL_PEERS, DB_REPMGR_ACKS_NONE,
+		DB_REPMGR_ACKS_ONE, DB_REPMGR_ACKS_ONE_PEER,
+		DB_REPMGR_ACKS_QUORUM
+	};
+	int i;
+
+	/* --- ack policy: every policy set then GET (getter never called). */
+	for (i = 0; i < (int)(sizeof(policies) / sizeof(policies[0])); i++) {
+		CHK_OK(dbenv->repmgr_set_ack_policy(dbenv, policies[i]));
+		policy = -1;
+		CHK_OK(dbenv->repmgr_get_ack_policy(dbenv, &policy));
+		CHK_EQ(policy, policies[i], "repmgr_get_ack_policy");
+	}
+	/* A bogus policy is rejected. */
+	CHK_FAILS(dbenv->repmgr_set_ack_policy(dbenv, 999));
+
+	/* --- the two repmgr-only config flags, set + get. */
+	CHK_OK(dbenv->rep_set_config(dbenv,
+	    DB_REPMGR_CONF_2SITE_STRICT, 1));
+	on = -1;
+	CHK_OK(dbenv->rep_get_config(dbenv,
+	    DB_REPMGR_CONF_2SITE_STRICT, &on));
+	CHK_EQ(on, 1, "2SITE_STRICT get");
+	CHK_OK(dbenv->rep_set_config(dbenv, DB_REPMGR_CONF_ELECTIONS, 1));
+	CHK_OK(dbenv->rep_set_config(dbenv, DB_REPMGR_CONF_ELECTIONS, 0));
+
+	/*
+	 * --- the local site.  repmgr_site() creates/looks up a site handle;
+	 * DB_SITE has its own method table (get_address / get_config /
+	 * get_eid / set_config), and every getter is in the never-called set.
+	 */
+	site = NULL;
+	CHK_OK(dbenv->repmgr_site(dbenv, "127.0.0.1", 30999, &site, 0));
+	if (site != NULL) {
+		CHK_OK(site->set_config(site, DB_LOCAL_SITE, 1));
+		cfg = 0;
+		CHK_OK(site->get_config(site, DB_LOCAL_SITE, &cfg));
+		CHK_EQ(cfg, 1, "DB_SITE get_config DB_LOCAL_SITE");
+		eid = -99;
+		CHK_OK(site->get_eid(site, &eid));
+		host = NULL; port = 0;
+		CHK_OK(site->get_address(site, &host, &port));
+		CHK_EQ(port, 30999, "DB_SITE get_address port");
+		if (host == NULL || strcmp(host, "127.0.0.1") != 0) {
+			fprintf(stderr, "FAIL: DB_SITE get_address host\n");
+			fails++;
+		}
+		checks++;
+
+		/*
+		 * __repmgr_local_site + __repmgr_site_by_eid: both look the
+		 * site back up through the env, both never called.
+		 */
+		site2 = NULL;
+		CHK_OK(dbenv->repmgr_local_site(dbenv, &site2));
+		if (site2 != NULL)
+			CHK_OK(site2->close(site2));
+		site2 = NULL;
+		CHK_OK(dbenv->repmgr_site_by_eid(dbenv, eid, &site2));
+		if (site2 != NULL)
+			CHK_OK(site2->close(site2));
+		/* A non-existent EID is the rejection branch. */
+		site2 = NULL;
+		CHK_FAILS(dbenv->repmgr_site_by_eid(dbenv, 4242, &site2));
+
+		/*
+		 * Each remaining DB_SITE config flag, set + read back.
+		 * DB_REPMGR_PEER is NOT legal on the LOCAL site (a site cannot
+		 * be its own peer) -- that rejection is itself a cold branch.
+		 */
+		CHK_OK(site->set_config(site, DB_GROUP_CREATOR, 1));
+		CHK_OK(site->get_config(site, DB_GROUP_CREATOR, &cfg));
+		CHK_OK(site->set_config(site, DB_LEGACY, 1));
+		CHK_OK(site->get_config(site, DB_LEGACY, &cfg));
+		CHK_OK(site->set_config(site, DB_LEGACY, 0));
+		CHK_FAILS(site->set_config(site, DB_REPMGR_PEER, 1));
+		CHK_OK(site->get_config(site, DB_REPMGR_PEER, &cfg));
+		/*
+		 * An unknown DB_SITE config flag: get_config switches on the
+		 * flag and returns 0 with an untouched value rather than
+		 * EINVAL, so drive the fall-through without asserting an error.
+		 */
+		(void)site->get_config(site, 0x40000000, &cfg);
+		checks++;
+
+		CHK_OK(site->close(site));
+	}
+
+	/* --- a remote site: the non-local half of the site table. */
+	site = NULL;
+	CHK_OK(dbenv->repmgr_site(dbenv, "127.0.0.1", 30998, &site, 0));
+	if (site != NULL) {
+		CHK_OK(site->set_config(site, DB_BOOTSTRAP_HELPER, 1));
+		CHK_OK(site->get_config(site, DB_BOOTSTRAP_HELPER, &cfg));
+		/* remove() then close() is the site-removal path. */
+		CHK_OK(site->close(site));
+	}
+}
+
+/*
+ * repmgr_before_start --
+ *	The repmgr entry points that must FAIL cleanly when repmgr has not
+ *	been started.  These are the *_inval stubs and the "not started"
+ *	guards -- __repmgr_channel_timeout_inval, __repmgr_send_request_inval,
+ *	__repmgr_channel_close_inval, bad_callback_method -- every one of them
+ *	never called in report #3, and every one of them the first thing a
+ *	misconfigured application hits.
+ */
+static void
+repmgr_before_start(dbenv)
+	DB_ENV *dbenv;
+{
+	DB_CHANNEL *chan;
+	DB_REPMGR_SITE *list;
+	DB_REPMGR_STAT *rstat;
+	u_int count;
+
+	/*
+	 * A channel to a site in an env whose repmgr threads were never
+	 * started: repmgr_channel must refuse (or hand back a channel whose
+	 * every operation refuses, via the _inval stubs).
+	 */
+	chan = NULL;
+	if (dbenv->repmgr_channel(dbenv, DB_EID_MASTER, &chan, 0) == 0 &&
+	    chan != NULL) {
+		/* The _inval method table: each call must fail, not crash. */
+		CHK_FAILS(chan->set_timeout(chan, 1000000));
+		CHK_FAILS(chan->close(chan, 0));
+	} else
+		checks++;
+	/* An invalid EID is a distinct rejection branch. */
+	chan = NULL;
+	CHK_FAILS(dbenv->repmgr_channel(dbenv, -12345, &chan, 0));
+
+	/* Installing a dispatch callback is legal before start. */
+	CHK_OK(dbenv->repmgr_msg_dispatch(dbenv, noop_dispatch, 0));
+	/* An unknown flag to msg_dispatch is rejected. */
+	CHK_FAILS(dbenv->repmgr_msg_dispatch(dbenv, noop_dispatch, 0x8000));
+
+	/* site_list / stat on a never-started repmgr: the empty-group path. */
+	count = 0; list = NULL;
+	if (dbenv->repmgr_site_list(dbenv, &count, &list) == 0 &&
+	    list != NULL)
+		__os_ufree(dbenv->env, list);
+	checks++;
+	rstat = NULL;
+	if (dbenv->repmgr_stat(dbenv, &rstat, 0) == 0 && rstat != NULL)
+		__os_ufree(dbenv->env, rstat);
+	checks++;
+	/* stat_print with each flag: the repmgr_stat.c formatter. */
+	(void)dbenv->repmgr_stat_print(dbenv, 0);
+	(void)dbenv->repmgr_stat_print(dbenv, DB_STAT_ALL);
+	(void)dbenv->repmgr_stat_print(dbenv, DB_STAT_CLEAR);
+}
+
+/*
+ * base_api_rejects_repmgr --
+ *	A base-API replication application (one that called rep_set_transport)
+ *	must be refused when it calls repmgr entry points, and vice versa.
+ *	That APP_IS_BASEAPI / APP_IS_REPMGR cross-check is a branch in
+ *	__rep_set_config, __repmgr_set_ack_policy and __repmgr_site that no
+ *	Tcl test reaches, because each Tcl rep test picks one API and stays.
+ */
+static void
+base_api_rejects_repmgr(dbenv)
+	DB_ENV *dbenv;
+{
+	DB_SITE *site;
+
+	/* This env is base-API (rep_set_transport was called). */
+	CHK_FAILS(dbenv->rep_set_config(dbenv,
+	    DB_REPMGR_CONF_2SITE_STRICT, 1));
+	CHK_FAILS(dbenv->rep_set_config(dbenv,
+	    DB_REPMGR_CONF_ELECTIONS, 1));
+	site = NULL;
+	CHK_FAILS(dbenv->repmgr_site(dbenv, "127.0.0.1", 30997, &site, 0));
+	CHK_FAILS(dbenv->repmgr_start(dbenv, 2, DB_REP_MASTER));
+}
+
+/*
+ * txn_applied_paths --
+ *	DB_ENV->txn_applied (__rep_txn_applied) with a real commit token from a
+ *	master.  Never called anywhere in the suite.  On a master the answer is
+ *	immediate (already applied); a zero-gen token is the EINVAL branch.
+ */
+static void
+txn_applied_paths(dbenv)
+	DB_ENV *dbenv;
+{
+	DB *dbp;
+	DB_TXN *txn;
+	DB_TXN_TOKEN token;
+	DBT key, data;
+	int ret;
+
+	dbp = NULL;
+	if ((ret = db_create(&dbp, dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_create: %s\n", db_strerror(ret));
+		fails++;
+		return;
+	}
+	if ((ret = dbp->open(dbp, NULL, "applied.db", NULL, DB_BTREE,
+	    DB_CREATE | DB_AUTO_COMMIT, 0600)) != 0) {
+		/*
+		 * Opening a DB in a replication env that has not synced can
+		 * legitimately fail; the token paths below still get driven
+		 * with a synthetic token, which is the point.
+		 */
+		fprintf(stderr, "note: open in rep env: %s\n",
+		    db_strerror(ret));
+		(void)dbp->close(dbp, 0);
+		dbp = NULL;
+	}
+
+	if (dbp != NULL) {
+		CHK_OK(dbenv->txn_begin(dbenv, NULL, &txn, 0));
+		/* A token is only produced if the txn asks for one. */
+		CHK_OK(txn->set_name(txn, "cov_rep_api"));
+		memset(&key, 0, sizeof(key));
+		memset(&data, 0, sizeof(data));
+		key.data = "k"; key.size = 1;
+		data.data = "v"; data.size = 1;
+		CHK_OK(dbp->put(dbp, txn, &key, &data, 0));
+		memset(&token, 0, sizeof(token));
+		CHK_OK(txn->set_commit_token(txn, &token));
+		CHK_OK(txn->commit(txn, 0));
+
+		/*
+		 * The real token from a committed master txn: already
+		 * applied, so this is the "success now" arm of
+		 * __rep_check_applied.
+		 */
+		(void)dbenv->txn_applied(dbenv, &token, 0, 0);
+		checks++;
+		/* Same query with a timeout: the timed arm. */
+		(void)dbenv->txn_applied(dbenv, &token, 1000, 0);
+		checks++;
+		CHK_OK(dbp->close(dbp, 0));
+	}
+
+	/* A zeroed token has gen == 0: the "non-replication commit token"
+	 * EINVAL branch at the top of __rep_txn_applied. */
+	memset(&token, 0, sizeof(token));
+	CHK_FAILS(dbenv->txn_applied(dbenv, &token, 0, 0));
+}
+
+/*
+ * rep_stat_and_flush --
+ *	rep_stat / rep_stat_print / rep_flush / rep_sync on a configured but
+ *	quiescent env: the "nothing to do" arms.
+ */
+static void
+rep_stat_and_flush(dbenv)
+	DB_ENV *dbenv;
+{
+	DB_REP_STAT *sp;
+
+	/* stat_print writes to the msgfile; keep the run's output quiet. */
+	dbenv->set_msgfile(dbenv, NULL);
+	sp = NULL;
+	if (dbenv->rep_stat(dbenv, &sp, 0) == 0 && sp != NULL)
+		__os_ufree(dbenv->env, sp);
+	checks++;
+	sp = NULL;
+	if (dbenv->rep_stat(dbenv, &sp, DB_STAT_CLEAR) == 0 && sp != NULL)
+		__os_ufree(dbenv->env, sp);
+	checks++;
+	(void)dbenv->rep_stat_print(dbenv, 0);
+	(void)dbenv->rep_stat_print(dbenv, DB_STAT_ALL);
+	(void)dbenv->rep_stat_print(dbenv, DB_STAT_CLEAR);
+	/* rep_flush on a master with no clients: the empty-send path. */
+	(void)dbenv->rep_flush(dbenv);
+	checks++;
+	/* rep_sync as a master is a no-op / error, not a hang. */
+	(void)dbenv->rep_sync(dbenv, 0);
+	checks++;
+}
+
+/*
+ * unconfigured_env_rejects --
+ *	Every rep_* / repmgr_* method on an env opened WITHOUT DB_INIT_REP must
+ *	take the ENV_NOT_CONFIGURED branch.  That branch exists in essentially
+ *	every function in rep_method.c and repmgr_method.c and is never
+ *	exercised, because every Tcl rep test naturally has DB_INIT_REP.
+ */
+static void
+unconfigured_env_rejects()
+{
+	DB_ENV *dbenv;
+	DB_SITE *site;
+	u_int32_t a, b;
+	int i, ret;
+
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		fails++;
+		return;
+	}
+	dbenv->set_errpfx(dbenv, "cov_rep_api-norep");
+	/* Silence the expected complaints. */
+	dbenv->set_errfile(dbenv, NULL);
+	clean_home("COVREP_TESTDIR_norep");
+	if ((ret = dbenv->open(dbenv, "COVREP_TESTDIR_norep",
+	    DB_CREATE | DB_INIT_MPOOL | DB_PRIVATE, 0600)) != 0) {
+		fprintf(stderr, "FAIL: open no-rep env: %s\n",
+		    db_strerror(ret));
+		fails++;
+		(void)dbenv->close(dbenv, 0);
+		return;
+	}
+
+	CHK_FAILS(dbenv->rep_get_limit(dbenv, &a, &b));
+	CHK_FAILS(dbenv->rep_get_nsites(dbenv, &a));
+	CHK_FAILS(dbenv->rep_get_priority(dbenv, &a));
+	CHK_FAILS(dbenv->rep_get_request(dbenv, &a, &b));
+	CHK_FAILS(dbenv->rep_get_clockskew(dbenv, &a, &b));
+	CHK_FAILS(dbenv->rep_start(dbenv, NULL, DB_REP_MASTER));
+	CHK_FAILS(dbenv->rep_flush(dbenv));
+	CHK_FAILS(dbenv->rep_sync(dbenv, 0));
+	CHK_FAILS(dbenv->rep_elect(dbenv, 3, 2, 0));
+	site = NULL;
+	CHK_FAILS(dbenv->repmgr_site(dbenv, "127.0.0.1", 30996, &site, 0));
+	CHK_FAILS(dbenv->repmgr_start(dbenv, 2, DB_REP_CLIENT));
+	CHK_FAILS(dbenv->repmgr_local_site(dbenv, &site));
+	CHK_FAILS(dbenv->repmgr_site_by_eid(dbenv, 1, &site));
+	/*
+	 * repmgr_get_ack_policy answers from the handle, not the region, so it
+	 * succeeds even with no DB_INIT_REP -- drive it, do not assert an
+	 * error the API does not promise.
+	 */
+	(void)dbenv->repmgr_get_ack_policy(dbenv, &i);
+	checks++;
+
+	CHK_OK(dbenv->close(dbenv, 0));
+}
+
+/*
+ * pre_open_knobs --
+ *	Every rep knob set + read back on a handle that has NOT been opened.
+ *	Each setter has a distinct !REP_ON(env) arm that stores into the
+ *	DB_REP handle instead of the shared region -- half of every setter.
+ */
+static void
+pre_open_knobs()
+{
+	DB_ENV *dbenv;
+	u_int32_t a, b;
+	int ret, on;
+
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		fails++;
+		return;
+	}
+	dbenv->set_errfile(dbenv, NULL);
+
+	/*
+	 * ORDERING MATTERS in this function.  Several rep knobs silently make
+	 * the handle a REPMGR application (APP_SET_REPMGR): rep_set_config
+	 * with a DB_REPMGR_CONF_* flag, repmgr_set_ack_policy, and
+	 * rep_set_timeout with any repmgr timeout kind (DB_REP_ACK_TIMEOUT,
+	 * CONNECTION_RETRY, ELECTION_RETRY, HEARTBEAT_*).  Once that happens,
+	 * the BASE-API nsites calls are refused -- and worse,
+	 * __rep_get_nsites then delegates to __repmgr_get_nsites
+	 * (src/repmgr/repmgr_util.c:520), which dereferences
+	 * `db_rep->region->config_nsites` with no guard while db_rep->region
+	 * is still NULL pre-open, i.e. it SIGSEGVs.  ENV_NOT_CONFIGURED does
+	 * not catch it because src/dbinc/db_int.in:604 makes that macro a
+	 * no-op unless ENV_OPEN_CALLED is set.
+	 *
+	 * So: base-API nsites FIRST, repmgr-flavoured knobs LAST.  The crash
+	 * is a real defect, reported in
+	 * test/coverage/FULL-COVERAGE-REPORT-4.md and NOT fixed here (12-line
+	 * public-API repro in that report).
+	 */
+
+	/* --- 1. base-API-only knobs, while the handle is still neutral. */
+	/* nsites pre-open goes through __rep_set_nsites_pp's other arm. */
+	CHK_OK(dbenv->rep_set_nsites(dbenv, 5));
+	CHK_OK(dbenv->rep_get_nsites(dbenv, &a));
+	CHK_EQ(a, 5, "pre-open rep_get_nsites");
+
+	/* Pre-open: the db_rep->config half of set/get_config. */
+	rep_config_roundtrip(dbenv, 0);
+
+	CHK_OK(dbenv->rep_set_limit(dbenv, 0, 65536));
+	CHK_OK(dbenv->rep_get_limit(dbenv, &a, &b));
+	CHK_EQ(b, 65536, "pre-open rep_get_limit");
+	CHK_OK(dbenv->rep_set_priority(dbenv, 50));
+	CHK_OK(dbenv->rep_get_priority(dbenv, &a));
+	CHK_EQ(a, 50, "pre-open rep_get_priority");
+	CHK_OK(dbenv->rep_set_request(dbenv, 1000, 8000));
+	CHK_OK(dbenv->rep_get_request(dbenv, &a, &b));
+	CHK_EQ(a, 1000, "pre-open rep_get_request min");
+	CHK_OK(dbenv->rep_set_clockskew(dbenv, 105, 100));
+	CHK_OK(dbenv->rep_get_clockskew(dbenv, &a, &b));
+	CHK_EQ(a, 105, "pre-open rep_get_clockskew");
+	/* A base-API timeout kind: does NOT flip the app type. */
+	CHK_OK(dbenv->rep_set_timeout(dbenv,
+	    DB_REP_ELECTION_TIMEOUT, 500000));
+	CHK_OK(dbenv->rep_get_timeout(dbenv,
+	    DB_REP_ELECTION_TIMEOUT, &a));
+	CHK_EQ(a, 500000, "pre-open rep_get_timeout");
+
+	/* --- 2. repmgr-flavoured knobs need a FRESH, still-neutral handle:
+	 * the base-API knobs above have already set APP_IS_BASEAPI (any
+	 * rep_set_* on a non-repmgr path does), and a base-API handle refuses
+	 * every repmgr entry point.  That refusal is itself covered in
+	 * base_api_rejects_repmgr(); here we want the ACCEPTING arms.
+	 */
+	CHK_FAILS(dbenv->rep_set_timeout(dbenv, DB_REP_ACK_TIMEOUT, 500000));
+	CHK_FAILS(dbenv->repmgr_set_ack_policy(dbenv, DB_REPMGR_ACKS_QUORUM));
+	/* Never opened: close must still tear the rep handle down. */
+	CHK_OK(dbenv->close(dbenv, 0));
+
+	/* A second unopened handle, repmgr-flavoured from the start. */
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		fails++;
+		return;
+	}
+	dbenv->set_errfile(dbenv, NULL);
+	CHK_OK(dbenv->repmgr_set_ack_policy(dbenv, DB_REPMGR_ACKS_QUORUM));
+	CHK_OK(dbenv->repmgr_get_ack_policy(dbenv, &on));
+	CHK_EQ(on, DB_REPMGR_ACKS_QUORUM, "pre-open ack policy");
+	CHK_OK(dbenv->rep_set_timeout(dbenv, DB_REP_ACK_TIMEOUT, 500000));
+	CHK_OK(dbenv->rep_get_timeout(dbenv, DB_REP_ACK_TIMEOUT, &a));
+	CHK_EQ(a, 500000, "pre-open repmgr rep_get_timeout");
+	CHK_OK(dbenv->rep_set_timeout(dbenv,
+	    DB_REP_CONNECTION_RETRY, 500000));
+	CHK_OK(dbenv->rep_get_timeout(dbenv,
+	    DB_REP_CONNECTION_RETRY, &a));
+	CHK_OK(dbenv->rep_set_timeout(dbenv,
+	    DB_REP_HEARTBEAT_SEND, 500000));
+	CHK_OK(dbenv->rep_get_timeout(dbenv,
+	    DB_REP_HEARTBEAT_SEND, &a));
+	CHK_OK(dbenv->rep_set_timeout(dbenv,
+	    DB_REP_HEARTBEAT_MONITOR, 900000));
+	CHK_OK(dbenv->rep_get_timeout(dbenv,
+	    DB_REP_HEARTBEAT_MONITOR, &a));
+	/* The repmgr-only config flags are legal pre-open on this handle. */
+	CHK_OK(dbenv->rep_set_config(dbenv,
+	    DB_REPMGR_CONF_2SITE_STRICT, 1));
+	CHK_OK(dbenv->rep_get_config(dbenv,
+	    DB_REPMGR_CONF_2SITE_STRICT, &on));
+	CHK_EQ(on, 1, "pre-open 2SITE_STRICT");
+	CHK_OK(dbenv->rep_set_config(dbenv, DB_REPMGR_CONF_ELECTIONS, 1));
+	/*
+	 * On a repmgr handle the base-API nsites SETTER must be refused (the
+	 * "cannot call from Replication Manager application" branch).  Do NOT
+	 * call rep_get_nsites here -- see the crash note above.
+	 */
+	CHK_FAILS(dbenv->rep_set_nsites(dbenv, 7));
+
+	CHK_OK(dbenv->close(dbenv, 0));
+}
+
+int
+main(argc, argv)
+	int argc;
+	char *argv[];
+{
+	DB_ENV *dbenv;
+	int ret;
+
+	COMPQUIET(argc, 0);
+	COMPQUIET(argv, NULL);
+
+	(void)signal(SIGALRM, on_alarm);
+	(void)alarm(ALARM_SECS);
+
+	printf("cov_rep_api: replication + repmgr config/query surface\n");
+
+	/* --- 1. Knobs on an unopened handle (the !REP_ON half of each). */
+	printf("1. pre-open rep/repmgr knobs\n");
+	pre_open_knobs();
+
+	/* --- 2. Every rep and repmgr method on an env with no DB_INIT_REP. */
+	printf("2. unconfigured env rejects rep/repmgr calls\n");
+	unconfigured_env_rejects();
+
+	/* --- 3. A real base-API replication env (rep_set_transport). */
+	printf("3. base-API replication env\n");
+	clean_home(HOME_BASE);
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		return (2);
+	}
+	dbenv->set_errpfx(dbenv, "cov_rep_api-base");
+	dbenv->set_errfile(dbenv, NULL);
+	dbenv->set_msgfile(dbenv, NULL);
+	CHK_OK(dbenv->rep_set_transport(dbenv, 1, noop_send));
+	if ((ret = dbenv->open(dbenv, HOME_BASE, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_INIT_REP |
+	    DB_THREAD, 0600)) != 0) {
+		fprintf(stderr, "FAIL: open base rep env: %s\n",
+		    db_strerror(ret));
+		(void)dbenv->close(dbenv, 0);
+		return (2);
+	}
+	/* Post-open: the REP_ON(env) half of every setter/getter. */
+	rep_config_roundtrip(dbenv, 1);
+	rep_scalar_knobs(dbenv);
+	/* A base-API app must be refused the repmgr entry points. */
+	base_api_rejects_repmgr(dbenv);
+	/* Become master so the stat/flush/token paths have a real state. */
+	CHK_OK(dbenv->rep_start(dbenv, NULL, DB_REP_MASTER));
+	rep_stat_and_flush(dbenv);
+	txn_applied_paths(dbenv);
+	/* rep_start again as master: the "already master" idempotent arm. */
+	CHK_OK(dbenv->rep_start(dbenv, NULL, DB_REP_MASTER));
+	CHK_OK(dbenv->close(dbenv, 0));
+
+	/* --- 4. A repmgr env: sites, channels, ack policy, dispatch. */
+	printf("4. repmgr env (not started)\n");
+	clean_home(HOME_MGR);
+	if ((ret = db_env_create(&dbenv, 0)) != 0) {
+		fprintf(stderr, "FAIL: db_env_create: %s\n",
+		    db_strerror(ret));
+		return (2);
+	}
+	dbenv->set_errpfx(dbenv, "cov_rep_api-mgr");
+	dbenv->set_errfile(dbenv, NULL);
+	dbenv->set_msgfile(dbenv, NULL);
+	if ((ret = dbenv->open(dbenv, HOME_MGR, DB_CREATE | DB_INIT_LOCK |
+	    DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_INIT_REP |
+	    DB_THREAD, 0600)) != 0) {
+		fprintf(stderr, "FAIL: open repmgr env: %s\n",
+		    db_strerror(ret));
+		(void)dbenv->close(dbenv, 0);
+		return (2);
+	}
+	repmgr_knobs(dbenv);
+	repmgr_before_start(dbenv);
+	CHK_OK(dbenv->close(dbenv, 0));
+
+	(void)alarm(0);
+	printf("cov_rep_api: %d checks, %d failures\n", checks, fails);
+	if (fails != 0) {
+		printf("cov_rep_api: FAIL\n");
+		return (1);
+	}
+	printf("cov_rep_api: PASS\n");
+	return (0);
+}

--- a/test/c/run_cov_api_surface.sh
+++ b/test/c/run_cov_api_surface.sh
@@ -1,0 +1,58 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_api_surface.sh --
+#	Build and run cov_api_surface.c, the direct driver for the DB_ENV / DB /
+#	DBC / DB_TXN / DB_MPOOLFILE *getter* + callback-setter surface and the
+#	argument-validation branches of the matching setters (the ~60
+#	never-called getters in db_method.c / env_method.c / mp_fmethod.c /
+#	db_cds.c that the Tcl bindings never reach).
+#
+#	Same shape as test/xa/run_xa_direct.sh and test/os/run_os_aio.sh:
+#	compile against the just-built libdb in ./.libs, run in a clean home
+#	under a hard timeout, report PASS/FAIL, exit non-zero on failure.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_api_surface.sh
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/c/cov_api_surface.c}
+TIMEOUT=${TIMEOUT:-180}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+
+EXTRA_LIBS="-lpthread"
+# liburing is linked into the .so on Linux builds that found it.
+if echo 'int main(){return 0;}' > /tmp/_covapi_surface_probe.c && \
+    gcc /tmp/_covapi_surface_probe.c -luring -o /tmp/_covapi_surface_probe 2>/dev/null; then
+	EXTRA_LIBS="$EXTRA_LIBS -luring"
+fi
+rm -f /tmp/_covapi_surface_probe.c /tmp/_covapi_surface_probe 2>/dev/null || true
+
+echo "Compiling cov_api_surface against $LIB"
+gcc -g -O1 ${CFLAGS:-} -I"$BUILD" -I../src -I../src/dbinc "$SRC" "$LIB" \
+    $EXTRA_LIBS -Wl,-rpath,"$(cd "$BUILD/.libs" && pwd)" \
+    -o "$BUILD/cov_api_surface"
+
+# Guaranteed-clean homes (no rm -rf).
+for d in COVAPI_TESTDIR COVAPI_TESTDIR_notxn COVAPI_TESTDIR_cds; do
+	rm -f "$d"/__db.* "$d"/__dbq.* "$d"/log.* "$d"/*.db "$d"/*.dat "$d"/DB_CONFIG 2>/dev/null || true
+	mkdir -p "$d"
+done
+
+echo "Running cov_api_surface (timeout ${TIMEOUT}s)"
+if timeout "$TIMEOUT" "$BUILD/cov_api_surface"; then
+	echo "run_cov_api_surface.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_cov_api_surface.sh: FAIL (rc=$rc)"
+	exit $rc
+fi

--- a/test/c/run_cov_codecs.sh
+++ b/test/c/run_cov_codecs.sh
@@ -1,0 +1,62 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_codecs.sh --
+#	Build and run cov_codecs.c: exhaustive boundary coverage of libdb's
+#	self-contained codecs -- the compressed-integer (varint) codec in
+#	src/common/db_compint.c and the string-to-number parsers in
+#	src/common/db_getlong.c.
+#
+#	db_compint sits at 21% line / 25% branch in report #3 with
+#	__db_decompress_int NEVER CALLED, because btree compression only
+#	marshals 32-bit lengths (so the 64-bit decoder and the 4..9-byte size
+#	classes are unreachable from any Tcl workload) and the property-based
+#	tier that does cover them (test/pbt/pbt_compint.c) needs the `hegel`
+#	server binary and compiles in STUB mode -- it links, prints SKIP and
+#	executes nothing -- on a machine without hegel.  This driver walks the
+#	size-class boundaries directly, with no external dependency.
+#
+#	Same shape as test/xa/run_xa_direct.sh and test/os/run_os_aio.sh:
+#	compile against the just-built libdb in ./.libs, run in a clean home
+#	under a hard timeout, report PASS/FAIL, exit non-zero on failure.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_codecs.sh
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/c/cov_codecs.c}
+TIMEOUT=${TIMEOUT:-120}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+
+EXTRA_LIBS="-lpthread"
+# liburing is linked into the .so on Linux builds that found it.
+if echo 'int main(){return 0;}' > /tmp/_covcodecs_probe.c && \
+    gcc /tmp/_covcodecs_probe.c -luring -o /tmp/_covcodecs_probe 2>/dev/null; then
+	EXTRA_LIBS="$EXTRA_LIBS -luring"
+fi
+rm -f /tmp/_covcodecs_probe.c /tmp/_covcodecs_probe 2>/dev/null || true
+
+echo "Compiling cov_codecs against $LIB"
+gcc -g -O1 ${CFLAGS:-} -I"$BUILD" -I../src -I../src/dbinc "$SRC" "$LIB" \
+    $EXTRA_LIBS -Wl,-rpath,"$(cd "$BUILD/.libs" && pwd)" \
+    -o "$BUILD/cov_codecs"
+
+# No environment and no files: these are pure functions.
+
+echo "Running cov_codecs (timeout ${TIMEOUT}s)"
+if timeout "$TIMEOUT" "$BUILD/cov_codecs"; then
+	echo "run_cov_codecs.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_cov_codecs.sh: FAIL (rc=$rc)"
+	exit $rc
+fi

--- a/test/c/run_cov_cutest.sh
+++ b/test/c/run_cov_cutest.sh
@@ -1,0 +1,131 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_cutest.sh --
+#	Run the C unit-test binary `cutest` (test/c/cutest + test/c/suites)
+#	from a coverage driver.
+#
+#	This is a MEASUREMENT GAP closer, not a new test.  `cutest` is a
+#	12-suite CuTest binary that already exists, already has a Makefile.in
+#	target (`make cutest`), and passes 100%.  No coverage driver has ever
+#	run it, so the code only it reaches has always measured as cold.  Two
+#	of its suites reach surfaces nothing else in the tree does:
+#
+#	  * TestChannel -- brings up THREE live repmgr sites in one process
+#	    (ports 30101-30103), installs a message-dispatch callback, and
+#	    drives the whole DB_CHANNEL API: async send, request/response,
+#	    multi-segment and zero-segment messages, USERMEM buffers with and
+#	    without DB_MULTIPLE, send-to-master, send-to-self, master
+#	    switchover, sending to a shut-down site, connecting to a
+#	    non-existent EID, and illegal calls from inside the dispatch
+#	    function.  That is precisely the never-called set in
+#	    repmgr/repmgr_method.c (__repmgr_channel, __repmgr_send_msg,
+#	    __repmgr_send_request, __repmgr_send_response,
+#	    __repmgr_set_msg_dispatch, get_channel_connection,
+#	    establish_connection, send_msg_conn, send_msg_self,
+#	    request_self, response_complete, adjust_bulk_response,
+#	    copy_body, bad_callback_method, ...) plus repmgr_msg.c's
+#	    dispatch-side handlers.
+#	  * TestDbTuner -- drives db_tuner.c (the page-size advisor), which
+#	    no Tcl test runs.
+#
+#	The other suites (TestDbHotBackup x5, TestEncryption x12,
+#	TestEnvConfig x12, TestEnvMethod, TestKeyExistErrorReturn,
+#	TestPartial x4, TestQueue incl. the shared-list unit tests) add
+#	env-config, encryption and partial-record coverage cheaply.
+#
+#	Runs in its own directory under a hard timeout; cutest creates and
+#	removes its own TESTDIR-style homes.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_cutest.sh
+
+set -u
+
+BUILD=${BUILD:-.}
+TIMEOUT=${TIMEOUT:-600}		# per suite
+RUNDIR=${RUNDIR:-CUTEST_TESTDIR}
+
+# Build it if it is not there yet (the coverage driver's `make` may not have
+# asked for it; `make cutest` is cheap next to a full build).
+if [ ! -x "$BUILD/cutest" ]; then
+	echo "Building cutest"
+	( cd "$BUILD" && make cutest ) || {
+		echo "run_cov_cutest.sh: SKIP (cutest did not build)"
+		exit 0
+	}
+fi
+
+mkdir -p "$BUILD/$RUNDIR"
+# Guaranteed-clean run dir (no rm -rf).
+find "$BUILD/$RUNDIR" -mindepth 1 -delete 2>/dev/null || true
+
+# cutest links the shared lib; point the loader at the build tree.
+LIBS_DIR=$(cd "$BUILD/.libs" && pwd)
+LD_LIBRARY_PATH="$LIBS_DIR:${LD_LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH
+
+#
+# Run ONE SUITE PER PROCESS (cutest -s <suite>) rather than the whole binary.
+# Two reasons, both about not losing coverage:
+#
+#   1. gcov writes its .gcda from an atexit handler, so a process that dies by
+#      a signal contributes NOTHING.  One crashing suite would throw away the
+#      coverage of every suite in the same process.
+#   2. TestQueue DOES crash in an optimised build: sh_l_as_string()
+#      (test/c/suites/TestQueue.c:64) fills a fixed `static char buf[1024]`
+#      from a list with no bound check, and the shared-list op matrix
+#      overruns it -- SIGSEGV at TestQueue.c:64 via TestQueue.c:827.  That is
+#      a pre-existing bug in the TEST HARNESS, not in libdb, and it is
+#      reported in test/coverage/FULL-COVERAGE-REPORT-4.md rather than fixed
+#      here.  Isolating it keeps the other eleven suites' coverage.
+#
+# A suite that crashes is reported but does not fail the run, for the same
+# reason: this driver's job is measurement, and the crash is a known,
+# documented harness defect.  A suite that reports a CuTest FAILURE does fail.
+#
+SUITES=${SUITES:-"TestChannel TestDbHotBackup TestDbTuner TestEncryption \
+TestEnvConfig TestEnvMethod TestKeyExistErrorReturn TestPartial TestQueue"}
+
+cd "$BUILD/$RUNDIR"
+ran=0
+okc=0
+bad=0
+crashed=""
+failed=""
+
+for s in $SUITES; do
+	log="cutest-$s.log"
+	timeout "$TIMEOUT" ../cutest -s "$s" > "$log" 2>&1
+	rc=$?
+	ran=$((ran + 1))
+	if grep -q '!!!FAILURES!!!' "$log" 2>/dev/null; then
+		bad=$((bad + 1))
+		failed="$failed $s"
+	elif [ $rc -eq 0 ]; then
+		okc=$((okc + 1))
+	else
+		crashed="$crashed $s(rc=$rc)"
+	fi
+	# Clean between suites: several create their own TESTDIR homes.
+	find . -mindepth 1 ! -name 'cutest-*.log' -delete 2>/dev/null || true
+done
+
+echo "run_cov_cutest.sh: ran $ran suites, $okc clean, $bad with test failures"
+[ -n "$crashed" ] && echo "run_cov_cutest.sh: CRASHED (known harness bugs):$crashed"
+if [ "$bad" -gt 0 ]; then
+	echo "run_cov_cutest.sh: FAILURES:$failed"
+	for s in $failed; do
+		echo "--- $s ---"
+		grep -A6 '!!!FAILURES!!!' "cutest-$s.log" | head -20
+	done
+	echo "run_cov_cutest.sh: FAIL"
+	exit 1
+fi
+if [ "$okc" -eq 0 ]; then
+	echo "run_cov_cutest.sh: SKIP (no suite ran clean)"
+	exit 0
+fi
+echo "run_cov_cutest.sh: PASS"
+exit 0

--- a/test/c/run_cov_dst.sh
+++ b/test/c/run_cov_dst.sh
@@ -1,0 +1,138 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_dst.sh --
+#	Run the Deterministic Simulation Testing (DST) scenarios
+#	(test/sim/test_sim_*.c, 41 of them) against the COVERAGE-instrumented
+#	libdb so their crash / fault-injection paths are measured.
+#
+#	Why this is a measurement gap.  The DST tier is built by
+#	`make dst_tests` and normally run from its own sweep scripts
+#	(test/sim/dst-sweep.sh, dst-swarm.sh) against a `--enable-dst` build.
+#	No coverage driver has ever run it, so everything only DST reaches has
+#	always measured as cold.  DST is the tree's ONLY source for several
+#	whole classes of branch:
+#
+#	  * crash-at-an-arbitrary-write recovery (torn pages, torn log, torn
+#	    meta page) -- the redo/undo error arms of the recovery handlers
+#	  * ENOSPC on a data write, a log write, and during a checkpoint --
+#	    the "out of space" propagation branches of log_put.c / mp_sync.c /
+#	    os_write, which no functional test produces
+#	  * crash DURING recovery (test_sim_crash_in_recovery,
+#	    test_sim_recovery_undo_crash / _redo_crash / _ckp_crash) -- the
+#	    re-entrant recovery arms
+#	  * clock skew (backward jumps, timeout skew, checkpoint skew) --
+#	    the timespec comparison branches
+#	  * latency injection + a compound multi-fault scenario
+#
+#	Each scenario is a self-contained C program with its own bounded
+#	workload and its own assertions, so this script just runs them and
+#	reports; a scenario failure is a real DST failure and is surfaced.
+#
+#	IMPORTANT: this runs the scenarios as built by the ambient build.  It
+#	does NOT plant DST bugs (DSTBUG=n) -- test/sim/dst-bug-inject.sh owns
+#	that, and a planted bug is *supposed* to fail, which would make the
+#	coverage run red.  Untouched scenarios must all pass.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_dst.sh
+# Env:
+#	DST_TIMEOUT  per-scenario timeout (default 300s)
+#	DST_ONLY     space-separated scenario names to run (default: all built)
+
+set -u
+
+BUILD=${BUILD:-.}
+DST_TIMEOUT=${DST_TIMEOUT:-300}
+RUNDIR=${RUNDIR:-DSTCOV_TESTDIR}
+
+# Build the DST scenarios if they are not there (the coverage driver's make
+# does not ask for them by default).
+#
+# NOTE: they only LINK against a library built with --enable-dst -- the sim
+# core (test/sim/sim_core.c, sim_os_hooks.c) is compiled INTO libdb by that
+# option, so without it the scenarios fail to link with undefined references
+# to __db_sim_strict / __db_sim_nondeterminism / __db_sim_deactivate.  Both
+# --enable-dst and --enable-faultinject are additive and inert until armed
+# (dist/configure.ac: "when off ... a production build is bit-for-bit the
+# stock library"), so the coverage build can and should carry both; see
+# test/coverage/full_run4.sh.  If the ambient build lacks it we SKIP rather
+# than fail, so this script is safe in any tree.
+if [ ! -x "$BUILD/test_sim_crash_recover" ]; then
+	echo "Building dst_tests"
+	( cd "$BUILD" && make dst_tests ) >/tmp/covdst-build.log 2>&1 || {
+		if grep -q '__db_sim_' /tmp/covdst-build.log 2>/dev/null; then
+			echo "run_cov_dst.sh: SKIP (library built without" \
+			    "--enable-dst; DST hooks are not in libdb)"
+		else
+			echo "run_cov_dst.sh: SKIP (dst_tests did not build)"
+			tail -20 /tmp/covdst-build.log
+		fi
+		exit 0
+	}
+fi
+
+mkdir -p "$BUILD/$RUNDIR"
+find "$BUILD/$RUNDIR" -mindepth 1 -delete 2>/dev/null || true
+
+LIBS_DIR=$(cd "$BUILD/.libs" && pwd)
+LD_LIBRARY_PATH="$LIBS_DIR:${LD_LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH
+
+if [ -n "${DST_ONLY:-}" ]; then
+	scenarios="$DST_ONLY"
+else
+	scenarios=""
+	for f in "$BUILD"/test_sim_* "$BUILD"/mp_failchk_pilot; do
+		[ -x "$f" ] || continue
+		case "$f" in *.o|*.lo|*.c|*.gcno|*.gcda) continue ;; esac
+		scenarios="$scenarios $(basename "$f")"
+	done
+fi
+
+pass=0
+fail=0
+hang=0
+failed_names=""
+
+for s in $scenarios; do
+	[ -x "$BUILD/$s" ] || continue
+	# Each scenario in its own cwd so their homes cannot collide, and
+	# under a hard timeout so a fault-injected hang cannot wedge the run.
+	d="$BUILD/$RUNDIR/$s"
+	mkdir -p "$d"
+	( cd "$d" && timeout "$DST_TIMEOUT" "../../$s" >run.log 2>&1 )
+	rc=$?
+	if [ $rc -eq 0 ]; then
+		pass=$((pass + 1))
+	elif [ $rc -eq 124 ]; then
+		hang=$((hang + 1))
+		failed_names="$failed_names $s(HANG)"
+	else
+		fail=$((fail + 1))
+		failed_names="$failed_names $s(rc=$rc)"
+	fi
+	# Reclaim space between scenarios (some write large logs).
+	find "$d" -mindepth 1 ! -name run.log -delete 2>/dev/null || true
+done
+
+echo "run_cov_dst.sh: $pass passed, $fail failed, $hang hung"
+if [ $fail -ne 0 ] || [ $hang -ne 0 ]; then
+	echo "run_cov_dst.sh: FAILURES:$failed_names"
+	for s in $failed_names; do
+		n=${s%%(*}
+		[ -f "$BUILD/$RUNDIR/$n/run.log" ] && {
+			echo "--- $n ---"
+			tail -15 "$BUILD/$RUNDIR/$n/run.log"
+		}
+	done
+	echo "run_cov_dst.sh: FAIL"
+	exit 1
+fi
+if [ $pass -eq 0 ]; then
+	echo "run_cov_dst.sh: SKIP (no scenario ran)"
+	exit 0
+fi
+echo "run_cov_dst.sh: PASS"
+exit 0

--- a/test/c/run_cov_fuzz_corpus.sh
+++ b/test/c/run_cov_fuzz_corpus.sh
@@ -1,0 +1,118 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_fuzz_corpus.sh --
+#	Replay the committed fuzz corpus + crash seeds through the fuzz
+#	harnesses built in FUZZ_STANDALONE mode against the COVERAGE-
+#	instrumented libdb, so the branches those inputs reach are measured.
+#
+#	Why this is a measurement gap, not a new test.  test/fuzz/run.sh and
+#	check-crashes.sh both build their own libdb (clang + ASan/libFuzzer,
+#	in build_asan_gate/ or a separate build_unix), because their job is
+#	memory-safety detection.  That means the corpus never runs against
+#	the gcov-instrumented tree, so the code it covers -- the corrupt-input
+#	rejection branches of db_vrfy.c / bt_verify.c / hash_verify.c /
+#	qam_verify.c / heap_verify.c / db_conv.c / __memp_fopen's header
+#	validation / the recovery log-header parser -- measures as cold even
+#	though the seeds exercise it hard.  Those are the "reject malformed
+#	input" halves of conditionals: a big, genuinely-covered branch slice
+#	that simply was not being counted.
+#
+#	This script builds the SAME harness sources with FUZZ_STANDALONE (a
+#	main() that replays file arguments, no libFuzzer runtime needed) and
+#	links them against the instrumented .so, then feeds every file in
+#	test/fuzz/corpus/<h>/ and every test/fuzz/crashes/<h>_*.seed to the
+#	matching harness.
+#
+#	It does NOT assert memory safety -- check-crashes.sh owns that gate
+#	and needs an ASan build to do it properly.  Here a seed that makes the
+#	engine abort is expected for some inputs (an --enable-diagnostic build
+#	panics by design on unrecoverable corruption), so each replay runs in
+#	its own timeout-guarded child and a crash is counted, not fatal.  The
+#	assertion is that every seed gets replayed.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_fuzz_corpus.sh
+
+set -u
+
+BUILD=${BUILD:-.}
+FUZZDIR=${FUZZDIR:-../test/fuzz}
+TIMEOUT=${TIMEOUT:-30}		# per-seed
+RUNDIR=${RUNDIR:-FUZZCOV_TESTDIR}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+LIBS_DIR=$(cd "$BUILD/.libs" && pwd)
+
+EXTRA_LIBS="-lpthread"
+if echo 'int main(){return 0;}' > /tmp/_covfuzz_probe.c && \
+    gcc /tmp/_covfuzz_probe.c -luring -o /tmp/_covfuzz_probe 2>/dev/null; then
+	EXTRA_LIBS="$EXTRA_LIBS -luring"
+fi
+rm -f /tmp/_covfuzz_probe.c /tmp/_covfuzz_probe 2>/dev/null || true
+
+mkdir -p "$BUILD/$RUNDIR"
+find "$BUILD/$RUNDIR" -mindepth 1 -delete 2>/dev/null || true
+
+built=0
+replayed=0
+crashed=0
+
+for h in dbfile recover api; do
+	src="$FUZZDIR/fuzz_$h.c"
+	[ -f "$src" ] || continue
+	bin="$BUILD/cov_fuzz_$h"
+	echo "Compiling fuzz_$h (standalone) against $LIB"
+	if ! gcc -g -O1 ${CFLAGS:-} -DFUZZ_STANDALONE \
+	    -I"$BUILD" -I../src -I../src/dbinc -I"$FUZZDIR" \
+	    "$src" "$LIB" $EXTRA_LIBS -Wl,-rpath,"$LIBS_DIR" -o "$bin" \
+	    2>/tmp/covfuzz-$h-build.log; then
+		echo "  SKIP fuzz_$h (did not compile)"
+		head -20 /tmp/covfuzz-$h-build.log
+		continue
+	fi
+	built=$((built + 1))
+
+	# Collect this harness's inputs: its corpus dir + its crash seeds.
+	set -- 
+	if [ -d "$FUZZDIR/corpus/$h" ]; then
+		for f in "$FUZZDIR/corpus/$h"/*; do
+			[ -f "$f" ] && set -- "$@" "$f"
+		done
+	fi
+	for f in "$FUZZDIR/crashes/${h}_"*.seed; do
+		[ -f "$f" ] && set -- "$@" "$f"
+	done
+	[ $# -eq 0 ] && { echo "  no inputs for fuzz_$h"; continue; }
+
+	echo "  replaying $# inputs through fuzz_$h"
+	for f in "$@"; do
+		# Each seed in its own child + cwd so a panic cannot wedge the
+		# loop and artifacts do not accumulate.
+		( cd "$BUILD/$RUNDIR" && \
+		  timeout "$TIMEOUT" "../$(basename "$bin")" "../../${f#../}" \
+		    >/dev/null 2>&1 ) || crashed=$((crashed + 1))
+		replayed=$((replayed + 1))
+		# Clean between seeds: each harness writes a scratch db file.
+		find "$BUILD/$RUNDIR" -mindepth 1 -delete 2>/dev/null || true
+	done
+done
+
+echo "run_cov_fuzz_corpus.sh: built=$built harnesses, replayed=$replayed inputs, $crashed non-zero exits"
+if [ "$built" -eq 0 ]; then
+	echo "run_cov_fuzz_corpus.sh: SKIP (no harness compiled)"
+	exit 0
+fi
+if [ "$replayed" -eq 0 ]; then
+	echo "run_cov_fuzz_corpus.sh: FAIL (nothing replayed)"
+	exit 1
+fi
+# Non-zero exits are expected for corrupt-input seeds on a diagnostic build;
+# check-crashes.sh is the memory-safety gate, not this script.
+echo "run_cov_fuzz_corpus.sh: PASS"
+exit 0

--- a/test/c/run_cov_logrec_print.sh
+++ b/test/c/run_cov_logrec_print.sh
@@ -1,0 +1,57 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_logrec_print.sh --
+#	Build and run cov_logrec_print.c: generate a log containing as many
+#	DISTINCT log record types as one process can produce, then walk the
+#	whole log through db_printlog so the generated per-record printers
+#	(src/<sub>/<sub>_autop.c, ~39 never-called functions) all execute.
+#
+#	Same shape as test/xa/run_xa_direct.sh and test/os/run_os_aio.sh:
+#	compile against the just-built libdb in ./.libs, run in a clean home
+#	under a hard timeout, report PASS/FAIL, exit non-zero on failure.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_logrec_print.sh
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/c/cov_logrec_print.c}
+TIMEOUT=${TIMEOUT:-300}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+
+EXTRA_LIBS="-lpthread"
+# liburing is linked into the .so on Linux builds that found it.
+if echo 'int main(){return 0;}' > /tmp/_covlogrec_print_probe.c && \
+    gcc /tmp/_covlogrec_print_probe.c -luring -o /tmp/_covlogrec_print_probe 2>/dev/null; then
+	EXTRA_LIBS="$EXTRA_LIBS -luring"
+fi
+rm -f /tmp/_covlogrec_print_probe.c /tmp/_covlogrec_print_probe 2>/dev/null || true
+
+echo "Compiling cov_logrec_print against $LIB"
+gcc -g -O1 ${CFLAGS:-} -I"$BUILD" -I../src -I../src/dbinc "$SRC" "$LIB" \
+    $EXTRA_LIBS -Wl,-rpath,"$(cd "$BUILD/.libs" && pwd)" \
+    -o "$BUILD/cov_logrec_print"
+
+# Guaranteed-clean homes (no rm -rf).
+for d in COVLOGREC_TESTDIR; do
+	rm -f "$d"/__db.* "$d"/__dbq.* "$d"/log.* "$d"/*.db "$d"/*.dat "$d"/DB_CONFIG 2>/dev/null || true
+	mkdir -p "$d"
+done
+
+echo "Running cov_logrec_print (timeout ${TIMEOUT}s)"
+if timeout "$TIMEOUT" "$BUILD/cov_logrec_print"; then
+	echo "run_cov_logrec_print.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_cov_logrec_print.sh: FAIL (rc=$rc)"
+	exit $rc
+fi

--- a/test/c/run_cov_oom_paths.sh
+++ b/test/c/run_cov_oom_paths.sh
@@ -1,0 +1,64 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_oom_paths.sh --
+#	Build and run cov_oom_paths.c: a COVERAGE-oriented OOM error-path
+#	sweep.  test/faultinject/fi_sweep.c is the bug-finding sweep; its
+#	children _exit() (correct for a watchdogged classifier, but it skips
+#	gcov's atexit flush, so its 947 failure points contribute ZERO
+#	measured coverage).  This driver sweeps the same seam with a breadth-
+#	first workload and calls __gcov_dump() in each child before _exit, so
+#	the OOM error-return branches -- 6,016 of report #3's 38,998 missing
+#	branches sit on `if ((ret = f()) != 0)` lines -- are measured.
+#
+#	Requires --enable-faultinject; without it the driver prints SKIP and
+#	exits 0, so it is safe to run unconditionally.
+#
+#	Same shape as test/xa/run_xa_direct.sh and test/os/run_os_aio.sh:
+#	compile against the just-built libdb in ./.libs, run in a clean home
+#	under a hard timeout, report PASS/FAIL, exit non-zero on failure.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_oom_paths.sh
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/c/cov_oom_paths.c}
+TIMEOUT=${TIMEOUT:-2400}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+
+EXTRA_LIBS="-lpthread"
+# liburing is linked into the .so on Linux builds that found it.
+if echo 'int main(){return 0;}' > /tmp/_covoom_probe.c && \
+    gcc /tmp/_covoom_probe.c -luring -o /tmp/_covoom_probe 2>/dev/null; then
+	EXTRA_LIBS="$EXTRA_LIBS -luring"
+fi
+rm -f /tmp/_covoom_probe.c /tmp/_covoom_probe 2>/dev/null || true
+
+echo "Compiling cov_oom_paths against $LIB"
+gcc -g -O1 ${CFLAGS:-} -I"$BUILD" -I../src -I../src/dbinc -I../test/faultinject "$SRC" "$LIB" \
+    $EXTRA_LIBS -Wl,-rpath,"$(cd "$BUILD/.libs" && pwd)" \
+    -o "$BUILD/cov_oom_paths"
+
+# Guaranteed-clean homes (no rm -rf).
+for d in COVOOM_TESTDIR; do
+	rm -f "$d"/__db.* "$d"/__dbq.* "$d"/log.* "$d"/*.db "$d"/*.pag "$d"/DB_CONFIG 2>/dev/null || true
+	mkdir -p "$d"
+done
+
+echo "Running cov_oom_paths (timeout ${TIMEOUT}s)"
+if timeout "$TIMEOUT" "$BUILD/cov_oom_paths"; then
+	echo "run_cov_oom_paths.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_cov_oom_paths.sh: FAIL (rc=$rc)"
+	exit $rc
+fi

--- a/test/c/run_cov_rep_api.sh
+++ b/test/c/run_cov_rep_api.sh
@@ -1,0 +1,56 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_cov_rep_api.sh --
+#	Build and run cov_rep_api.c, the direct driver for the replication +
+#	replication-manager CONFIGURATION and QUERY surface (the rep_* /
+#	repmgr_* DB_ENV methods, the DB_SITE handle methods, txn_applied).
+#
+#	Same shape as test/xa/run_xa_direct.sh and test/os/run_os_aio.sh:
+#	compile against the just-built libdb in ./.libs, run in a clean home
+#	under a hard timeout, report PASS/FAIL, exit non-zero on failure.
+#
+# Usage (from build_unix):
+#	sh ../test/c/run_cov_rep_api.sh
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/c/cov_rep_api.c}
+TIMEOUT=${TIMEOUT:-180}
+
+LIB="$BUILD/.libs/libdb-5.3.so"
+if [ ! -f "$LIB" ]; then
+	LIB=$(ls "$BUILD"/.libs/libdb-*.so 2>/dev/null | head -1)
+fi
+[ -n "$LIB" ] || { echo "FAIL: libdb .so not found in $BUILD/.libs"; exit 1; }
+
+EXTRA_LIBS="-lpthread"
+# liburing is linked into the .so on Linux builds that found it.
+if echo 'int main(){return 0;}' > /tmp/_covrep_probe.c && \
+    gcc /tmp/_covrep_probe.c -luring -o /tmp/_covrep_probe 2>/dev/null; then
+	EXTRA_LIBS="$EXTRA_LIBS -luring"
+fi
+rm -f /tmp/_covrep_probe.c /tmp/_covrep_probe 2>/dev/null || true
+
+echo "Compiling cov_rep_api against $LIB"
+gcc -g -O1 ${CFLAGS:-} -I"$BUILD" -I../src -I../src/dbinc "$SRC" "$LIB" \
+    $EXTRA_LIBS -Wl,-rpath,"$(cd "$BUILD/.libs" && pwd)" \
+    -o "$BUILD/cov_rep_api"
+
+# Guaranteed-clean homes (no rm -rf).
+for d in COVREP_TESTDIR_base COVREP_TESTDIR_mgr COVREP_TESTDIR_norep; do
+	rm -f "$d"/__db.* "$d"/__dbq.* "$d"/log.* "$d"/*.db "$d"/DB_CONFIG 2>/dev/null || true
+	mkdir -p "$d"
+done
+
+echo "Running cov_rep_api (timeout ${TIMEOUT}s)"
+if timeout "$TIMEOUT" "$BUILD/cov_rep_api"; then
+	echo "run_cov_rep_api.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_cov_rep_api.sh: FAIL (rc=$rc)"
+	exit $rc
+fi

--- a/test/coverage/full_run4.sh
+++ b/test/coverage/full_run4.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# full_run4.sh -- authoritative full-suite coverage driver, portable rework of
+# full_run3_combined.sh.
+#
+# Differences from full_run3_combined.sh (which was written for a 96-way EC2 box
+# with a distro tcl):
+#   * repo root is derived from the script location (was hard-coded $HOME/libdb)
+#   * tcl lib dir + gcov are taken from the environment / nix dev shell
+#   * PHASE 1 group launches are throttled to $COV_PAR concurrent groups so the
+#     run is survivable on an 8-way box (uncapped fan-out on 8 cores makes every
+#     group hit its timeout instead of finishing)
+#   * PHASE 2 folds in the C drivers that report #3 recorded as a MEASUREMENT
+#     GAP (recd_handlers) plus the new cov_* drivers, the faultinject sweep,
+#     the PBT tier, the fuzz corpus replay and the DST scenarios
+#   * SKIP_PHASE1=1 / SKIP_PHASE2=1 / PHASE2_ONLY_NEW=1 let a run add .gcda to
+#     an existing accumulation instead of starting over, which is how the
+#     per-batch coverage deltas in FULL-COVERAGE-REPORT-4.md were measured.
+#
+# Measurement only -- no engine code touched.
+set -uo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+R="$(cd "$here/../.." && pwd)"
+B="${COV_BUILD:-$R/build_unix}"
+TCLBIN="${TCLBIN:-tclsh8.6}"
+command -v "$TCLBIN" >/dev/null 2>&1 || TCLBIN=tclsh
+TCLLIB="${TCLLIB:-}"
+IGN="mismatch,source,gcov,unused,negative,empty,inconsistent,version,corrupt,range,count"
+LCOV="${LCOV:-lcov}"
+GCOV="${GCOV:-gcov}"
+AM_CAP=${AM_CAP:-9000}; SUB_CAP=${SUB_CAP:-5400}; REP_CAP=${REP_CAP:-420}; LV_CAP=${LV_CAP:-2400}
+COV_PAR=${COV_PAR:-8}
+SKIP_PHASE1=${SKIP_PHASE1:-0}
+SKIP_PHASE2=${SKIP_PHASE2:-0}
+PHASE2_ONLY_NEW=${PHASE2_ONLY_NEW:-0}
+SKIP_BUILD=${SKIP_BUILD:-0}
+TAG=${TAG:-cov4}
+export CC="${CC:-gcc}"
+log(){ echo "[$(date -u +%H:%M:%S)] $*"; }
+mkdir -p "$B"; cd "$B"
+RESULTS=/tmp/$TAG-results.txt; [ "$SKIP_PHASE1$SKIP_PHASE2" = "00" ] && : > "$RESULTS"; touch "$RESULTS"
+T_START=$(date +%s)
+
+throttle(){ while [ "$(jobs -rp | wc -l)" -ge "$COV_PAR" ]; do sleep 2; done; }
+
+# =========================================================================
+# PHASE 0: configure + build ONCE with coverage instrumentation
+# =========================================================================
+if [ "$SKIP_BUILD" = 0 ]; then
+log "=== PHASE 0: configure + build (--coverage) ==="
+find "$B" \( -name '*.gcda' -o -name '*.gcno' \) -delete 2>/dev/null || true
+rm -f "$B"/coverage*.info "$B"/cov*-src*.info "$B"/cov-src.info 2>/dev/null || true
+#
+# --enable-dst and --enable-faultinject are BOTH added here, on top of the
+# --enable-debug --enable-test that report #3 used.  Rationale:
+#
+#   * The DST tier (test/sim, 41 scenarios) links against the sim core, which
+#     that option compiles INTO libdb -- without it `make dst_tests` fails with
+#     undefined __db_sim_* references, which is why no coverage run has ever
+#     measured DST.
+#   * The OOM sweep (test/c/cov_oom_paths.c) needs the __os_* allocation hook
+#     that --enable-faultinject compiles in.
+#
+# Both are documented as additive and inert until armed (dist/configure.ac:
+# "when off ... bit-for-bit the stock library"), and neither changes any
+# measured branch unless a test arms it, so they widen what CAN be measured
+# without distorting what IS measured.  Set COV_PLAIN=1 to reproduce report
+# #3's exact configure line instead.
+EXTRA_CONF="--enable-dst --enable-faultinject"
+[ "${COV_PLAIN:-0}" = 1 ] && EXTRA_CONF=""
+CC=$CC ../dist/configure --enable-debug --enable-test $EXTRA_CONF \
+  ${TCLLIB:+--with-tcl="$TCLLIB"} \
+  CFLAGS="-O0 -g --coverage" LDFLAGS="--coverage" >/tmp/$TAG-configure.log 2>&1 \
+  || { echo "CONFIGURE FAILED"; tail -30 /tmp/$TAG-configure.log; exit 1; }
+make -j"$(nproc)" >/tmp/$TAG-build.log 2>&1 \
+  || { echo "BUILD FAILED"; tail -40 /tmp/$TAG-build.log; exit 1; }
+log "  .gcno files: $(find . -name '*.gcno' | wc -l)"
+fi
+
+# --- build include.tcl template with ABSOLUTE source paths (.libs relative) ---
+INC_TMPL=/tmp/$TAG-include.tcl
+sed -e "s#^set src_root .*#set src_root $R#" \
+    -e "s#^set test_path .*#set test_path $R/test/tcl#" \
+    -e "s#^set je_root .*#set je_root $R/../je#" \
+    -e "s#^set tcl_utils .*#set tcl_utils $R/test/tcl_utils#" \
+    "$B/include.tcl" > "$INC_TMPL"
+
+mkrundir(){ # dir  -- isolated rundir: symlinks .libs + util wrappers + include.tcl
+  local rd="$1"; mkdir -p "$rd"
+  ln -sfn "$B/.libs" "$rd/.libs"
+  cp "$INC_TMPL" "$rd/include.tcl"
+  for f in "$B"/db_* "$B"/berkdb_svc "$B"/test_micro; do
+    bn=$(basename "$f")
+    case "$bn" in *.o|*.d|*.lo|*.gcno|*.gcda|*.c|*.h) continue;; esac
+    [ -f "$f" ] && [ -x "$f" ] && ln -sfn "$f" "$rd/$bn"
+  done
+}
+
+run_group(){ # name cap tcl-body
+  local name="$1" cap="$2" body="$3"
+  local rd="$B/rd_$name" out="/tmp/$TAG-grp-$name.log"
+  mkrundir "$rd"
+  { echo "source $R/test/tcl/test.tcl"; echo "set testdir ./TESTDIR"; echo "$body"; } > "$rd/.run.tcl"
+  ( cd "$rd"; t0=$(date +%s); timeout "$cap" "$TCLBIN" .run.tcl >"$out" 2>&1; rc=$?; t1=$(date +%s)
+    fl=$(grep -c '^FAIL' "$out" 2>/dev/null || echo 0)
+    log "GRP-DONE $name rc=$rc dur=$((t1-t0))s FAILlines=$fl"
+    echo "$name rc=$rc dur=$((t1-t0)) faillines=$fl" >> "$RESULTS"
+    find "$rd/TESTDIR" -mindepth 1 -delete 2>/dev/null || true ) &
+}
+am_body(){ cat <<EOF
+foreach t \$test_names(test) {
+  if {[catch {eval run_method $1 \$t 0 1 stdout} res]} { puts "FAIL $1/\$t: \$res" }
+}
+puts "GROUP_DONE_$1"
+EOF
+}
+sub_body(){ echo "if {[catch {r $1} res]} { puts \"FAIL sub_$1: \$res\" }; puts \"GROUP_DONE_$1\""; }
+
+if [ "$SKIP_PHASE1" = 0 ]; then
+# =========================================================================
+# PHASE 1: full Tcl suite (access methods + subsystems + rep + logverify + recd)
+# =========================================================================
+log "=== PHASE 1: access-method groups ==="
+for m in btree hash recno queue heap; do throttle; run_group "am_$m" "$AM_CAP" "$(am_body $m)"; done
+
+log "=== PHASE 1: subsystem groups ==="
+for sub in env archive backup fop lock log memp mutex txn sdb byte rsrc dbm ndbm hsearch sindex sec compact partition compressed; do
+  throttle; run_group "sub_$sub" "$SUB_CAP" "$(sub_body $sub)"
+done
+throttle; run_group "recd" "$SUB_CAP" "if {[catch {run_recds all 1 0} r]} { puts \"FAIL recd: \$r\" }; puts GROUP_DONE_recd"
+
+log "=== PHASE 1: logverify ==="
+throttle; run_group "logverify" "$LV_CAP" \
+  "source $R/test/tcl/logverify001.tcl; source $R/test/tcl/logverify002.tcl; if {[catch {logverify001} r]} {puts \"FAIL logverify001: \$r\"}; if {[catch {logverify002} r]} {puts \"FAIL logverify002: \$r\"}; puts GROUP_DONE_logverify"
+
+# replication: SKIP known hangers rep016 rep034 repmgr024 repmgr026.
+REP_TESTS="rep001 rep002 rep003 rep005 rep006 rep007 rep008 rep009 rep010 rep011 rep012 rep013 rep014 rep015 rep019 rep020 rep021 rep022 rep023 rep024 rep025 rep026"
+REPMGR_TESTS="repmgr009 repmgr010 repmgr011 repmgr012 repmgr013 repmgr017 repmgr018 repmgr023 repmgr025 repmgr027 repmgr030 repmgr031 repmgr032 repmgr033 repmgr034"
+run_rep_one(){ # test baseport
+  local t="$1" bp="$2"
+  local rd="$B/rd_rep_$t" out="/tmp/$TAG-rep-$t.log"
+  mkrundir "$rd"
+  case "$t" in rep[0-9]*) call="$t btree" ;; *) call="$t" ;; esac
+  printf 'source %s/test/tcl/test.tcl\nset testdir ./TESTDIR\nsource %s/test/tcl/reputils.tcl\nif {[catch {%s} r]} { puts "FAIL %s: $r"; exit 3 }\nputs "PASS %s"\n' \
+    "$R" "$R" "$call" "$t" "$t" > "$rd/.run.tcl"
+  ( cd "$rd"; BDBBASEPORT="$bp" timeout "$REP_CAP" "$TCLBIN" .run.tcl >"$out" 2>&1; rc=$?
+    if [ $rc -eq 124 ]; then st="HANG"; elif [ $rc -eq 0 ] && grep -q "^PASS $t" "$out"; then st="PASS"; else st="FAIL(rc=$rc)"; fi
+    log "REP-DONE $t: $st"; echo "rep_$t $st" >> "$RESULTS"
+    find "$rd/TESTDIR" -mindepth 1 -delete 2>/dev/null || true ) &
+}
+log "=== PHASE 1: rep0NN in-process tests ==="
+for t in $REP_TESTS; do throttle; run_rep_one "$t" 30100; done
+log "=== PHASE 1: repmgrNN socket tests (distinct base ports) ==="
+i=0
+for t in $REPMGR_TESTS; do
+  bp=$((31000 + i*200)); i=$((i+1)); throttle; run_rep_one "$t" "$bp"
+done
+log "=== PHASE 1: waiting ==="
+wait
+log "=== PHASE 1 COMPLETE. gcda=$(find .libs -name '*.gcda' | wc -l) ==="
+fi
+
+if [ "$SKIP_PHASE2" = 0 ]; then
+# =========================================================================
+# PHASE 2: COV_* blocks -- curated subset + all C drivers (adds to .gcda)
+# =========================================================================
+run_driver(){ # name script [env...]
+  local name="$1"; shift
+  local scr="$1"; shift
+  if [ ! -f "$scr" ]; then echo "SKIP $name (no $scr)"; echo "driver_$name SKIP" >> "$RESULTS"; return 0; fi
+  if env "$@" sh "$scr" >/tmp/$TAG-$name.log 2>&1; then echo "PASS $name"; echo "driver_$name PASS" >> "$RESULTS"
+  else echo "FAIL $name (rc=$?)"; echo "driver_$name FAIL" >> "$RESULTS"; tail -5 /tmp/$TAG-$name.log; fi
+}
+
+if [ "$PHASE2_ONLY_NEW" = 0 ]; then
+log "=== PHASE 2: curated COV_TESTS subset (crypto/stat/mvcc/lock/compression) ==="
+COV_TESTS="lock001: txn001: ssi001: ssi002: env007: lock007: \
+  btree/test001 btree/test111 test143:btree \
+  hash/test001 hash/test006 hash/test010 hash/test025 hash/test077 \
+  queue/test001 queue/test007 queue/test025 \
+  recno/test001 recno/test006 recno/test024 recno/test025 \
+  heap/test001 heap/test013 heap/test024 \
+  run_range_partition@test001@btree run_partition_callback@test001@btree \
+  logverify001: logverify002: env020: statprint001: mvcc001: sec001: sec002:"
+subsetrd="$B/rd_covsubset"; mkrundir "$subsetrd"
+runtcl="$subsetrd/.cov-run.tcl"
+{
+  echo "source $R/test/tcl/test.tcl"
+  echo 'set testdir ./TESTDIR'
+  for pair in $COV_TESTS; do
+    case "$pair" in
+    *@*) p="${pair%%@*}"; rest="${pair#*@}"; t="${rest%%@*}"; m="${rest#*@}"
+      printf 'source %s/test/tcl/%s.tcl\n' "$R" "$t"
+      printf 'if {[catch {%s %s %s 0 1} res]} { puts "FAIL %s/%s/%s: $res" }\n' "$p" "$t" "$m" "$p" "$t" "$m"
+      printf 'puts "PASS %s/%s/%s"\n' "$p" "$t" "$m" ;;
+    */*) m="${pair%%/*}"; t="${pair#*/}"
+      printf 'source %s/test/tcl/%s.tcl\n' "$R" "$t"
+      printf 'if {[catch {run_method %s %s 0 1} res]} { puts "FAIL %s/%s: $res" }\n' "$m" "$t" "$m" "$t"
+      printf 'puts "PASS %s/%s"\n' "$m" "$t" ;;
+    *) t="${pair%%:*}"; a="${pair#*:}"
+      printf 'source %s/test/tcl/%s.tcl\n' "$R" "$t"
+      printf 'if {[catch {eval %s %s} res]} { puts "FAIL %s: $res" }\n' "$t" "$a" "$t"
+      printf 'puts "PASS %s"\n' "$t" ;;
+    esac
+  done
+} > "$runtcl"
+( cd "$subsetrd"; timeout 4800 "$TCLBIN" .cov-run.tcl >/tmp/$TAG-subset.log 2>&1
+  grep -cE '^FAIL' /tmp/$TAG-subset.log | xargs -I{} echo "covsubset faillines={}" >> "$RESULTS"
+  find "$subsetrd/TESTDIR" -mindepth 1 -delete 2>/dev/null || true )
+log "  subset done: $(grep -cE '^PASS' /tmp/$TAG-subset.log) pass / $(grep -cE '^FAIL' /tmp/$TAG-subset.log) fail"
+
+log "=== PHASE 2: C drivers (XA + upgrade + os_aio + backup + recd_compact + recd_handlers) ==="
+run_driver xa            "$R/test/xa/run_xa_direct.sh"
+run_driver db_upgrade    "$R/test/db/run_upgrade.sh"
+run_driver os_aio        "$R/test/os/run_os_aio.sh"
+run_driver backup        "$R/test/backup/run_backup_direct.sh"
+run_driver recd_compact  "$R/test/db/run_recd_compact.sh"
+# report #3 recorded recd_handlers as a MEASUREMENT GAP -- it was never in the
+# combined driver even though the code shipped.  Folded in here.
+run_driver recd_handlers "$R/test/db/run_recd_handlers.sh"
+log "  .gcda after C drivers: $(find .libs -name '*.gcda' | wc -l)"
+
+# COV_DEAD_REG: deadlock detector + DB_REGISTER (driver-per-test)
+log "=== PHASE 2: deadlock + DB_REGISTER drivers ==="
+DR_CAP=420
+dead_reg=( "dead001:dead001 {2 4}" "dead002:dead002 {2 4}" "dead003:dead003 {2 4}" \
+  "dead004:dead004" "dead005:dead005 {4}" "dead006:dead006 {2 4}" "env012:env012" )
+drrd="$B/rd_deadreg"; mkrundir "$drrd"; dregtcl="$drrd/.cov-deadreg.tcl"
+for spec in "${dead_reg[@]}"; do
+  name="${spec%%:*}"; call="${spec#*:}"
+  printf 'source %s/test/tcl/test.tcl\nset testdir ./TESTDIR\nif {[catch {%s} r]} { puts "FAIL %s: $r"; exit 3 }\nputs "PASS %s"\n' \
+    "$R" "$call" "$name" "$name" > "$dregtcl"
+  ( cd "$drrd"; timeout "$DR_CAP" "$TCLBIN" .cov-deadreg.tcl >/tmp/$TAG-dreg-$name.log 2>&1; rc=$?
+    pkill -f 'wrap.tcl' 2>/dev/null||true; pkill -f 'ddscript' 2>/dev/null||true
+    pkill -f 'envscript' 2>/dev/null||true; pkill -f 'db_deadlock' 2>/dev/null||true
+    if [ $rc -eq 124 ]; then echo "HANG $name"; echo "dreg_$name HANG">>"$RESULTS"
+    elif [ $rc -eq 0 ] && grep -q "^PASS $name" /tmp/$TAG-dreg-$name.log; then echo "PASS $name"; echo "dreg_$name PASS">>"$RESULTS"
+    else echo "FAIL $name (rc=$rc)"; echo "dreg_$name FAIL">>"$RESULTS"; fi
+    find "$drrd/TESTDIR" -mindepth 1 -delete 2>/dev/null || true )
+done
+
+# COV_RECD extra curated recd tests (driver-per-test) -- adds redo/undo branches
+log "=== PHASE 2: recd recovery-record handler tests ==="
+RECD_CAP=420
+recd_tests=( "recd002:btree:0" "recd002:hash:0" "recd002:queue:0" "recd002:recno:0" \
+  "recd004:btree:" "recd005:btree:" "recd005:hash:" "recd005:queue:" "recd005:recno:" \
+  "recd006:btree:" "recd006:hash:" "recd008:btree:" "recd009:btree:" "recd010:btree:" \
+  "recd013:btree:" "recd013:hash:" "recd014:queueext:" "recd016:btree:" "recd017:btree:" \
+  "recd018:btree:" "recd019:btree:" "recd020:btree:" "recd022:btree:" "recd023:btree:" \
+  "recd024:btree:" "recd025:btree:" )
+recdrd="$B/rd_recdcov"; mkrundir "$recdrd"; recdtcl="$recdrd/.cov-recd.tcl"
+for spec in "${recd_tests[@]}"; do
+  t="${spec%%:*}"; rest="${spec#*:}"; m="${rest%%:*}"; a="${rest#*:}"
+  printf 'source %s/test/tcl/test.tcl\nset testdir ./TESTDIR\nsource %s/test/tcl/%s.tcl\nif {[catch {eval %s %s %s} r]} { puts "FAIL %s %s: $r"; exit 3 }\nputs "PASS %s %s"\n' \
+    "$R" "$R" "$t" "$t" "$m" "$a" "$t" "$m" "$t" "$m" > "$recdtcl"
+  ( cd "$recdrd"; timeout "$RECD_CAP" "$TCLBIN" .cov-recd.tcl >/tmp/$TAG-recd-$t-$m.log 2>&1; rc=$?
+    pkill -f 'recdscript' 2>/dev/null || true
+    if [ $rc -eq 124 ]; then echo "HANG $t $m"; echo "recd_${t}_$m HANG">>"$RESULTS"
+    elif [ $rc -eq 0 ] && grep -q "^PASS $t $m" /tmp/$TAG-recd-$t-$m.log; then echo "PASS $t $m"; echo "recd_${t}_$m PASS">>"$RESULTS"
+    else echo "FAIL $t $m (rc=$rc)"; echo "recd_${t}_$m FAIL">>"$RESULTS"; fi
+    find "$recdrd/TESTDIR" -mindepth 1 -delete 2>/dev/null || true )
+done
+fi   # PHASE2_ONLY_NEW
+
+# ---------------------------------------------------------------------------
+# PHASE 2b: the tiers report #3 never measured -- new in run #4.
+#
+# Each of these is a MEASUREMENT GAP closer as much as a new test: the tier
+# already existed and passed, but no coverage driver ever ran it, so what it
+# covers has always been reported cold.  They are ordered cheapest-first so a
+# time-boxed run still gets the high-value ones.
+# ---------------------------------------------------------------------------
+log "=== PHASE 2b: new coverage C drivers + never-measured tiers ==="
+# Deterministic, seconds each: the API/config/query surface drivers.
+run_driver cov_api_surface  "$R/test/c/run_cov_api_surface.sh"
+run_driver cov_rep_api      "$R/test/c/run_cov_rep_api.sh"
+# One rich log -> both the *_autop.c printers and log_verify_int.c's verifiers.
+run_driver cov_logrec_print "$R/test/c/run_cov_logrec_print.sh"
+# cutest: 12 existing suites incl. TestChannel (3 live repmgr sites).
+run_driver cov_cutest       "$R/test/c/run_cov_cutest.sh"
+# The committed fuzz corpus + crash seeds, replayed against THIS build.
+run_driver cov_fuzz_corpus  "$R/test/c/run_cov_fuzz_corpus.sh"
+# The 41 DST scenarios (crash/torn/ENOSPC/clock-skew/crash-in-recovery).
+run_driver cov_dst          "$R/test/c/run_cov_dst.sh"
+# The OOM error-path sweep.  Last: it is the longest, and it is the one that
+# needs --enable-faultinject (it SKIPs cleanly without it).
+run_driver cov_oom_paths    "$R/test/c/run_cov_oom_paths.sh"
+
+log "=== PHASE 2 COMPLETE. gcda=$(find .libs -name '*.gcda' | wc -l) ==="
+fi
+
+# =========================================================================
+# PHASE 3: single lcov capture from .libs, merge everything
+# =========================================================================
+log "=== PHASE 3: lcov capture from .libs ==="
+$LCOV --capture --directory .libs --output-file coverage4.info --gcov-tool "$GCOV" \
+  --rc geninfo_unexecuted_blocks=1 --branch-coverage --ignore-errors "$IGN" >/tmp/$TAG-lcov.log 2>&1 \
+  || { echo "LCOV CAPTURE FAILED"; tail -30 /tmp/$TAG-lcov.log; exit 1; }
+$LCOV --extract coverage4.info "*/src/*" --output-file cov4-src-all.info --branch-coverage --ignore-errors "$IGN" >/dev/null 2>&1
+$LCOV --remove cov4-src-all.info "*/dbinc_auto/*" --output-file cov-src.info --branch-coverage --ignore-errors "$IGN" >/dev/null 2>&1
+log "=== SUMMARY ==="; $LCOV --summary cov-src.info --branch-coverage --ignore-errors "$IGN" 2>&1 | tee /tmp/$TAG-summary.txt
+log "ranking"; python3 "$here/rank_coverage.py" cov-src.info > /tmp/$TAG-ranking.txt 2>&1
+log "subsystems"; python3 "$here/subsystem_breakdown.py" cov-src.info > /tmp/$TAG-subsystems.txt 2>&1
+cp cov-src.info /tmp/$TAG-cov-src.info
+T_END=$(date +%s)
+echo "WALL_SECONDS=$((T_END-T_START))" | tee /tmp/$TAG-wall.txt
+echo "=== TOP 30 COLD FILES ==="; head -31 /tmp/$TAG-ranking.txt
+echo "=== SUBSYSTEMS ==="; cat /tmp/$TAG-subsystems.txt
+echo "=== RESULTS ==="; sort "$RESULTS"
+log "ALL DONE"


### PR DESCRIPTION
Phase C of the evolved plan. Adds test drivers for surfaces the suite never measured, and — importantly — establishes with arithmetic that **>85% branch is not a reachable target**, while **>85% function is**.

## The honest headline: 85% branch is out of reach; 85% function is not

Current (committed lcov, report #3): **line 68.0%, branch 50.2% (39238/78236), function 80.5% (2129/2644)**.

Reaching 85% branch needs **+27,262 branches = 70% of every currently-missing branch**. The structural reason: ~1,662 `if ((ret = f()) != 0)` sites in `src/` are OOM/error-return legs reachable *only* by malloc-fault injection, and `fi_sweep.c` reaches exactly **one** failure point per process run (it sweeps K=1..M) — so covering K error legs costs K runs. Another 2,368 are NULL checks and 1,496 flag tests.

**>85% function is the reachable goal**: it needs only **+118** functions, and ~250 recoverable ones were identified.

## Drivers added (each validated with real check counts)
| Artifact | Result | Targets |
|---|---|---|
| `cov_api_surface.c` | **418 checks, 0 fail** | ~60 never-called getters (`db_method.c` 24, `env_method.c` 21, `mp_fmethod.c` 8, `db_cds.c` 8) |
| `cov_rep_api.c` | **254 checks, 0 fail** | rep/repmgr config+query surface, `DB_SITE`, `txn_applied`, base-API↔repmgr cross-rejection |
| `cov_logrec_print.c` | **5115 checks, 0 fail**, 41 log-record types | ~39 `*_autop.c` printers, 62 of `log_verify_int.c`'s 99 functions |
| `cov_codecs.c` | **290326 checks, 0 fail** | `db_compint.c`'s 66 missing branches, `db_getlong`/`getulong` |
| `cov_oom_paths.c` | builds with/without faultinject | error-return branches; calls `__gcov_dump()` before `_exit` |
| 7 runner scripts | `cutest` 8/9 suites, fuzz 3 harnesses/14 inputs, DST skips cleanly | tiers whose coverage was never collected |

## Two measurement gaps found (why some tiers showed as 0%)
- `fi_sweep.c`'s 947 fault points measured as **zero** because the child `_exit()`s without `__gcov_dump()`. Any driver that `_exit()`s must dump first or its coverage is invisible.
- `test/fuzz/run.sh` builds its **own** ASan libdb, so corrupt-input rejection branches never reach the main profile.

## Five latent defects found (reported, not fixed here)
1. **NULL-deref** `__lock_set_lk_priority`/`get_lk_priority` (`lock_method.c:482,507`) — `__lock_getlocker(create=0)` returns 0 with `*retp=NULL`, both deref unconditionally; `__lock_vec_pp` (`lock.c:93`) shares the pattern.
2. **NULL-deref** `rep_get_nsites` on an unopened repmgr handle (12-line repro; `ENV_NOT_CONFIGURED` is a no-op pre-open).
3. `__cdsgroup_begin` installs **8 of `DB_TXN`'s 12** methods — `get_priority`/`set_priority`/`set_commit_token`/`set_txn_lsnp` are NULL; calling them jumps to 0x0.
4. `TestQueue.c:64` buffer overrun in `sh_l_as_string` (harness bug, crashes at `-O2`).
5. `db_printlog` in this fork has no `-a` flag (report #3's driver assumed it did).

## Honest limitation
**No new measured before/after numbers.** A full coverage run needs a big box (report #3 used a 96-way instance); on this 8-core box shared with concurrent agents (load 143–216) the BEFORE run did not finish. `baseline.txt` is therefore **untouched** and report #4 is unwritten — the drivers are validated by their own check counts, not yet by a coverage delta. Finishing that is mechanical: `full_run4.sh` accumulates `.gcda` so the AFTER run reuses the BEFORE work.

Two driver assertions were corrected rather than filed as bugs: the compressed-int encoding is deliberately **not** order-preserving (only used for lengths/sizes, never as a sort key), and `__db_getlong` uses base-10 `strtol`, so rejecting `"0x10"` is correct.