### PR TITLE
fix(txn): make the SSI commit-time pivot check atomic with the commit decision (#136)

### DIFF
--- a/docs_src/api/c/txnbegin.md
+++ b/docs_src/api/c/txnbegin.md
@@ -83,7 +83,7 @@ The **flags** parameter must be set to 0 or by bitwise inclusively **OR**'ing to
 
   > **Note:** In this fork, `DB_TXN_SNAPSHOT` provides *serializable* snapshot isolation. In stock Oracle Berkeley DB, `DB_TXN_SNAPSHOT` provided only plain (non-serializable) snapshot isolation, and the earlier `DB_TXN_SNAPSHOT_SAFE` flag has been removed — there is no separate non-serializable snapshot mode.
 
-  > **Known limitation (as of 5.3.34).** Outside review found that the serializable guarantee is **not yet absolute**. A conflicting write that lands while another transaction is *inside* <a href="txncommit.md" class="xref" title="DB_TXN-&gt;commit()">DB_TXN-&gt;commit()</a> can escape detection, allowing a write skew to commit; and two records on different pages of one B-tree may not be detected as conflicting. Separately, long-lived environments running many snapshot transactions can exhaust the mutex region (`ENOMEM`) because reader bookkeeping is not fully reclaimed. Applications that depend on serializability for a correctness invariant should not yet rely on it alone. Tracking: issues #136, #137, #138 (and #140 for a related replication-path defect).
+  > **Known limitation (as of 5.3.34).** Long-lived environments running many snapshot transactions can exhaust the mutex region (`ENOMEM`) because reader bookkeeping is not fully reclaimed. Tracking: issues #137, #138 (and #140 for a related replication-path defect).
 
 - `DB_TXN_SYNC`
 

--- a/rfc/0003-ssi-serializable-snapshot-isolation.md
+++ b/rfc/0003-ssi-serializable-snapshot-isolation.md
@@ -60,19 +60,23 @@ Both of Cahill's rw-conflict detection paths are implemented:
 
 SIREAD markers are reclaimed incrementally (not only at checkpoint).
 
-> **Known limitations (2026-09, from external reports #136–#140).** The claims in
+The commit-time pivot check is atomic with respect to conflict recording. Both
+pivot flags are read under `TXN_SYSTEM_LOCK` — the mutex every recorder
+(`__lock_get_internal`, `__memp_si_rwconflict`) takes around its flag
+read-modify-write — and, in the same critical section, a passing check publishes
+`TXN_DTL_SICHECKED` on the detail. That flag is what makes the window between
+the check and `__txn_end`'s `TXN_COMMITTED` store safe: a recorder that arrives
+during it sees that the committing transaction will not re-examine its flags and
+resolves the edge itself (`DB_SNAPSHOT_UNSAFE`) instead of deferring to a check
+that has already happened. Deferring on `status == TXN_RUNNING` alone was
+issue #136 — a write skew where both transactions committed; `test/isolation`
+gates it.
+
+> **Known limitations (2026-09, from external reports #137–#140).** The claims in
 > this RFC describe the *intended* design; the delivered behavior is weaker in
 > ways confirmed by outside review. Until the fixes land with regression tests,
 > treat the serializability guarantee as **best-effort, not absolute**:
 >
-> - **#136 — write skew can commit.** The commit-time pivot check is **not**
->   atomic with respect to the `TXN_RUNNING` → `TXN_COMMITTED` transition. A
->   conflicting write that lands while the first transaction is *inside*
->   `DB_TXN->commit` can leave both transactions committing, producing a state
->   with no serial order. A separate observation from the same report: two
->   records on *different pages of one B-tree* may detect no conflict at all.
->   (An earlier working note in this directory claimed this race was resolved;
->   that claim was wrong and is retracted.)
 > - **#137 / #138 — marker reclamation is not fully bounded.** SIREAD cleanup
 >   does not reclaim the deferred committed-reader locker, and
 >   `__txn_reap_si_details` frees a transaction detail without releasing its MVCC

--- a/src/dbinc/txn.h
+++ b/src/dbinc/txn.h
@@ -114,6 +114,7 @@ typedef struct __txn_detail {
 #define	TXN_DTL_NOWAIT		0x10	/* Don't block on locks. */
 #define	TXN_DTL_WCONF		0x20	/* SSI: write end of an rw-conflict. */
 #define	TXN_DTL_RCONF		0x40	/* SSI: read end of an rw-conflict. */
+#define	TXN_DTL_SICHECKED	0x80	/* SSI: past its commit pivot check. */
 	u_int32_t flags;
 
 	SH_TAILQ_ENTRY	links;		/* active/free/snapshot list */
@@ -128,6 +129,35 @@ typedef struct __txn_detail {
 	int32_t format;			/* XA format */
 	roff_t slots[TXN_NSLOTS];	/* Initial DB slot allocation. */
 } TXN_DETAIL;
+
+/*
+ * TXN_SI_PAST_CHECK --
+ *	SSI: TRUE when this transaction will not consult its own pivot flags
+ *	again, so a writer forming an rw-conflict edge into it now cannot defer
+ *	the conflict to it and must resolve the edge itself.  That is the case
+ *	once the transaction has committed and, crucially, also while it is
+ *	inside DB_TXN->commit past its one and only pivot check: __txn_commit
+ *	publishes TXN_DTL_SICHECKED under TXN_SYSTEM_LOCK, atomically with that
+ *	check.
+ *
+ *	Without the flag the whole span from the pivot check to __txn_end's
+ *	status store still reads TXN_RUNNING, so a writer deferred to a check
+ *	that had already happened and both transactions committed a write skew
+ *	(issue #136).  An aborted transaction is deliberately NOT "past check":
+ *	its reads never committed, so an edge into it is not a conflict at all
+ *	-- hence the status test rather than testing TXN_DTL_SICHECKED alone,
+ *	which survives on the detail if the commit fails after publishing it.
+ *	In that narrow error window (commit published the flag, then failed and
+ *	his on its way to TXN_ABORTED) a writer may abort itself needlessly.
+ *	That errs safe -- a spurious DB_SNAPSHOT_UNSAFE, never a missed one --
+ *	and only on a path where the peer is already failing.
+ *
+ *	Callers hold TXN_SYSTEM_LOCK, which is where every writer of the pivot
+ *	flags and of TXN_DTL_SICHECKED serializes.
+ */
+#define	TXN_SI_PAST_CHECK(td)						\
+	((td)->status == TXN_COMMITTED ||				\
+	    ((td)->status == TXN_RUNNING && F_ISSET(td, TXN_DTL_SICHECKED)))
 
 /*
  * DB_TXNMGR --

--- a/src/dbinc_auto/int_def.in
+++ b/src/dbinc_auto/int_def.in
@@ -1846,6 +1846,7 @@
 #define	__os_support_db_register __os_support_db_register@DB_VERSION_UNIQUE_NAME@
 #define	__os_support_replication __os_support_replication@DB_VERSION_UNIQUE_NAME@
 #define	__os_cpu_count __os_cpu_count@DB_VERSION_UNIQUE_NAME@
+#define	__os_csprng __os_csprng@DB_VERSION_UNIQUE_NAME@
 #define	__os_ctime __os_ctime@DB_VERSION_UNIQUE_NAME@
 #define	__os_dirlist __os_dirlist@DB_VERSION_UNIQUE_NAME@
 #define	__os_dirfree __os_dirfree@DB_VERSION_UNIQUE_NAME@

--- a/src/lock/lock.c
+++ b/src/lock/lock.c
@@ -1102,22 +1102,34 @@ again:	if (obj == NULL) {
 				 * Record R --rw--> W under the txn-region mutex so
 				 * the two-flag reads and writes are atomic against
 				 * a concurrent recorder and the commit-time check.
+				 *
+				 * Both fate tests below ask "can R still resolve
+				 * this edge itself?", which is FALSE not only once R
+				 * has committed but also while R is inside
+				 * DB_TXN->commit past its pivot check --
+				 * TXN_SI_PAST_CHECK covers both, because
+				 * __txn_commit publishes TXN_DTL_SICHECKED under
+				 * this same mutex.  Testing R's status alone read
+				 * TXN_RUNNING for the whole span between R's check
+				 * and __txn_end, so we deferred to a check that had
+				 * already happened and both transactions committed a
+				 * write skew (#136).
 				 */
 				if (TXN_ON(env))
 					TXN_SYSTEM_LOCK(env);
 				if (F_ISSET(LOCK_OWNER(env, sireadlp),
 				    TXN_DTL_WCONF) &&
-				    LOCK_OWNER(env, sireadlp)->status ==
-				    TXN_COMMITTED)
+				    TXN_SI_PAST_CHECK(LOCK_OWNER(env, sireadlp)))
 					ret = DB_SNAPSHOT_UNSAFE;
 				else {
 					rwconf = 1;
 					/*
 					 * Set our incoming-conflict flag unless
-					 * the reader will itself abort.
+					 * the reader will itself abort -- which it
+					 * only will if it has a pivot check left.
 					 */
-					if (LOCK_OWNER(env, sireadlp)->status ==
-					    TXN_COMMITTED ||
+					if (TXN_SI_PAST_CHECK(LOCK_OWNER(env,
+					    sireadlp)) ||
 					    !F_ISSET(LOCK_OWNER(env, sireadlp),
 					    TXN_DTL_WCONF)) {
 						if (F_ISSET(LOCKER_TD(env,

--- a/src/mp/mp_fget.c
+++ b/src/mp/mp_fget.c
@@ -156,12 +156,16 @@ __memp_si_rwconflict(env, txn, visible_bhp)
 			break;
 		}
 		/*
-		 * Set W's write-end flag unless W already committed with the
-		 * read end set (W was itself a pivot that slipped through);
-		 * in that case the incoming edge still makes R the pivot.
+		 * Set W's write-end flag unless W already reached the point
+		 * where it will not re-examine its own pivot flags -- it has
+		 * committed, or it is inside DB_TXN->commit past its pivot
+		 * check (TXN_DTL_SICHECKED, published under this same mutex).
+		 * If W is there and already carries the read end, W is a pivot
+		 * that nobody will stop, so the incoming edge makes R abort
+		 * instead.  Testing W's status alone missed the committing case
+		 * and let a write skew commit (issue #136).
 		 */
-		if (F_ISSET(wtd, TXN_DTL_RCONF) &&
-		    wtd->status == TXN_COMMITTED) {
+		if (F_ISSET(wtd, TXN_DTL_RCONF) && TXN_SI_PAST_CHECK(wtd)) {
 			ret = DB_SNAPSHOT_CONFLICT;
 			break;
 		}

--- a/src/txn/txn.c
+++ b/src/txn/txn.c
@@ -746,12 +746,25 @@ __txn_commit(txn, flags)
 	 * could produce a non-serializable schedule.
 	 *
 	 * The pivot flags are set on td by concurrent writers in the lock
-	 * manager, which serialize their flag writes on the txn-region mutex
-	 * (see __lock_get_internal).  Read both flags under the same mutex so
-	 * the two-flag test and this commit decision are atomic with respect
-	 * to a writer recording our second conflict edge -- otherwise an edge
-	 * set between the two reads, or just after they pass, would let a real
-	 * pivot commit.
+	 * manager and in mpool, which serialize their flag writes on the
+	 * txn-region mutex (see __lock_get_internal, __memp_si_rwconflict).
+	 * Read both flags under that mutex so the two-flag test is atomic with
+	 * respect to a writer recording our second conflict edge.
+	 *
+	 * This is our ONLY pivot check: everything below (cursor close, lease
+	 * check, log write) is past the point where aborting on a late edge
+	 * would be correct, and __txn_end does not publish TXN_COMMITTED until
+	 * much later.  So, in the same critical section, publish
+	 * TXN_DTL_SICHECKED: it tells a writer that arrives during that whole
+	 * span that this transaction will not look at its pivot flags again, so
+	 * the writer must resolve the edge itself (abort with
+	 * DB_SNAPSHOT_UNSAFE) rather than defer to a check that has already
+	 * happened.  Without it a writer treats us as "still running, already
+	 * flagged, it will abort at its check" and both transactions commit a
+	 * write skew (issue #136).
+	 *
+	 * Only a snapshot-safe txn is examined by those writers, so nothing is
+	 * published for the ordinary path.
 	 */
 	if (F_ISSET(txn, TXN_SNAPSHOT_SAFE)) {
 		int is_pivot;
@@ -759,6 +772,8 @@ __txn_commit(txn, flags)
 			TXN_SYSTEM_LOCK(env);
 		is_pivot = F_ISSET(td, TXN_DTL_WCONF) &&
 		    F_ISSET(td, TXN_DTL_RCONF);
+		if (!is_pivot)
+			F_SET(td, TXN_DTL_SICHECKED);
 		if (TXN_ON(env))
 			TXN_SYSTEM_UNLOCK(env);
 		if (is_pivot) {

--- a/test/isolation/README.md
+++ b/test/isolation/README.md
@@ -38,11 +38,11 @@ The state vector has two kinds of slot:
 
 | Scenario | Shape | Expectation on master |
 |---|---|---|
-| `write_skew_trigger` | two one-page DBs; T2's write lands while T1 is inside `commit` | **XFAIL — reproduces #136** |
+| `write_skew_trigger` | two one-page DBs; T2's write lands while T1 is inside `commit` | PASS (`DB_SNAPSHOT_UNSAFE` to T2) — regression gate for #136 |
 | `write_skew_control` | two one-page DBs; T2 writes and commits before T1 commits | PASS (`DB_SNAPSHOT_CONFLICT` to T1) |
 | `write_skew_late` | two one-page DBs; T2 writes after T1's commit returned | PASS (`DB_SNAPSHOT_UNSAFE` to T2) |
 | `write_skew_samebtree_control` | two records on **different pages of one** B-tree; control timing | PASS |
-| `write_skew_samebtree_trigger` | same, trigger timing | **XFAIL — reproduces #136** |
+| `write_skew_samebtree_trigger` | same, trigger timing | PASS — regression gate for #136 |
 | `g2_antidep` | G2-item: both txns scan for markers, both insert one | PASS |
 | `read_only_anomaly` | Fekete's 3-txn pattern; the read-only txn's observation is checked | PASS |
 | `lost_update` | both txns read the counter and write read+1 | PASS |
@@ -83,7 +83,8 @@ purpose: **one** violation in any attempt is a reproduction, while a pass
 requires **every** attempt to be clean. A serializability violation is a real
 counterexample; a single clean run of a racy schedule proves nothing.
 
-In practice both #136 shapes violate on the first attempt.
+In practice both #136 shapes violated on the first attempt before the fix; both
+now report `DB_SNAPSHOT_UNSAFE` to T2 in every attempt.
 
 ## Running it
 
@@ -113,5 +114,6 @@ Environment: `CC`, `LIBDB_BUILD` (default `../../build_unix`), `ISO_TIMEOUT`
   `test_iso_anomaly.c`. The message says which.
 - `2` — harness error.
 
-When #136 lands, clear `expect_fail` on `write_skew_trigger` and
-`write_skew_samebtree_trigger`; the tier then gates the fix against regression.
+#136 is fixed (`TXN_DTL_SICHECKED`, see `rfc/0003`), so `expect_fail` is clear
+on every scenario and this tier is a plain regression gate: any violation is a
+new bug.

--- a/test/isolation/test_iso_anomaly.c
+++ b/test/isolation/test_iso_anomaly.c
@@ -1019,7 +1019,7 @@ read_your_writes(iso_scenario *sc, iso_state *st, iso_txn *t)
 static iso_scenario scenarios[] = {
     { "write_skew_trigger",
       "two one-page DBs; T2's write lands while T1 is inside commit",
-      2, 2, 2, 1, "#136", 40, sk_trigger },
+      2, 2, 2, 0, NULL, 40, sk_trigger },
     { "write_skew_control",
       "two one-page DBs; T2 writes and commits before T1 commits",
       2, 2, 2, 0, NULL, 5, sk_control },
@@ -1031,7 +1031,7 @@ static iso_scenario scenarios[] = {
       2, 2, 2, 0, NULL, 5, sk_samebtree_control },
     { "write_skew_samebtree_trigger",
       "two records on DIFFERENT pages of ONE btree; trigger timing",
-      2, 2, 2, 1, "#136", 40, sk_samebtree_trigger },
+      2, 2, 2, 0, NULL, 40, sk_samebtree_trigger },
     { "g2_antidep",
       "G2-item: both txns scan for markers, both insert one",
       1, 1, 2, 0, NULL, 1, g2_antidep },


### PR DESCRIPTION
## The defect

A write skew **commits** under `DB_TXN_SNAPSHOT` when the second transaction's
write lands while the first is inside `DB_TXN->commit`. Both commits return 0
and the stored state has no serial order. Reported in #136 with a complete
reproducer and a correct root-cause analysis.

Two halves of one race:

**(a) The commit-side check was not atomic with the status transition.**
`__txn_commit` read both pivot flags under `TXN_SYSTEM_LOCK`, then released it —
but `td->status` stays `TXN_RUNNING` until `__txn_end` publishes
`TXN_COMMITTED`, far later, past cursor close, lease checks and the log write.
Throughout that span T1 looked like a running transaction whose pivot check was
still ahead of it. The in-code comment claiming the test and the commit decision
are atomic was true only of the two flag reads, not of the decision.

**(b) The writer-side "reader will abort itself" optimization trusted that
stale status.** In `__lock_get_internal`, T2 met T1's SIREAD marker, saw
`status == TXN_RUNNING` **and** `TXN_DTL_WCONF` already set, and concluded T1
would abort at a later pivot check. So it skipped the branch that would have
rejected T2 for its own existing `TXN_DTL_RCONF`, did not set `WCONF` on itself,
and only added `RCONF` to T1 — a transaction that had already passed its one and
only pivot check. T1 ended up holding both pivot flags with nobody left to look
at them; T2 held only `RCONF`; both committed.

## Design chosen: option 1 — publish a "checked/committing" state under the same mutex as the check

A passing pivot check now publishes `TXN_DTL_SICHECKED` on the detail *in the
same `TXN_SYSTEM_LOCK` critical section as the check itself*. The writer-side
fate tests ask "can the peer still resolve this edge?" through a new
`TXN_SI_PAST_CHECK(td)` predicate instead of `status == TXN_COMMITTED`, so a
committing-but-not-yet-committed peer is treated like a committed one and the
writer resolves the edge itself (`DB_SNAPSHOT_UNSAFE`).

**Why the alternatives are worse:**

- **Option 2, re-check after the point of no return** — not correct. The
  "last moment" before `status = TXN_COMMITTED` in `__txn_end` is *after*
  `__txn_regop_log`/log flush and after `__lock_vec(DB_LOCK_PUT_READ)` released
  the read locks. Aborting there is not available: `__txn_end` is documented as
  unable to return an error and panics on failure, and the commit record is
  already durable, so a replica or a recovery pass would already have accepted
  the commit. It also cannot use `goto err` (which calls `__txn_abort`) because
  the transaction's locks are gone. The task brief anticipated this, and reading
  the code confirms it: the window is not abortable, so the state must be
  published *at* the decision, not re-examined after it.
- **Making the writer test `status != TXN_RUNNING`** — wrong direction: it would
  treat an *aborted* peer as "past check", turning every edge into a doomed
  transaction into a spurious abort of the writer. An aborted transaction's reads
  never committed, so an edge into it is not a conflict at all. Hence
  `TXN_SI_PAST_CHECK` tests `TXN_COMMITTED || (TXN_RUNNING && SICHECKED)`.
- **Atomic flags word / wider locking** — the existing analysis note already
  rejected converting `TXN_DETAIL.flags` to an atomic: it carries many non-SSI
  bits and atomics alone would not make the decision atomic. Both sides already
  serialize on `TXN_SYSTEM_LOCK`; the missing ingredient was *state*, not more
  mutual exclusion.
- **Abort the pivot the moment the second edge forms** (no commit-time check at
  all) — arguably the better long-term shape, but a much larger behavioral change
  than a bug fix should carry.

Also fixed the same staleness at the mirror site in mpool
(`__memp_si_rwconflict`), which had the identical `wtd->status == TXN_COMMITTED`
test. The reported reproducer does not reach it, but it is the same defect one
mechanism over — the lazy fix is the one predicate used by both callers.

## Constraints honoured

- **No layout/ABI/format change.** `TXN_DTL_SICHECKED` is the spare bit `0x80`
  in `TXN_DETAIL`'s existing `u_int32_t flags` word (bits through `0x40` were
  taken). Verified by compiling the struct both ways:

  | | master | this branch |
  |---|---|---|
  | `sizeof(TXN_DETAIL)` | 344 | 344 |
  | `offsetof(flags)` | 140 | 140 |
  | `offsetof(links)` | 144 | 144 |
  | `offsetof(slots)` | 312 | 312 |
  | `sizeof(DB_TXNREGION)` | 208 | 208 |

  No on-disk, log or region-layout change; no public ABI change. No new message
  IDs (no new user-visible strings), so `s_message_id` was not needed.
- **Lock ordering unchanged.** No new mutex and no new nesting: both sides
  already took `TXN_SYSTEM_LOCK` around their flag access. The commit critical
  section grows by exactly one `F_SET` on a word already in cache.
- **Existing correct behaviors preserved:** `control` still yields
  `DB_SNAPSHOT_CONFLICT`, `late` still yields `DB_SNAPSHOT_UNSAFE`.

## Proof the race is closed

The reporter's own reproducer, built against this branch, on both the debug
(`--enable-debug --enable-diagnostic`) and the release (`CFLAGS=-O2`) trees:

| timing | master | this branch |
|---|---|---|
| trigger | both commit, `alice=0 bob=0`, **no serial order** | T2 put -> `DB_SNAPSHOT_UNSAFE`, `alice=0 bob=1` |
| control | T1 commit -> `DB_SNAPSHOT_CONFLICT` | unchanged |
| late | T2 put -> `DB_SNAPSHOT_UNSAFE` | unchanged |

It is a race, so it was run repeatedly rather than once:

- **debug build:** 60 + 40 = 100 trigger runs, 100 control, 100 late -> **300/300
  serializable, 0 violations**. Every trigger run gave `DB_SNAPSHOT_UNSAFE`;
  every control gave `DB_SNAPSHOT_CONFLICT`.
- **release `-O2` build:** 25 runs per mode -> **75/75 serializable**.
- On master the trigger reproduced on the first attempt, every attempt.

## The isolation tier, expectations cleared

`expect_fail` is now clear on `write_skew_trigger` and
`write_skew_samebtree_trigger` (and the README table/exit-status section
updated), so the tier is a plain regression gate — any violation is a new bug.

```
9 scenario(s) run, 0 unexpected outcome(s)
```

Run 4x in full (each racy scenario doing 40 attempts) plus 5 extra runs of just
the two trigger scenarios: **~700 racy attempts, 0 non-serializable histories.**

Both #136 shapes now show `T2 read alice=1; put bob=0 -> DB_SNAPSHOT_UNSAFE`.

### On the reporter's "separate defect"

Confirmed **not** a second bug, with two independent constructions: the tier's
`write_skew_samebtree_control` (512-byte pages + filler keys, 33 leaf pages
verified via `DB->stat`→`bt_leaf_pg`, `alice`=min key, `bob`=max key) and the
reporter's own two-one-page-DB shape both return `DB_SNAPSHOT_CONFLICT` at
control timing and only fail at trigger timing. So the different-pages shape has
the same single root cause. The reporter never published their same-btree
variant, so their exact shape is unverified — with two records at the default
page size those sit on one page, a case they themselves report behaves
correctly. The `samebtree_control` PASS expectation is kept live so a real
page-granularity hole would surface there.

## Regression matrix

| Suite | Result |
|---|---|
| `ssi001`–`ssi009` | 9/9 OK |
| `txn001` / `txn002` / `txn003` | OK |
| `lock001` / `lock002` / `lock003` | OK |
| `recd001` / `recd002` (btree) | OK |
| `test001` btree / hash / queue / recno | 4/4 OK |
| **`ssi009` + ssi001/002/004 under ASan** | **OK, 0 sanitizer reports** |
| `test/isolation/run.sh` | 9 scenarios, 0 unexpected (x4) |
| `test/soak/run.sh` | 5 workloads, 0 unexpected, no slope exceeded |
| `test/lockmatrix/run.sh` | 0 checks failed |
| `test/fuzz/check-crashes.sh` | 9/9 PASS |
| `test_sim_crash_recover` (`--enable-dst`) | PASS, 64 committed txns survived, verifies clean |

ASan runs used `LD_PRELOAD=$(cc -print-file-name=libasan.so)
ASAN_OPTIONS=detect_leaks=0` as required for the instrumented `libdb_tcl`.

**Builds:** `--enable-debug --enable-diagnostic --enable-test`,
`--enable-diagnostic`, release `CFLAGS=-O2`, `--enable-debug --enable-dst`,
ASan, and `meson setup build && ninja -C build` — all clean, 0 errors.

## Measured commit-path cost

The fix adds one `F_SET` inside an already-held critical section, on the
SSI-only path (`F_ISSET(txn, TXN_SNAPSHOT_SAFE)`); non-SSI commits execute
identical code. `test/bench/ssi_abort_bench`, A/B against master built the same
way (`-O2`), alternating runs:

| config | master | this branch |
|---|---|---|
| 8 threads, hot=4096, 3s (n=7) | median 2532 txn/s | median 2356 txn/s |
| 8 threads, hot=16, 3s (n=6) | median 2081 txn/s, abort 12.3–12.8% | median 2493 txn/s, abort 12.3–13.0% |
| 4 threads, hot=4096, 10s (n=5) | median 1164 txn/s | median 1290 txn/s |

**Honest reading: this bench cannot resolve the cost.** Run-to-run spread within
one config is ±2x (e.g. master alone ranged 1534–3066 txn/s at hot=4096), which
swamps any effect of a single store; the fix is ahead in two of three configs
and behind in one, which is noise, not signal. What *is* structural: the
critical section is not widened by any lock acquisition, loop or I/O — one bit
set on a word the same line already read — and the SSI abort rate is unchanged
(12.3–13.0% both sides at hot=16), so the fix is not converting benign
schedules into aborts at scale. It only aborts the writer in the specific
commit-window schedule that previously produced a non-serializable history.

## Docs

- `rfc/0003-ssi-serializable-snapshot-isolation.md` — removed the #136 bullet
  from **Known limitations** (retitled to #137–#140; the other items are left
  intact) and documented the delivered mechanism in **Design**.
- `docs_src/api/c/txnbegin.md` — removed the #136 half of the
  `DB_TXN_SNAPSHOT` known-limitation caveat, including the different-pages
  claim; the #137/#138 mutex-exhaustion caveat stays.
- `test/isolation/README.md` — expectation table, exit-status section.

Fixes #136

---
*Supersedes #150, which was opened from a pre-rebase base. That branch is 3 commits stale and merging it would have deleted the 14 coverage-driver files added in #147 (-5304 lines); this branch is the same change rebased onto current master.*