### PR TITLE
test(qam): make the read-path DoS limit robust to machine load

### DIFF
--- a/test/db/qam_readpath_bound.c
+++ b/test/db/qam_readpath_bound.c
@@ -37,11 +37,17 @@
 #define	PAGESZ		512
 #define	EXTENTSZ	2
 /*
- * The hostile walk must finish well inside this.  Before the fix it ran for
- * minutes and was killed; a correct bound returns essentially immediately, so
- * a generous ceiling still separates the two cleanly.
+ * Ceiling for the hostile walk.  The point is to separate BOUNDED from RUNAWAY,
+ * not to track machine speed: unbounded this ran for minutes to hours, while a
+ * correctly bounded walk is tens of seconds.
+ *
+ * Measured on one machine: 25-27s idle, but 66s while a parallel build was
+ * running, and 74-120s under an ASan-instrumented library.  A 60s limit failed
+ * on load alone, so the ceiling is generous by design -- a real regression
+ * reverts to unbounded and blows past any of these numbers.  Override with
+ * QAM_DOS_LIMIT_SECS on very slow or heavily instrumented builds.
  */
-#define	DOS_LIMIT_SECS	60
+#define	DOS_LIMIT_SECS	600
 
 static int failures = 0;
 static int checks = 0;
@@ -190,6 +196,8 @@ main(int argc, char *argv[])
 	time_t start;
 	double elapsed;
 	long got;
+	int limit;
+	char *lp;
 
 	(void)argc; (void)argv;
 
@@ -228,16 +236,20 @@ main(int argc, char *argv[])
 	}
 	printf("  rewrote meta: first_recno=4000000000 cur_recno=10 (wrapped)\n");
 
+	limit = DOS_LIMIT_SECS;
+	if ((lp = getenv("QAM_DOS_LIMIT_SECS")) != NULL && atoi(lp) > 0)
+		limit = atoi(lp);
+
 	start = time(NULL);
 	dbp = open_queue(DBNAME, 0);
 	(void)walk_all(dbp);
 	(void)dbp->close(dbp, 0);
 	elapsed = difftime(time(NULL), start);
 	printf("  hostile meta page: walk finished in %.0f seconds\n", elapsed);
-	CHECK(elapsed < DOS_LIMIT_SECS,
+	CHECK(elapsed < limit,
 	    "a walk over a hostile wrapped meta page took %.0f seconds "
 	    "(limit %d) -- the read path is still probing one extent per recno",
-	    elapsed, DOS_LIMIT_SECS);
+	    elapsed, limit);
 
 	printf("qam_readpath_bound: %d checks, %d failures\n", checks, failures);
 	printf("qam_readpath_bound: %s\n", failures == 0 ? "PASS" : "FAIL");


### PR DESCRIPTION
`DOS_LIMIT_SECS` was 60, set from a single measurement, and it **failed while qualifying 5.3.36 from a pristine clone** — exactly what that step is for.

| Condition | Bounded walk |
|---|---|
| idle machine | **25–27s** |
| parallel meson build running | **66s** (failed the 60s limit) |
| ASan-instrumented library | **74–120s** |

The check exists to separate **bounded** from **runaway**, not to track machine speed: unbounded, this walk ran for minutes to hours. So the ceiling is now **600s** and deliberately generous, with the measurements recorded beside it so the number isn't re-tightened by guess. `QAM_DOS_LIMIT_SECS` overrides it for very slow or heavily instrumented builds.

**Teeth re-verified after loosening**: with the bound removed the runner still FAILS (rc=124, killed by the runner's own 180s timeout), so a real regression is still caught. A generous ceiling costs nothing here because the failure mode isn't "slightly slow", it's "does not finish".

This is the second threshold I set too tightly from one sample this session (the other was the fuzz gate's `SEED_TIMEOUT`, #169). Both are now documented with their measurement spread.
