### PR TITLE
fix(dbreg): don't hand a half-opened DB handle to recovery

### DIFF
--- a/src/dbreg/dbreg_util.c
+++ b/src/dbreg/dbreg_util.c
@@ -433,7 +433,24 @@ __dbreg_id_to_db(env, txn, dbpp, ndx, tryopen)
 			return (ret);
 
 		*dbpp = dblp->dbentry[ndx].dbp;
-		return (*dbpp == NULL ? DB_DELETED : 0);
+		if (*dbpp == NULL)
+			return (DB_DELETED);
+		/*
+		 * __dbreg_do_open() registers the handle with __dbreg_assign_id()
+		 * before the open is finished, so a failure after that point (an
+		 * allocation failure, say) leaves a handle in the entry whose
+		 * __db_open() never completed: its mpf is set but names an mpool
+		 * file that was never validly attached.  Reporting success here
+		 * handed that half-built handle to the caller, and REC_INTRO's
+		 * __db_cursor()/MULTIVERSION() dereferenced it -- a SIGSEGV while
+		 * undoing a transaction at env close.  Treat it as not openable;
+		 * every REC_INTRO caller already propagates the error.
+		 */
+		if (!F_ISSET(*dbpp, DB_AM_OPEN_CALLED)) {
+			*dbpp = NULL;
+			return (ENOENT);
+		}
+		return (0);
 	}
 
 	/*
@@ -447,7 +464,11 @@ __dbreg_id_to_db(env, txn, dbpp, ndx, tryopen)
 	/* It's an error if we don't have a corresponding writable DB. */
 	if ((*dbpp = dblp->dbentry[ndx].dbp) == NULL)
 		ret = ENOENT;
-	else
+	else if (!F_ISSET(*dbpp, DB_AM_OPEN_CALLED)) {
+		/* See the comment on the tryopen path above. */
+		*dbpp = NULL;
+		ret = ENOENT;
+	} else
 		/*
 		 * If we are in recovery, then set that the file has
 		 * been written.  It is possible to run recovery,


### PR DESCRIPTION
Fixes the long-standing OOM-during-recovery crash tracked in the agent notes as `oom-recovery-bug-A`. It reproduced on demand and is now covered by the existing fault-injection sweep.

```
ASAN_OPTIONS=abort_on_error=1 DB_FI_FAIL_AT=490 ./fi_sweep --one

SUMMARY: AddressSanitizer: SEGV os_atomic.c:174 in __os_atomic_read
  #1 __db_cursor            db_iface.c:370
  #2 __ham_insdel_recover   hash_rec.c:84     <- REC_INTRO
  #5 __txn_undo             txn.c:2058
  #7 __txn_env_refresh      txn_region.c:252  <- env close
```

## Root cause
`__dbreg_do_open()` registers the handle with `__dbreg_assign_id()` **before the open has finished**, so a failure after that point leaves an entry in `dblp->dbentry[]` whose `__db_open()` never completed: `DB_AM_OPEN_CALLED` is clear and `dbp->mpf` names an mpool file that was never validly attached. `__dbreg_id_to_db()` returned that handle with `ret == 0`.

Instrumenting both paths showed it plainly — the fast path returns a good handle four times, then the reopen path returns the bad one:

```
[DBG] fast   ndx=1 dbp=0x7daff67e0e80 mpf=0x7d1ff67e0640 open=1   (x4)
[DBG] reopen ndx=1 dbp=0x7daff67e1c80 mpf=0x7d1ff67e0c40 open=0
```

`0x7daff67e1c80` is exactly the pointer in the crash registers (`r15`), and `open=0` is the tell. `REC_INTRO` then calls `__db_cursor()` on it — *before* its own `mpf = file_dbp->mpf` line — and `MULTIVERSION()` dereferences the garbage.

## Fix
Both paths in `__dbreg_id_to_db()` now treat a handle without `DB_AM_OPEN_CALLED` as `ENOENT` and clear `*dbpp`, so the caller gets an error instead of a bad handle. Every `REC_INTRO` caller already propagates it (`goto out`). **Precedent:** `crdel_rec.c:52` already tests `!F_ISSET(file_dbp, DB_AM_OPEN_CALLED)` for exactly this reason.

Fixed at the source rather than symptom-patched — guarding `MULTIVERSION()` in `__db_cursor` only moves the crash to `__memp_fget(mpf=garbage)` on the next line (confirmed in the original diagnosis).

## Validation
Full ASan sweep, **all 947 failure points**:

| | before | after |
|---|---|---|
| K=490 | **SEGV** | clean error return |
| CRASH | 1 | **0** |
| HANG | 0 | **0** |
| DIRTY teardown | 0 | **0** |
| clean/tolerated | — | 81 |
| clean error return | — | 866 |

`fi: RESULT: PASS -- every failure point returned cleanly, held no lock, tore down cleanly.`

Teeth verified by reverting: K=490 SIGSEGVs again.

No regression: 6/6 `test/db` runners (including `run_recd_compact` and `run_recd_handlers`, which exercise recovery dispatch), `test/isolation`, `test/lockmatrix`, fuzz 9/9.