### PR TITLE
fix(db_verify): resolve the filename per file, not once (#165)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           set -e
           for r in run_hash_unsorted_cmp run_recd_compact run_recd_handlers run_upgrade \
                    run_lock_priority_nullderef run_null_method_slots \
-                   run_qam_extent_vrfy; do
+                   run_qam_extent_vrfy run_db_verify_multifile; do
             echo "::group::$r"
             bash "../test/db/$r.sh"
             echo "::endgroup::"

--- a/test/db/run_db_verify_multifile.sh
+++ b/test/db/run_db_verify_multifile.sh
@@ -1,0 +1,122 @@
+#!/bin/sh -
+#
+# $Id$
+#
+# run_db_verify_multifile.sh --
+#	Regression gate for issue #165 -- db_verify given several files verified
+#	the FIRST file repeatedly.
+#
+#	util/db_verify.c set fname/dname once from argv[0] before the per-file
+#	loop, and the loop did ++argv without re-reading them, so every
+#	iteration re-verified the first file while the message at the bottom of
+#	the loop printed the current argv[0].  The output looked correct while
+#	the work was wrong: `db_verify good.db corrupt.db` reported BOTH as
+#	succeeded and exited 0.  Present identically in upstream 5.3.28.
+#
+#	Anyone running `db_verify *.db` therefore got a false clean bill of
+#	health for every file after the first -- a silent failure of the one
+#	tool whose entire purpose is detecting corruption.
+#
+#	This asserts both directions, because a checker that reports success on
+#	everything also "passes" a good-files-only test:
+#	  1. all-good files      -> every line succeeded, exit 0
+#	  2. one corrupt in the middle -> that file (and only it) reported
+#	     failed, exit non-zero
+#	  3. the corrupt file first -> still detected (order independence)
+#
+# Exits non-zero on failure or hang.
+
+set -eu
+
+BUILD=${BUILD:-.}
+HOME_DIR=${HOME_DIR:-DB_VERIFY_MULTI_TESTDIR}
+TIMEOUT=${TIMEOUT:-180}
+
+VERIFY="$BUILD/db_verify"
+LOAD="$BUILD/db_load"
+[ -x "$VERIFY" ] || { echo "FAIL: $VERIFY missing"; exit 1; }
+[ -x "$LOAD" ] || { echo "FAIL: $LOAD missing"; exit 1; }
+VERIFY=$(cd "$(dirname "$VERIFY")" && pwd)/$(basename "$VERIFY")
+LOAD=$(cd "$(dirname "$LOAD")" && pwd)/$(basename "$LOAD")
+
+# `timeout` is GNU coreutils: absent on stock macOS (gtimeout with coreutils).
+# If neither exists, run without one rather than failing with rc=127.
+if command -v timeout >/dev/null 2>&1; then
+	TIMEOUT_CMD="timeout"
+elif command -v gtimeout >/dev/null 2>&1; then
+	TIMEOUT_CMD="gtimeout"
+else
+	TIMEOUT_CMD=""
+fi
+run_with_timeout() {
+	if [ -n "$TIMEOUT_CMD" ]; then
+		"$TIMEOUT_CMD" "$@"
+	else
+		shift
+		"$@"
+	fi
+}
+
+PYTHON=${PYTHON:-python3}
+command -v "$PYTHON" >/dev/null 2>&1 || \
+    { echo "FAIL: $PYTHON needed to corrupt a page"; exit 1; }
+
+rm -f "$HOME_DIR"/*.db 2>/dev/null || true
+mkdir -p "$HOME_DIR"
+cd "$HOME_DIR"
+
+fail=0
+note() { echo "  $*"; }
+
+# Three distinct, valid btrees.
+for n in a b c; do
+	printf 'k%s\nv%s\n' "$n" "$n" | "$LOAD" -T -t btree "$n.db" >/dev/null
+done
+note "built a.db b.db c.db"
+
+# --- Case 1: all good.  Every file must be reported, all succeeded.
+out=$(run_with_timeout "$TIMEOUT" "$VERIFY" a.db b.db c.db 2>&1) && rc=0 || rc=$?
+ok=$(printf '%s\n' "$out" | grep -c 'succeeded' || true)
+note "all-good:      exit=$rc succeeded_lines=$ok"
+[ "$rc" -eq 0 ] || { echo "  FAIL: all-good run exited $rc, expected 0"; fail=1; }
+[ "$ok" -eq 3 ] || { echo "  FAIL: expected 3 'succeeded' lines, got $ok"; fail=1; }
+
+# --- Case 2: corrupt the MIDDLE file.  Only it may be reported failed, and the
+# exit status must be non-zero.  Before the fix this printed three 'succeeded'
+# lines and exited 0.
+"$PYTHON" - <<'PY'
+d = bytearray(open("b.db", "rb").read())
+d[25] = 255                     # page type byte -> invalid
+open("b.db", "wb").write(bytes(d))
+PY
+note "corrupted b.db page type -> 255"
+
+out=$(run_with_timeout "$TIMEOUT" "$VERIFY" a.db b.db c.db 2>&1) && rc=0 || rc=$?
+bad=$(printf '%s\n' "$out" | grep -c 'failed' || true)
+note "one-corrupt:   exit=$rc failed_lines=$bad"
+printf '%s\n' "$out" | grep -E 'succeeded|failed' | sed 's/^/    /'
+
+[ "$rc" -ne 0 ] || { echo "  FAIL: a corrupt file was present but db_verify exited 0 -- files after the first are not being verified"; fail=1; }
+printf '%s\n' "$out" | grep -q 'b.db.*failed' || \
+    { echo "  FAIL: b.db is corrupt but was not reported as failed"; fail=1; }
+printf '%s\n' "$out" | grep -q 'a.db.*succeeded' || \
+    { echo "  FAIL: a.db is valid but was not reported as succeeded"; fail=1; }
+printf '%s\n' "$out" | grep -q 'c.db.*succeeded' || \
+    { echo "  FAIL: c.db is valid but was not reported as succeeded -- the last file is being mis-verified"; fail=1; }
+
+# --- Case 3: order independence.  The corrupt file first must still be caught,
+# and the good files after it must still be verified as themselves.
+out=$(run_with_timeout "$TIMEOUT" "$VERIFY" b.db a.db c.db 2>&1) && rc=0 || rc=$?
+note "corrupt-first: exit=$rc"
+[ "$rc" -ne 0 ] || { echo "  FAIL: corrupt-first run exited 0"; fail=1; }
+printf '%s\n' "$out" | grep -q 'a.db.*succeeded' || \
+    { echo "  FAIL: a.db not verified correctly when it follows a corrupt file"; fail=1; }
+printf '%s\n' "$out" | grep -q 'c.db.*succeeded' || \
+    { echo "  FAIL: c.db not verified correctly when it follows a corrupt file"; fail=1; }
+
+if [ "$fail" -eq 0 ]; then
+	echo "run_db_verify_multifile.sh: PASS"
+	exit 0
+fi
+echo "run_db_verify_multifile.sh: FAIL"
+exit 1

--- a/util/db_verify.c
+++ b/util/db_verify.c
@@ -97,14 +97,6 @@ main(argc, argv)
 	if (argc <= 0)
 		return (usage());
 
-	if (mflag) {
-		dname = argv[0];
-		fname = NULL;
-	} else {
-		fname = argv[0];
-		dname = NULL;
-	}
-
 	/* Handle possible interruptions. */
 	__db_util_siginit();
 
@@ -169,6 +161,21 @@ retry:	if ((ret = db_env_create(&dbenv, 0)) != 0) {
 	 * enabled.
 	 */
 	for (; !__db_util_interrupted() && argv[0] != NULL; ++argv) {
+		/*
+		 * Resolve the name for THIS iteration.  These used to be set
+		 * once before the loop, so every file after the first was
+		 * verified as a repeat of the first while the message at the
+		 * bottom of the loop printed the current argv[0] -- the output
+		 * looked right while the work was wrong, and a corrupt second
+		 * file was reported as clean.
+		 */
+		if (mflag) {
+			dname = argv[0];
+			fname = NULL;
+		} else {
+			fname = argv[0];
+			dname = NULL;
+		}
 		if ((ret = db_create(&dbp, dbenv, 0)) != 0) {
 			dbenv->err(dbenv, ret, "%s: db_create", progname);
 			goto err;


### PR DESCRIPTION
Fixes #165. `db_verify` given several files verified the **first file repeatedly**.

`fname`/`dname` were set once from `argv[0]` before the per-file loop, and the loop did `++argv` without re-reading them. The message at the bottom of the loop prints the *current* `argv[0]`, so the output looked correct while the work was wrong.

| | `db_verify a.db b.db c.db` — only `b.db` corrupt |
|---|---|
| **before** | `a.db succeeded` / **`b.db succeeded`** / `c.db succeeded` — **exit 0** |
| **after** | `a.db succeeded` / `b.db` **DB_VERIFY_BAD → failed** / `c.db succeeded` — **exit 1** |

Anyone running `db_verify *.db` got a **false clean bill of health for every file after the first** — a silent failure of the one tool whose entire purpose is detecting corruption. Present identically in upstream 5.3.28.

## The change
The assignment moves inside the loop, keeping the `mflag` branch exactly as it was.

Checked for collateral damage:
- **`-m` output is byte-identical to stock** (compared directly).
- **Single-file runs unchanged**: good → exit 0, corrupt → exit 1.
- `exitval` was *already* set correctly on failure (`ret != 0 → exitval = 1`). The bug was purely that the wrong file was being verified, so the correct status was computed for the wrong input.

## Test
`test/db/run_db_verify_multifile.sh` asserts **three** things, because a checker that reports success on everything would also pass a good-files-only test:

1. all-good → 3 `succeeded` lines, exit 0
2. one corrupt **in the middle** → that file and only it reported failed, non-zero exit
3. the corrupt file placed **first** → still caught, and the good files after it still verified as themselves (order independence)

**Proven to have teeth** — reverting the hoist makes the runner report exactly the shipped bug:

```
BDB5105 Verification of b.db succeeded.
FAIL: a corrupt file was present but db_verify exited 0 -- files after the first are not being verified
FAIL: b.db is corrupt but was not reported as failed
```

## Validation
**8/8** `test/db` runners pass; `actionlint` clean for the new CI entry.