### PR TITLE
fix(qam): bound queue extent verification by the extents, not the main file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,8 @@ jobs:
         run: |
           set -e
           for r in run_hash_unsorted_cmp run_recd_compact run_recd_handlers run_upgrade \
-                   run_lock_priority_nullderef run_null_method_slots; do
+                   run_lock_priority_nullderef run_null_method_slots \
+                   run_qam_extent_vrfy; do
             echo "::group::$r"
             bash "../test/db/$r.sh"
             echo "::endgroup::"

--- a/src/dbinc_auto/int_def.in
+++ b/src/dbinc_auto/int_def.in
@@ -1916,6 +1916,7 @@
 #define	__qam_mswap __qam_mswap@DB_VERSION_UNIQUE_NAME@
 #define	__qam_pgin_out __qam_pgin_out@DB_VERSION_UNIQUE_NAME@
 #define	__qam_fprobe __qam_fprobe@DB_VERSION_UNIQUE_NAME@
+#define	__qam_extent_maxpage __qam_extent_maxpage@DB_VERSION_UNIQUE_NAME@
 #define	__qam_fclose __qam_fclose@DB_VERSION_UNIQUE_NAME@
 #define	__qam_fremove __qam_fremove@DB_VERSION_UNIQUE_NAME@
 #define	__qam_sync __qam_sync@DB_VERSION_UNIQUE_NAME@

--- a/src/dbinc_auto/qam_ext.h
+++ b/src/dbinc_auto/qam_ext.h
@@ -23,6 +23,7 @@ int __qam_init_print __P((ENV *, DB_DISTAB *));
 int __qam_mswap __P((ENV *, PAGE *));
 int __qam_pgin_out __P((ENV *, db_pgno_t, void *, DBT *));
 int __qam_fprobe __P((DBC *, db_pgno_t, void *, qam_probe_mode, DB_CACHE_PRIORITY, u_int32_t));
+int __qam_extent_maxpage __P((DB *, db_pgno_t *));
 int __qam_fclose __P((DB *, db_pgno_t));
 int __qam_fremove __P((DB *, db_pgno_t));
 int __qam_sync __P((DB *));

--- a/src/qam/qam_files.c
+++ b/src/qam/qam_files.c
@@ -332,6 +332,99 @@ err:
 }
 
 /*
+ * __qam_extent_maxpage --
+ *	Find the highest page number that any extent file present on disk can
+ *	hold.
+ *
+ * A queue's meta page records first_recno/cur_recno, and the page numbers
+ * derived from them are trusted from the file.  For a queue with extents the
+ * main .db file holds only the meta page -- every data page lives in a separate
+ * __dbq.<name>.<extid> file -- so the main file's size says nothing at all about
+ * which pages may exist.  The only on-disk evidence of the queue's true extent
+ * is which extent files are actually there, so read the directory once and take
+ * the largest id.
+ *
+ * A missing extent is NOT an error: consuming from a queue unlinks extents and
+ * legitimately leaves holes.  This gives a bound on where the queue *ends*, not
+ * a claim that everything below it is present.
+ *
+ * *maxpagep is set to PGNO_INVALID when no extent file exists at all, which is
+ * a legitimate state (a newly created or fully consumed queue).
+ *
+ * PUBLIC: int __qam_extent_maxpage __P((DB *, db_pgno_t *));
+ */
+int
+__qam_extent_maxpage(dbp, maxpagep)
+	DB *dbp;
+	db_pgno_t *maxpagep;
+{
+	ENV *env;
+	QUEUE *qp;
+	size_t len;
+	u_long extid, maxextid;
+	int cnt, i, found, ret;
+	char *buf, *dirbuf, **names;
+
+	env = dbp->env;
+	qp = (QUEUE *)dbp->q_internal;
+	buf = dirbuf = NULL;
+	names = NULL;
+	cnt = 0;
+	found = 0;
+	maxextid = 0;
+	*maxpagep = PGNO_INVALID;
+
+	/* No extents configured, or nothing to look at: nothing to bound. */
+	if (qp->page_ext == 0 || qp->name == NULL ||
+	    F_ISSET(dbp, DB_AM_INMEM))
+		return (0);
+
+	if ((ret = __db_appname(env,
+	    DB_APP_DATA, qp->dir, NULL, &dirbuf)) != 0)
+		return (ret);
+	if ((ret = __os_dirlist(env, dirbuf, 0, &names, &cnt)) != 0)
+		goto err;
+
+	/* Build the "__dbq.<name>." prefix that this queue's extents share. */
+	len = strlen(QUEUE_EXTENT_HEAD) + strlen(qp->name) + 1;
+	if ((ret = __os_malloc(env, len, &buf)) != 0)
+		goto err;
+	len = (size_t)snprintf(buf, len, QUEUE_EXTENT_HEAD, qp->name);
+
+	for (i = 0; i < cnt; i++) {
+		if (strncmp(names[i], buf, len) != 0)
+			continue;
+		extid = strtoul(&names[i][len], NULL, 10);
+		if (!found || extid > maxextid) {
+			maxextid = extid;
+			found = 1;
+		}
+	}
+
+	/*
+	 * Pages in extent e are e*page_ext+1 .. (e+1)*page_ext, since
+	 * QAM_PAGE_EXTENT() is (pgno - 1) / page_ext.  Saturate rather than
+	 * wrap: a bogus extent file name can be any 32-bit value, and a bound
+	 * that overflowed to a small number would reject real pages.
+	 */
+	if (found) {
+		if (maxextid >= (u_long)(PGNO_INVALID - 1) / qp->page_ext)
+			*maxpagep = (db_pgno_t)PGNO_INVALID - 1;
+		else
+			*maxpagep =
+			    (db_pgno_t)((maxextid + 1) * qp->page_ext);
+	}
+
+err:	if (names != NULL)
+		__os_dirfree(env, names, cnt);
+	if (buf != NULL)
+		__os_free(env, buf);
+	if (dirbuf != NULL)
+		__os_free(env, dirbuf);
+	return (ret);
+}
+
+/*
  * __qam_fclose -- close an extent.
  *
  * Calculate which extent the page is in and close it.

--- a/src/qam/qam_verify.c
+++ b/src/qam/qam_verify.c
@@ -439,7 +439,7 @@ __qam_vrfy_walkqueue(dbp, vdp, handle, callback, flags)
 	PAGE *h;
 	QUEUE *qp;
 	VRFY_PAGEINFO *pip;
-	db_pgno_t first, i, last, pg_ext, stop;
+	db_pgno_t first, i, last, maxpage, pg_ext, stop;
 	int isbad, nextents, ret, t_ret;
 
 	COMPQUIET(h, NULL);
@@ -467,27 +467,33 @@ __qam_vrfy_walkqueue(dbp, vdp, handle, callback, flags)
 	/*
 	 * A wrapped queue (first > last) sets `stop` to the page holding recno
 	 * UINT32_MAX -- for a small rec_page that is billions of pages, far
-	 * more than the file can hold.  The loop below steps one page at a time
+	 * more than any queue can hold.  The loop below steps one page at a time
 	 * (it only skips ahead by an extent when a page is missing), so a
 	 * corrupt or hostile queue meta page turns verification into a
 	 * multi-billion-iteration scan: a denial of service.  It is a bounded
 	 * one -- the scan terminates and corrupts nothing -- but it can occupy
 	 * a verify for hours.
 	 *
-	 * No page past the end of the file can belong to the queue, so clamp to
-	 * the real last page.  vdp->last_pgno is set from
-	 * __memp_get_last_pgno() in __db_verify_arg(), i.e. the actual file
-	 * size, and is what IS_VALID_PGNO() already tests against.  A
-	 * legitimate large or wrapped queue cannot be rejected by this: its
-	 * pages exist, so they are <= last_pgno.  Extent pages live in separate
-	 * files and are reached through __qam_fget() below, not by this bound.
+	 * Bound the scan by what the extent files on disk can actually hold.
+	 * Note this must NOT be bounded by vdp->last_pgno: that is the last page
+	 * of the main .db file, and a queue with extents keeps only its meta
+	 * page there (every data page lives in a separate __dbq.<name>.<id>
+	 * file), so last_pgno is 0 and clamping to it skips this loop entirely,
+	 * silently verifying nothing.  __qam_extent_maxpage() reads the data
+	 * directory instead and returns the last page of the highest-numbered
+	 * extent present.
 	 *
-	 * Note the sibling scan in __qam_vrfy_meta() needs no such clamp: it
-	 * returns early unless last_recno > first_recno, and QAM_RECNO_PAGE()
-	 * is monotonic in recno, so its own `first > last` branch is dead code.
+	 * A legitimate queue cannot be truncated by this bound: its pages live
+	 * in extents that exist, so they are <= maxpage.  A missing extent stays
+	 * non-fatal -- consuming unlinks extents and leaves holes, and the
+	 * ENOENT path below still skips ahead rather than failing.  When no
+	 * extent file exists at all (maxpage == PGNO_INVALID) there is nothing
+	 * to walk, so the queue's own first/last remain the only bound.
 	 */
-	if (stop > vdp->last_pgno)
-		stop = vdp->last_pgno;
+	if ((ret = __qam_extent_maxpage(dbp, &maxpage)) != 0)
+		return (ret);
+	if (maxpage != PGNO_INVALID && stop > maxpage)
+		stop = maxpage;
 	nextents = vdp->nextents;
 
 	/* Verify/salvage each page. */

--- a/test/db/qam_extent_vrfy.c
+++ b/test/db/qam_extent_vrfy.c
@@ -1,0 +1,238 @@
+/*-
+ * Regression test for the queue extent verification bound.
+ *
+ * PR #160 bounded __qam_vrfy_walkqueue()'s scan with
+ *	if (stop > vdp->last_pgno) stop = vdp->last_pgno;
+ * which looks obviously safe but is not: vdp->last_pgno comes from
+ * __memp_get_last_pgno() on the MAIN .db file, and a queue with extents keeps
+ * only its meta page there -- every data page lives in a separate
+ * __dbq.<name>.<extid> file.  So last_pgno was 0, the bound collapsed to 0, and
+ * the extent walk was skipped entirely: db_verify reported success on a queue
+ * with a corrupted extent page.  That shipped in 5.3.35.
+ *
+ * The bug survived review because the only things checked were "legitimate
+ * queues still verify OK" and "the DoS input finishes fast" -- and a verifier
+ * that silently does nothing satisfies BOTH.  So this test asserts both
+ * directions:
+ *
+ *	1. A legitimate many-extent queue verifies CLEAN (no false positive:
+ *	   the bound must not reject real extent pages).
+ *	2. The same queue with ONE corrupted extent page is DETECTED (the walk
+ *	   is actually running).
+ *
+ * Case 2 is the one that fails if the bound ever degenerates again.
+ */
+#include <sys/types.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <db.h>
+
+#define	DBNAME		"qext.db"
+#define	NRECS		20000
+#define	RECLEN		32
+#define	PAGESZ		512
+#define	EXTENTSZ	2
+
+static int failures = 0;
+static int checks = 0;
+
+#define	CHECK(cond, ...) do {						\
+	checks++;							\
+	if (!(cond)) {							\
+		failures++;						\
+		printf("  FAIL: ");					\
+		printf(__VA_ARGS__);					\
+		printf("\n");						\
+	}								\
+} while (0)
+
+/*
+ * build_queue --
+ *	Build a queue with tiny extents and a small page size, so the data
+ *	lands in many separate extent files and the main .db holds only its
+ *	meta page -- the shape that made the 5.3.35 bound degenerate.
+ */
+static int
+build_queue(const char *path)
+{
+	DB *dbp;
+	DBT key, data;
+	db_recno_t recno;
+	char buf[RECLEN];
+	int i, ret;
+
+	if ((ret = db_create(&dbp, NULL, 0)) != 0) {
+		fprintf(stderr, "db_create: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	(void)dbp->set_re_len(dbp, RECLEN);
+	(void)dbp->set_q_extentsize(dbp, EXTENTSZ);
+	(void)dbp->set_pagesize(dbp, PAGESZ);
+
+	if ((ret = dbp->open(dbp,
+	    NULL, path, NULL, DB_QUEUE, DB_CREATE, 0600)) != 0) {
+		fprintf(stderr, "open %s: %s\n", path, db_strerror(ret));
+		return (ret);
+	}
+
+	memset(&key, 0, sizeof(key));
+	memset(&data, 0, sizeof(data));
+	data.data = buf;
+	data.size = RECLEN;
+
+	for (i = 0; i < NRECS; i++) {
+		(void)snprintf(buf, sizeof(buf), "record-%08d", i);
+		key.data = &recno;
+		key.ulen = sizeof(recno);
+		key.flags = DB_DBT_USERMEM;
+		if ((ret = dbp->put(dbp, NULL, &key, &data, DB_APPEND)) != 0) {
+			fprintf(stderr, "put %d: %s\n", i, db_strerror(ret));
+			(void)dbp->close(dbp, 0);
+			return (ret);
+		}
+	}
+	if ((ret = dbp->close(dbp, 0)) != 0) {
+		fprintf(stderr, "close: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	return (0);
+}
+
+/*
+ * count_extents --
+ *	How many __dbq.<name>.<id> files exist, and the name of the first.
+ */
+static int
+count_extents(char *firstp, size_t firstlen)
+{
+	FILE *fp;
+	char line[512];
+	int n;
+
+	n = 0;
+	*firstp = '\0';
+	/*
+	 * The extent files sit alongside the database in the current
+	 * directory; listing them with the shell keeps this test free of
+	 * platform directory-reading differences.
+	 */
+	if ((fp = popen("ls __dbq." DBNAME ".* 2>/dev/null", "r")) == NULL)
+		return (0);
+	while (fgets(line, (int)sizeof(line), fp) != NULL) {
+		line[strcspn(line, "\r\n")] = '\0';
+		if (line[0] == '\0')
+			continue;
+		if (n == 0)
+			(void)snprintf(firstp, firstlen, "%s", line);
+		n++;
+	}
+	(void)pclose(fp);
+	return (n);
+}
+
+/*
+ * corrupt_extent_page --
+ *	Set the page-type byte of the first page of an extent file to an
+ *	invalid value.  Offset 25 is the type field of a Berkeley DB page.
+ */
+static int
+corrupt_extent_page(const char *path)
+{
+	FILE *fp;
+	unsigned char bad;
+
+	if ((fp = fopen(path, "r+b")) == NULL) {
+		fprintf(stderr, "open %s for corruption failed\n", path);
+		return (1);
+	}
+	if (fseek(fp, 25L, SEEK_SET) != 0) {
+		(void)fclose(fp);
+		return (1);
+	}
+	bad = 255;
+	if (fwrite(&bad, 1, 1, fp) != 1) {
+		(void)fclose(fp);
+		return (1);
+	}
+	(void)fclose(fp);
+	return (0);
+}
+
+/*
+ * verify_db --
+ *	DB->verify() consumes the handle on both success and failure.
+ */
+static int
+verify_db(const char *path)
+{
+	DB *dbp;
+	int ret;
+
+	if ((ret = db_create(&dbp, NULL, 0)) != 0) {
+		fprintf(stderr, "db_create: %s\n", db_strerror(ret));
+		return (ret);
+	}
+	/* The corruption diagnostics in case 2 are expected; stay quiet. */
+	dbp->set_errfile(dbp, NULL);
+	return (dbp->verify(dbp, path, NULL, NULL, 0));
+}
+
+int
+main(int argc, char *argv[])
+{
+	char first[512];
+	int nextents, ret;
+
+	(void)argc; (void)argv;
+
+	/*
+	 * Start from a clean slate.  This test writes the database and its
+	 * extent files into the current directory, and a previous run leaves a
+	 * deliberately corrupted extent behind -- reusing it would make case 1
+	 * fail for the wrong reason.  The runner only clears $HOME_DIR/*.db, so
+	 * do the extents here.
+	 */
+	(void)system("rm -f " DBNAME " __dbq." DBNAME ".* 2>/dev/null");
+
+	if (build_queue(DBNAME) != 0)
+		return (EXIT_FAILURE);
+
+	nextents = count_extents(first, sizeof(first));
+	printf("  built %s: %d records, %d extent file(s)\n",
+	    DBNAME, NRECS, nextents);
+	CHECK(nextents > 1,
+	    "expected many extent files, got %d -- this test needs the "
+	    "multi-extent shape to be meaningful", nextents);
+	if (nextents < 1) {
+		printf("qam_extent_vrfy: FAIL (no extents built)\n");
+		return (EXIT_FAILURE);
+	}
+
+	/* Case 1: the untouched queue must verify clean. */
+	ret = verify_db(DBNAME);
+	printf("  clean many-extent queue:   ret=%d (%s)\n",
+	    ret, ret == 0 ? "success" : db_strerror(ret));
+	CHECK(ret == 0,
+	    "a legitimate queue with %d extents failed verification (%d) -- "
+	    "the extent bound is too tight", nextents, ret);
+
+	/* Case 2: one corrupted extent page must be DETECTED. */
+	if (corrupt_extent_page(first) != 0) {
+		printf("qam_extent_vrfy: FAIL (could not corrupt %s)\n", first);
+		return (EXIT_FAILURE);
+	}
+	printf("  corrupted %s page type -> 255\n", first);
+
+	ret = verify_db(DBNAME);
+	printf("  corrupted extent page:     ret=%d (%s)\n",
+	    ret, ret == 0 ? "SUCCESS -- NOT DETECTED" : db_strerror(ret));
+	CHECK(ret != 0,
+	    "a corrupted extent page was NOT detected: the extent walk is "
+	    "being skipped, so queue verification is silently doing nothing");
+
+	printf("qam_extent_vrfy: %d checks, %d failures\n", checks, failures);
+	printf("qam_extent_vrfy: %s\n", failures == 0 ? "PASS" : "FAIL");
+	return (failures == 0 ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/test/db/run_qam_extent_vrfy.sh
+++ b/test/db/run_qam_extent_vrfy.sh
@@ -1,0 +1,85 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_qam_extent_vrfy.sh --
+#	Build and run qam_extent_vrfy.c, the regression gate for queue extent
+#	verification.  PR #160 bounded __qam_vrfy_walkqueue()'s scan by
+#	vdp->last_pgno, which is the last page of the MAIN .db file -- but a
+#	queue with extents keeps only its meta page there, so the bound
+#	collapsed to 0 and the extent walk was skipped: db_verify reported
+#	success on a queue with a corrupted extent page (shipped in 5.3.35).
+#
+#	The test asserts BOTH directions, because a verifier that silently does
+#	nothing also passes "legitimate queues still verify OK":
+#	  1. a legitimate many-extent queue verifies clean, and
+#	  2. a corrupted extent page is still DETECTED.
+#
+# Exits non-zero on failure or hang.
+
+set -e
+
+BUILD=${BUILD:-.}
+SRC=${SRC:-../test/db/qam_extent_vrfy.c}
+HOME_DIR=${HOME_DIR:-QAM_EXTENT_VRFY_TESTDIR}
+TIMEOUT=${TIMEOUT:-180}
+
+# Prefer the STATIC library: on macOS the .dylib carries a baked-in install name
+# (/usr/local/BerkeleyDB.5.3/lib/...) which takes precedence over -rpath, so a
+# shared link runs against an uninstalled path and dyld aborts.  Static linking
+# avoids the dynamic loader entirely, which is what the other CI-wired suites
+# (e.g. test/fuzz) already do.  Fall back to the shared library if no static one
+# was built.
+LIB=""
+LIBRPATH=""
+for cand in "$BUILD"/libdb.a "$BUILD"/.libs/libdb-5.3.a "$BUILD"/.libs/libdb-*.a; do
+	if [ -f "$cand" ]; then LIB="$cand"; break; fi
+done
+if [ -z "$LIB" ]; then
+	for cand in "$BUILD"/.libs/libdb-5.3.so "$BUILD"/.libs/libdb-5.3.dylib \
+	    "$BUILD"/.libs/libdb-*.so "$BUILD"/.libs/libdb-*.dylib; do
+		if [ -f "$cand" ]; then LIB="$cand"; break; fi
+	done
+	[ -n "$LIB" ] && LIBRPATH="-Wl,-rpath,$(cd "$BUILD/.libs" && pwd)"
+fi
+[ -n "$LIB" ] || { echo "FAIL: no libdb library (static or shared) found under $BUILD"; exit 1; }
+
+# A static libdb needs its transitive deps named explicitly.
+EXTRALIBS=""
+for l in $(pkg-config --libs liburing 2>/dev/null); do EXTRALIBS="$EXTRALIBS $l"; done
+
+echo "Compiling qam_extent_vrfy against $LIB"
+"${CC:-cc}" -g -O1 ${CFLAGS:-} -I"$BUILD" "$SRC" "$LIB" \
+    -lpthread $LIBRPATH $EXTRALIBS \
+    -o "$BUILD/qam_extent_vrfy"
+
+rm -f "$HOME_DIR"/*.db 2>/dev/null || true
+mkdir -p "$HOME_DIR"
+
+# `timeout` is GNU coreutils: present on Linux, absent on stock macOS (where it
+# is `gtimeout` if coreutils is installed).  Resolve it once; if neither exists,
+# run without a timeout rather than failing with rc=127.
+if command -v timeout >/dev/null 2>&1; then
+	TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+	TIMEOUT_CMD="gtimeout"
+else
+	TIMEOUT_CMD=""
+fi
+run_with_timeout() {
+	if [ -n "$TIMEOUT_CMD" ]; then
+		"$TIMEOUT_CMD" "$@"
+	else
+		shift	# drop the seconds argument
+		"$@"
+	fi
+}
+echo "Running qam_extent_vrfy (timeout ${TIMEOUT}s)"
+if run_with_timeout "$TIMEOUT" "$BUILD/qam_extent_vrfy"; then
+	echo "run_qam_extent_vrfy.sh: PASS"
+	exit 0
+else
+	rc=$?
+	echo "run_qam_extent_vrfy.sh: FAIL (rc=$rc)"
+	exit $rc
+fi


### PR DESCRIPTION
**Fixes a regression I introduced in #160 and shipped in v5.3.35: queue extent verification was silently disabled.**

## The regression
#160 bounded `__qam_vrfy_walkqueue()`'s scan with:

```c
if (stop > vdp->last_pgno)
        stop = vdp->last_pgno;
```

That looks obviously safe. It is not. `vdp->last_pgno` comes from `__memp_get_last_pgno()` on the **main** `.db` file — but a queue with extents keeps only its **meta page** there; every data page lives in a separate `__dbq.<name>.<extid>` file.

Measured on a 20,000-record queue with `set_q_extentsize(2)` and 512-byte pages: **main file 512 bytes (one page), 770 extent files** holding the data. So `last_pgno == 0`, `stop` clamped to 0, and the loop never ran:

```
[DBG] walkqueue first=1 last=1539 stop=1539 last_pgno=0
[DBG] after clamp stop=0 (loop runs NO -- SKIPPED)
BDB5105 Verification of many.db succeeded.        <- on a CORRUPTED database
```

My in-code comment — *"extent pages … are reached through `__qam_fget()` below, not by this bound"* — was flatly wrong. `stop` bounds **exactly** the loop that walks extent pages.

## The fix
New `__qam_extent_maxpage()` reads the data directory and returns the last page of the highest-numbered extent **present**, so the bound derives from the queue's actual on-disk extent rather than from a file that contains no data pages.

- A **missing extent stays non-fatal** — consuming unlinks extents and leaves holes; the existing `ENOENT` path still skips ahead.
- `PGNO_INVALID` (no extent files at all: newly created or fully consumed) leaves the queue's own first/last as the only bound.
- Extent ids parsed from a hostile filename are **saturated**, not allowed to overflow into a small bound.

## Why it shipped — and what the test does about it
I validated #160 by confirming legitimate queues still reported *"Verification succeeded"* (including one with 639 extents) and that the DoS input finished in 0s. **A verifier that silently does nothing satisfies both of those.** Both of my acceptance signals were satisfied by the bug.

So `test/db/qam_extent_vrfy.c` asserts **both directions** on a 770-extent queue:

```
built qext.db: 20000 records, 770 extent file(s)
clean many-extent queue:   ret=0 (success)
corrupted __dbq.qext.db.0 page type -> 255
corrupted extent page:     ret=-30970 (DB_VERIFY_BAD)
qam_extent_vrfy: 3 checks, 0 failures
```

**Proven to have teeth** — restoring the #160 clamp makes it report exactly the shipped bug:

```
corrupted extent page: ret=0 (SUCCESS -- NOT DETECTED)
qam_extent_vrfy: 3 checks, 1 failures
```

## Validation
On a c7i.4xlarge: **7/7** `test/db` runners (run twice, for idempotency — the first version of my test wasn't idempotent because it left a corrupted extent behind), crash-seed gate **9/9, exit 0**.

## Scope
**This does NOT fix #159.** The queue cursor *read* path still stats one extent file per recno, and the `known-slow` seed still hangs (rc=137 at 90s). That's a separate defect needing a read-path bound; #159 stays open. This closes only the verification hole, which is the more serious of the two — a silent verification failure beats a slow one.