### PR TITLE
test(fuzz): raise the per-seed timeout for instrumented builds

### DIFF
--- a/test/fuzz/check-crashes.sh
+++ b/test/fuzz/check-crashes.sh
@@ -78,7 +78,17 @@ found=0
 # these harnesses process one small file and finish in well under a second, so a
 # seed still running after SEED_TIMEOUT seconds has found a runaway scan.  Use
 # gtimeout on macOS, and if neither exists run unbounded rather than skip.
-SEED_TIMEOUT=${SEED_TIMEOUT:-30}
+# Per-seed ceiling.  These harnesses process one small file, so a seed still
+# running after this has found a runaway scan rather than merely slow work.
+#
+# 30s was too tight once dbfile_dos_qam_extent_scan.seed became a gated seed:
+# that input is a queue meta page claiming a wrapped near-UINT32_MAX range, and
+# even correctly bounded (#159) the walk does real work over the pages the meta
+# page legitimately describes -- measured 16s in a plain build but 74-120s under
+# the ASan library this gate builds by default, a ~5-7x instrumentation cost.
+# 240s keeps a genuine runaway (minutes to hours) clearly distinguishable while
+# not failing on instrumentation overhead.
+SEED_TIMEOUT=${SEED_TIMEOUT:-240}
 if command -v timeout >/dev/null 2>&1; then
 	TIMEOUT_CMD="timeout"
 elif command -v gtimeout >/dev/null 2>&1; then


### PR DESCRIPTION
The 30s per-seed ceiling became too tight once `dbfile_dos_qam_extent_scan.seed` became a **gated** seed in #168. That input is a queue meta page claiming a wrapped near-`UINT32_MAX` range; even correctly bounded, the walk does real work over the pages the meta page legitimately describes.

Measured on the same machine:

| Build | Seed time | 30s gate |
|---|---|---|
| plain (`LIBDB_ASAN=0`) | **16s** | passed 10/10 |
| ASan (the gate's default) | **74–120s** over three runs | **FAILED** |

So the failure was **instrumentation cost (~5–7×), not a runaway scan** — the seed exits `rc=0` either way. gdb confirmed the residual time is `memset` on newly created extent pages inside `__qam_fprobe`; that path carries `DB_MPOOL_CREATE`, which the #159 bound deliberately does not restrict (a writer legitimately extends past every existing extent). No filesystem probing remains.

240s keeps a genuine runaway — minutes to hours before #159 — clearly distinguishable, while not failing on ASan overhead. The reasoning is recorded in the script so the number isn't cargo-culted later.

Verified: ASan gate **10/10, exit 0**.

Found while qualifying 5.3.36 from a pristine clone, which is exactly what that step is for.
