### PR TITLE
ci(coverage): check the function= baseline, not just line and branch

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -62,8 +62,16 @@ jobs:
                | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
           ln=$(grep -E 'lines' build_unix/coverage-summary.txt \
                | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
+          # FUNCTION coverage is the metric with a reachable target: >85% needs
+          # ~+180 functions, whereas >85% BRANCH would need +27k -- 70% of every
+          # branch currently missing, because ~1662 `if ((ret = f()) != 0)` OOM
+          # legs are reachable only one-per-fault-injection-run.  See
+          # test/coverage/FULL-COVERAGE-REPORT-4.md.
+          fn=$(grep -E 'functions' build_unix/coverage-summary.txt \
+               | grep -oE '[0-9]+\.[0-9]+%' | head -1 | tr -d '%')
           echo "branch=$br" >> "$GITHUB_OUTPUT"
           echo "line=$ln" >> "$GITHUB_OUTPUT"
+          echo "function=$fn" >> "$GITHUB_OUTPUT"
 
       - name: Ratchet (advisory) -- warn if branch coverage dropped
         run: |
@@ -73,7 +81,9 @@ jobs:
           if [ -f "$base_file" ]; then
             base_br=$(grep -E '^branch=' "$base_file" | cut -d= -f2)
             base_ln=$(grep -E '^line=' "$base_file" | cut -d= -f2)
-            echo "baseline: line=${base_ln}% branch=${base_br}%  now: line=${ln}% branch=${br}%"
+            base_fn=$(grep -E '^function=' "$base_file" | cut -d= -f2)
+            echo "baseline: line=${base_ln}% branch=${base_br}% function=${base_fn:-n/a}"
+            echo "now:      line=${ln}% branch=${br}% function=${fn}"
             # bc may be absent; use awk for the float compare.
             drop=$(awk -v a="$br" -v b="$base_br" 'BEGIN{print (a+0 < b-0.5) ? 1 : 0}')
             if [ "$drop" = "1" ]; then
@@ -81,10 +91,20 @@ jobs:
             else
               echo "::notice title=Coverage ratchet::branch coverage ${br}% >= baseline ${base_br}% (ok)"
             fi
+            # Same advisory treatment for function coverage, the metric we
+            # actually track toward 85%.  Skipped when the baseline predates it.
+            if [ -n "${base_fn:-}" ]; then
+              fdrop=$(awk -v a="$fn" -v b="$base_fn" 'BEGIN{print (a+0 < b-0.5) ? 1 : 0}')
+              if [ "$fdrop" = "1" ]; then
+                echo "::warning title=Coverage ratchet::function coverage dropped ${base_fn}% -> ${fn}% (advisory)"
+              else
+                echo "::notice title=Coverage ratchet::function coverage ${fn}% >= baseline ${base_fn}% (ok)"
+              fi
+            fi
           else
             echo "::notice title=Coverage ratchet::no baseline file yet; current branch=${br}% line=${ln}%"
           fi
-          echo "To update the committed baseline: put 'line=${ln}' and 'branch=${br}' in $base_file"
+          echo "To update the committed baseline: put 'line=${ln}', 'branch=${br}' and 'function=${fn}' in $base_file"
 
       - name: Upload HTML report
         if: always()


### PR DESCRIPTION
Completes #172. That PR added `function=78.6` to `test/coverage/baseline.txt` and established function coverage as **the metric with a reachable target** — but `coverage.yml` only ever extracted `lines` and `branches`, so the new line was informational and nothing read it. The agent that added it had no `workflow` scope to wire the check.

## Change
Extract function coverage alongside the other two, and give it the same advisory drop warning — guarded on `base_fn` being present so an older baseline still works.

## Why function, not branch
| Target | Gap |
|---|---|
| >85% **function** | ~**+180** functions |
| >85% **branch** | **+27,000** — 70% of every branch currently missing |

The branch target is out of reach because ~1,662 error-return legs of the form `if ((ret = f()) != 0)` are reachable only **one per fault-injection run**. That arithmetic is in `FULL-COVERAGE-REPORT-4.md` and is now restated in the workflow next to the extraction, so the choice isn't re-litigated by guess.

## Verification
The `awk` float compare, exercised in all three directions:

```
78.6 vs 78.6  -> ok
70.0 vs 78.6  -> WARN
82.0 vs 78.6  -> ok
```

`actionlint` reports only the file's **pre-existing** `SC2129` style hint — no new findings.

Advisory, not gating, consistent with how the branch ratchet already behaves.
