### PR TITLE
perf(db): shard per-handle cursor queues — measured, plus a thread-id fix

### DIFF
--- a/build_windows/db.h
+++ b/build_windows/db.h
@@ -61,9 +61,9 @@ extern "C" {
 #define	DB_VERSION_RELEASE	2
 #define	DB_VERSION_MAJOR	5
 #define	DB_VERSION_MINOR	3
-#define	DB_VERSION_PATCH	34
-#define	DB_VERSION_STRING	"Berkeley DB 5.3.34: (August 3, 2026)"
-#define	DB_VERSION_FULL_STRING	"Berkeley DB 11g Release 2, library version 11.2.5.3.34: (August 3, 2026)"
+#define	DB_VERSION_PATCH	36
+#define	DB_VERSION_STRING	"Berkeley DB 5.3.36: (September 9, 2026)"
+#define	DB_VERSION_FULL_STRING	"Berkeley DB 11g Release 2, library version 11.2.5.3.36: (September 9, 2026)"
 
 /*
  * !!!
@@ -1450,6 +1450,15 @@ typedef enum {
 #define	DB_TXN_CKP		(-30888)/* Encountered ckp record in log. */
 #define	DB_VERIFY_FATAL		(-30887)/* DB->verify cannot proceed. */
 
+/*
+ * Number of partitions the per-handle cursor free/active queues are sharded
+ * into.  Must be a power of two so the partition index can be a mask of the
+ * thread id.  A threaded (DB_THREAD) handle allocates this many extra
+ * process-only mutexes; non-threaded handles allocate none (the queues are
+ * accessed without locking, as before).
+ */
+#define	DB_CURSOR_NPART		8
+
 /* Database handle. */
 struct __db {
 	/*******************************************************
@@ -1536,20 +1545,33 @@ struct __db {
 	/*
 	 * Cursor queues.
 	 *
+	 * The free and active cursor queues are sharded into DB_CURSOR_NPART
+	 * partitions, each with its own mutex, so concurrent cursor alloc/free
+	 * on a shared (DB_THREAD) handle does not serialize on a single mutex.
+	 * A cursor records its partition (DBC->part) at allocation so it is
+	 * always returned to the same partition, even when closed by a
+	 * different thread than allocated it.  The join queue is not sharded
+	 * (join cursors are rare and not on the hot path); it stays under
+	 * dbp->mutex.
+	 *
 	 * !!!
 	 * Explicit representations of structures from queue.h.
-	 * TAILQ_HEAD(__cq_fq, __dbc) free_queue;
-	 * TAILQ_HEAD(__cq_aq, __dbc) active_queue;
+	 * Per partition:
+	 *   TAILQ_HEAD(__cq_fq, __dbc) free_queue;
+	 *   TAILQ_HEAD(__cq_aq, __dbc) active_queue;
 	 * TAILQ_HEAD(__cq_jq, __dbc) join_queue;
 	 */
-	struct __cq_fq {
-		struct __dbc *tqh_first;
-		struct __dbc **tqh_last;
-	} free_queue;
-	struct __cq_aq {
-		struct __dbc *tqh_first;
-		struct __dbc **tqh_last;
-	} active_queue;
+	struct __cq_part {
+		db_mutex_t mutex;		/* Partition mutex (or INVALID). */
+		struct __cq_fq {
+			struct __dbc *tqh_first;
+			struct __dbc **tqh_last;
+		} free_queue;
+		struct __cq_aq {
+			struct __dbc *tqh_first;
+			struct __dbc **tqh_last;
+		} active_queue;
+	} cq_parts[DB_CURSOR_NPART];
 	struct __cq_jq {
 		struct __dbc *tqh_first;
 		struct __dbc **tqh_last;
@@ -2055,10 +2077,17 @@ struct __dbc {
 	/*
 	 * Active/free cursor queues.
 	 *
+	 * "part" is the index of the DB handle cursor-queue partition this
+	 * cursor belongs to (DB->cq_parts[part]).  It is assigned when the
+	 * cursor is allocated and never changes, so the cursor is returned to
+	 * the same partition when freed -- even if it is closed by a different
+	 * thread than allocated it.
+	 *
 	 * !!!
 	 * Explicit representations of structures from queue.h.
 	 * TAILQ_ENTRY(__dbc) links;
 	 */
+	u_int32_t part;		/* Cursor-queue partition index. */
 	struct {
 		DBC *tqe_next;
 		DBC **tqe_prev;

--- a/src/db/db.c
+++ b/src/db/db.c
@@ -499,6 +499,23 @@ __env_setup(dbp, txn, fname, dname, id, flags)
 		return (ret);
 
 	/*
+	 * For a threaded handle, allocate the per-partition cursor-queue
+	 * mutexes too, so concurrent cursor alloc/free spreads across
+	 * DB_CURSOR_NPART partitions instead of serializing on dbp->mutex.
+	 * Non-threaded handles leave these MUTEX_INVALID (CQ_LOCK is then a
+	 * no-op, matching the old unlocked single-queue behavior).
+	 */
+	if (LF_ISSET(DB_THREAD)) {
+		u_int32_t cqi;
+
+		for (cqi = 0; cqi < DB_CURSOR_NPART; cqi++)
+			if ((ret = __mutex_alloc(env, MTX_DB_HANDLE,
+			    DB_MUTEX_PROCESS_ONLY,
+			    &dbp->cq_parts[cqi].mutex)) != 0)
+				return (ret);
+	}
+
+	/*
 	 * Set up a bookkeeping entry for this database in the log region,
 	 * if such a region exists.  Note that even if we're in recovery
 	 * or a replication client, where we won't log registries, we'll
@@ -803,7 +820,7 @@ __db_refresh(dbp, txn, flags, deferred_closep, reuse)
 	ENV *env;
 	REGENV *renv;
 	REGINFO *infop;
-	u_int32_t save_flags;
+	u_int32_t cq_i, save_flags;
 	int resync, ret, t_ret;
 
 	ret = 0;
@@ -882,24 +899,34 @@ __db_refresh(dbp, txn, flags, deferred_closep, reuse)
 	 * routine.  Note that any failure on a close is considered "really
 	 * bad" and we just break out of the loop and force forward.
 	 */
-	resync = TAILQ_FIRST(&dbp->active_queue) == NULL ? 0 : 1;
-	while ((dbc = TAILQ_FIRST(&dbp->active_queue)) != NULL) {
-		if (dbc->txn != NULL)
-			TAILQ_REMOVE(&(dbc->txn->my_cursors), dbc, txn_cursors);
-
-		if ((t_ret = __dbc_close(dbc)) != 0) {
-			if (ret == 0)
-				ret = t_ret;
+	resync = 0;
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++)
+		if (TAILQ_FIRST(&dbp->cq_parts[cq_i].active_queue) != NULL) {
+			resync = 1;
 			break;
 		}
-	}
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++)
+		while ((dbc =
+		    TAILQ_FIRST(&dbp->cq_parts[cq_i].active_queue)) != NULL) {
+			if (dbc->txn != NULL)
+				TAILQ_REMOVE(
+				    &(dbc->txn->my_cursors), dbc, txn_cursors);
 
-	while ((dbc = TAILQ_FIRST(&dbp->free_queue)) != NULL)
-		if ((t_ret = __dbc_destroy(dbc)) != 0) {
-			if (ret == 0)
-				ret = t_ret;
-			break;
+			if ((t_ret = __dbc_close(dbc)) != 0) {
+				if (ret == 0)
+					ret = t_ret;
+				break;
+			}
 		}
+
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++)
+		while ((dbc =
+		    TAILQ_FIRST(&dbp->cq_parts[cq_i].free_queue)) != NULL)
+			if ((t_ret = __dbc_destroy(dbc)) != 0) {
+				if (ret == 0)
+					ret = t_ret;
+				break;
+			}
 
 	/*
 	 * Close any outstanding join cursors.  Join cursors destroy themselves
@@ -1158,6 +1185,16 @@ never_opened:
 	if ((t_ret = __mutex_free(env, &dbp->mutex)) != 0 && ret == 0)
 		ret = t_ret;
 
+	/* Discard the per-partition cursor-queue mutexes (if allocated). */
+	{
+		u_int32_t cqi;
+
+		for (cqi = 0; cqi < DB_CURSOR_NPART; cqi++)
+			if ((t_ret = __mutex_free(env,
+			    &dbp->cq_parts[cqi].mutex)) != 0 && ret == 0)
+				ret = t_ret;
+	}
+
 	/* Discard any memory allocated for the file and database names. */
 	if (dbp->fname != NULL) {
 		__os_free(dbp->env, dbp->fname);
@@ -1215,6 +1252,7 @@ __db_disassociate(sdbp)
 	DB *sdbp;
 {
 	DBC *dbc;
+	u_int32_t cq_i;
 	int ret, t_ret;
 
 	ret = 0;
@@ -1229,7 +1267,7 @@ __db_disassociate(sdbp)
 	 * the middle of a close, so there's really no turning back.)
 	 */
 	if (sdbp->s_refcnt != 1 ||
-	    TAILQ_FIRST(&sdbp->active_queue) != NULL ||
+	    __db_cq_active_any(sdbp) ||
 	    TAILQ_FIRST(&sdbp->join_queue) != NULL) {
 		__db_errx(sdbp->env, DB_STR("0674",
 "Closing a primary DB while a secondary DB has active cursors is unsafe"));
@@ -1237,9 +1275,11 @@ __db_disassociate(sdbp)
 	}
 	sdbp->s_refcnt = 0;
 
-	while ((dbc = TAILQ_FIRST(&sdbp->free_queue)) != NULL)
-		if ((t_ret = __dbc_destroy(dbc)) != 0 && ret == 0)
-			ret = t_ret;
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++)
+		while ((dbc =
+		    TAILQ_FIRST(&sdbp->cq_parts[cq_i].free_queue)) != NULL)
+			if ((t_ret = __dbc_destroy(dbc)) != 0 && ret == 0)
+				ret = t_ret;
 
 	F_CLR(sdbp, DB_AM_SECONDARY);
 	return (ret);
@@ -1343,18 +1383,26 @@ __db_log_page(dbp, txn, lsn, pgno, page)
 	for (*countp = 0;
 	    ldbp != NULL && ldbp->adj_fileid == dbp->adj_fileid;
 	    ldbp = TAILQ_NEXT(ldbp, dblistlinks)) {
-loop:		MUTEX_LOCK(env, ldbp->mutex);
-		TAILQ_FOREACH(dbc, &ldbp->active_queue, links)
-			if ((ret = (func)(dbc, my_dbc,
-			    countp, pgno, indx, args)) != 0)
+		u_int32_t cq_i;
+
+		for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++) {
+			struct __cq_part *cqp = &ldbp->cq_parts[cq_i];
+
+loop:			CQ_LOCK(env, cqp);
+			TAILQ_FOREACH(dbc, &cqp->active_queue, links)
+				if ((ret = (func)(dbc, my_dbc,
+				    countp, pgno, indx, args)) != 0)
+					break;
+			/*
+			 * We use the error to communicate that function
+			 * dropped the mutex.
+			 */
+			if (ret == DB_LOCK_NOTGRANTED)
+				goto loop;
+			CQ_UNLOCK(env, cqp);
+			if (ret != 0)
 				break;
-		/*
-		 * We use the error to communicate that function
-		 * dropped the mutex.
-		 */
-		if (ret == DB_LOCK_NOTGRANTED)
-			goto loop;
-		MUTEX_UNLOCK(env, ldbp->mutex);
+		}
 		if (ret != 0)
 			break;
 	}

--- a/src/db/db_am.c
+++ b/src/db/db_am.c
@@ -24,6 +24,26 @@ static int __dbc_set_priority __P((DBC *, DB_CACHE_PRIORITY));
 static int __dbc_get_priority __P((DBC *, DB_CACHE_PRIORITY* ));
 
 /*
+ * __db_cq_active_any --
+ *	Return 1 if any cursor-queue partition of this handle has an active
+ *	cursor, else 0.  Used by the (non-hot) paths that must check for
+ *	open cursors across all partitions.
+ *
+ * PUBLIC: int __db_cq_active_any __P((DB *));
+ */
+int
+__db_cq_active_any(dbp)
+	DB *dbp;
+{
+	u_int32_t i;
+
+	for (i = 0; i < DB_CURSOR_NPART; i++)
+		if (TAILQ_FIRST(&dbp->cq_parts[i].active_queue) != NULL)
+			return (1);
+	return (0);
+}
+
+/*
  * __db_cursor_int --
  *	Internal routine to create a cursor.
  *
@@ -45,12 +65,18 @@ __db_cursor_int(dbp, ip, txn, dbtype, root, flags, locker, dbcp)
 	DBC_INTERNAL *cp;
 	DB_LOCKREQ req;
 	ENV *env;
+	struct __cq_part *cqp;
 	db_threadid_t tid;
+	u_int32_t part;
 	int allocated, envlid, ret;
 	pid_t pid;
 
 	env = dbp->env;
 	allocated = envlid = 0;
+
+	/* Pick this thread's cursor-queue partition. */
+	part = DB_CURSOR_PART_PICK(dbp, ip);
+	cqp = &dbp->cq_parts[part];
 
 	/*
 	 * If dbcp is non-NULL it is assumed to point to an area to initialize
@@ -60,43 +86,44 @@ __db_cursor_int(dbp, ip, txn, dbtype, root, flags, locker, dbcp)
 	 * right type.  With off page dups we may have different kinds
 	 * of cursors on the queue for a single database.
 	 */
-	MUTEX_LOCK(env, dbp->mutex);
-
 #ifndef HAVE_NO_DB_REFCOUNT
 	/*
 	 * If this DBP is being logged then refcount the log filename
-	 * relative to this transaction. We do this here because we have
-	 * the dbp->mutex which protects the refcount.  We want to avoid
-	 * calling the function if the transaction handle has a shared parent
-	 * locker or we are duplicating a cursor.  This includes the case of
-	 * creating an off page duplicate cursor.
-	 * If we knew this cursor will not be used in an update, we could avoid
-	 * this, but we don't have that information.
+	 * relative to this transaction. We do this here under dbp->mutex,
+	 * which protects the refcount (the cursor queues have their own
+	 * per-partition mutexes).  We want to avoid calling the function if
+	 * the transaction handle has a shared parent locker or we are
+	 * duplicating a cursor.  This includes the case of creating an off
+	 * page duplicate cursor.  If we knew this cursor will not be used in
+	 * an update, we could avoid this, but we don't have that information.
 	 */
 	if (IS_REAL_TXN(txn) &&
 	    !LF_ISSET(DBC_OPD | DBC_DUPLICATE) &&
 	    !F_ISSET(dbp, DB_AM_RECOVER) &&
-	    dbp->log_filename != NULL && !IS_REP_CLIENT(env) &&
-	    (ret = __txn_record_fname(env, txn, dbp->log_filename)) != 0) {
+	    dbp->log_filename != NULL && !IS_REP_CLIENT(env)) {
+		MUTEX_LOCK(env, dbp->mutex);
+		ret = __txn_record_fname(env, txn, dbp->log_filename);
 		MUTEX_UNLOCK(env, dbp->mutex);
-		return (ret);
+		if (ret != 0)
+			return (ret);
 	}
-
 #endif
 
-	TAILQ_FOREACH(dbc, &dbp->free_queue, links)
+	CQ_LOCK(env, cqp);
+	TAILQ_FOREACH(dbc, &cqp->free_queue, links)
 		if (dbtype == dbc->dbtype) {
-			TAILQ_REMOVE(&dbp->free_queue, dbc, links);
+			TAILQ_REMOVE(&cqp->free_queue, dbc, links);
 			F_CLR(dbc, ~DBC_OWN_LID);
 			break;
 		}
-	MUTEX_UNLOCK(env, dbp->mutex);
+	CQ_UNLOCK(env, cqp);
 
 	if (dbc == NULL) {
 		if ((ret = __os_calloc(env, 1, sizeof(DBC), &dbc)) != 0)
 			return (ret);
 		allocated = 1;
 		dbc->flags = 0;
+		dbc->part = part;
 
 		dbc->dbp = dbp;
 		dbc->dbenv = dbp->dbenv;
@@ -408,10 +435,10 @@ __db_cursor_int(dbp, ip, txn, dbtype, root, flags, locker, dbcp)
 	else
 		ENV_GET_THREAD_INFO(env, dbc->thread_info);
 
-	MUTEX_LOCK(env, dbp->mutex);
-	TAILQ_INSERT_TAIL(&dbp->active_queue, dbc, links);
+	CQ_LOCK(env, cqp);
+	TAILQ_INSERT_TAIL(&cqp->active_queue, dbc, links);
 	F_SET(dbc, DBC_ACTIVE);
-	MUTEX_UNLOCK(env, dbp->mutex);
+	CQ_UNLOCK(env, cqp);
 
 	*dbcp = dbc;
 	return (0);

--- a/src/db/db_am.c
+++ b/src/db/db_am.c
@@ -24,6 +24,40 @@ static int __dbc_set_priority __P((DBC *, DB_CACHE_PRIORITY));
 static int __dbc_get_priority __P((DBC *, DB_CACHE_PRIORITY* ));
 
 /*
+ * __db_cursor_part --
+ *	Return the cursor-queue partition index for the calling thread.
+ *
+ *	Derived from the thread id (not the process id, and not the optional
+ *	DB_THREAD_INFO block) -- see DB_CURSOR_PART_PICK in db_am.h for why.
+ *
+ * PUBLIC: u_int32_t __db_cursor_part __P((DB *));
+ */
+u_int32_t
+__db_cursor_part(dbp)
+	DB *dbp;
+{
+	db_threadid_t tid;
+	pid_t pid;
+
+	DB_THREADID_INIT(tid);
+	dbp->dbenv->thread_id(dbp->dbenv, &pid, &tid);
+
+#ifdef HAVE_SIMPLE_THREAD_TYPE
+	/*
+	 * A db_threadid_t is a scalar (typically pthread_t, i.e. an address):
+	 * hash it directly.
+	 */
+	return (DB_CURSOR_PART_HASH(tid));
+#else
+	/*
+	 * A db_threadid_t is a struct: fold its bytes first.  __ham_func5 is
+	 * the same hash the thread-info table itself uses for this case.
+	 */
+	return (DB_CURSOR_PART_HASH(__ham_func5(NULL, &tid, sizeof(tid))));
+#endif
+}
+
+/*
  * __db_cq_active_any --
  *	Return 1 if any cursor-queue partition of this handle has an active
  *	cursor, else 0.  Used by the (non-hot) paths that must check for

--- a/src/db/db_cam.c
+++ b/src/db/db_cam.c
@@ -104,18 +104,29 @@ __dbc_close(dbc)
 	 * access specific cursor close routine, btree depends on having that
 	 * order of operations.
 	 */
-	MUTEX_LOCK(env, dbp->mutex);
-
+	/*
+	 * Remove each cursor from its own partition's active queue under that
+	 * partition's mutex.  dbc and opd may live in different partitions, so
+	 * lock each separately rather than relying on a single handle mutex.
+	 */
 	if (opd != NULL) {
-		DB_ASSERT(env, F_ISSET(opd, DBC_ACTIVE));
-		F_CLR(opd, DBC_ACTIVE);
-		TAILQ_REMOVE(&dbp->active_queue, opd, links);
-	}
-	DB_ASSERT(env, F_ISSET(dbc, DBC_ACTIVE));
-	F_CLR(dbc, DBC_ACTIVE);
-	TAILQ_REMOVE(&dbp->active_queue, dbc, links);
+		struct __cq_part *opd_cqp = DB_CURSOR_PART(opd);
 
-	MUTEX_UNLOCK(env, dbp->mutex);
+		DB_ASSERT(env, F_ISSET(opd, DBC_ACTIVE));
+		CQ_LOCK(env, opd_cqp);
+		F_CLR(opd, DBC_ACTIVE);
+		TAILQ_REMOVE(&opd_cqp->active_queue, opd, links);
+		CQ_UNLOCK(env, opd_cqp);
+	}
+	{
+		struct __cq_part *dbc_cqp = DB_CURSOR_PART(dbc);
+
+		DB_ASSERT(env, F_ISSET(dbc, DBC_ACTIVE));
+		CQ_LOCK(env, dbc_cqp);
+		F_CLR(dbc, DBC_ACTIVE);
+		TAILQ_REMOVE(&dbc_cqp->active_queue, dbc, links);
+		CQ_UNLOCK(env, dbc_cqp);
+	}
 
 	/* Call the access specific cursor close routine. */
 	if ((t_ret =
@@ -153,15 +164,23 @@ __dbc_close(dbc)
 	if ((txn = dbc->txn) != NULL)
 		txn->cursors--;
 
-	/* Move the cursor(s) to the free queue. */
-	MUTEX_LOCK(env, dbp->mutex);
+	/* Move the cursor(s) to their partition free queues. */
 	if (opd != NULL) {
+		struct __cq_part *opd_cqp = DB_CURSOR_PART(opd);
+
 		if (txn != NULL)
 			txn->cursors--;
-		TAILQ_INSERT_TAIL(&dbp->free_queue, opd, links);
+		CQ_LOCK(env, opd_cqp);
+		TAILQ_INSERT_TAIL(&opd_cqp->free_queue, opd, links);
+		CQ_UNLOCK(env, opd_cqp);
 	}
-	TAILQ_INSERT_TAIL(&dbp->free_queue, dbc, links);
-	MUTEX_UNLOCK(env, dbp->mutex);
+	{
+		struct __cq_part *dbc_cqp = DB_CURSOR_PART(dbc);
+
+		CQ_LOCK(env, dbc_cqp);
+		TAILQ_INSERT_TAIL(&dbc_cqp->free_queue, dbc, links);
+		CQ_UNLOCK(env, dbc_cqp);
+	}
 
 	if (txn != NULL && F_ISSET(txn, TXN_PRIVATE) && txn->cursors == 0 &&
 	    (t_ret = __txn_commit(txn, 0)) != 0 && ret == 0)
@@ -187,10 +206,14 @@ __dbc_destroy(dbc)
 	dbp = dbc->dbp;
 	env = dbp->env;
 
-	/* Remove the cursor from the free queue. */
-	MUTEX_LOCK(env, dbp->mutex);
-	TAILQ_REMOVE(&dbp->free_queue, dbc, links);
-	MUTEX_UNLOCK(env, dbp->mutex);
+	/* Remove the cursor from its partition's free queue. */
+	{
+		struct __cq_part *cqp = DB_CURSOR_PART(dbc);
+
+		CQ_LOCK(env, cqp);
+		TAILQ_REMOVE(&cqp->free_queue, dbc, links);
+		CQ_UNLOCK(env, cqp);
+	}
 
 	/* Free up allocated memory. */
 	if (dbc->my_rskey.data != NULL)

--- a/src/db/db_iface.c
+++ b/src/db/db_iface.c
@@ -78,6 +78,7 @@ __db_associate_pp(dbp, txn, sdbp, callback, flags)
 	DBC *sdbc;
 	DB_THREAD_INFO *ip;
 	ENV *env;
+	u_int32_t cq_i;
 	int handle_check, ret, t_ret, txn_local;
 
 	env = dbp->env;
@@ -101,7 +102,7 @@ __db_associate_pp(dbp, txn, sdbp, callback, flags)
 	 * to make sure that no older cursors are lying around when we make
 	 * the transition.
 	 */
-	if (TAILQ_FIRST(&sdbp->active_queue) != NULL ||
+	if (__db_cq_active_any(sdbp) ||
 	    TAILQ_FIRST(&sdbp->join_queue) != NULL) {
 		__db_errx(env, DB_STR("0572",
     "Databases may not become secondary indices while cursors are open"));
@@ -127,9 +128,11 @@ __db_associate_pp(dbp, txn, sdbp, callback, flags)
 	if ((ret = __db_check_txn(dbp, txn, DB_LOCK_INVALIDID, 0)) != 0)
 		goto err;
 
-	while ((sdbc = TAILQ_FIRST(&sdbp->free_queue)) != NULL)
-		if ((ret = __dbc_destroy(sdbc)) != 0)
-			goto err;
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++)
+		while ((sdbc =
+		    TAILQ_FIRST(&sdbp->cq_parts[cq_i].free_queue)) != NULL)
+			if ((ret = __dbc_destroy(sdbc)) != 0)
+				goto err;
 
 	ret = __db_associate(dbp, ip, txn, sdbp, callback, flags);
 

--- a/src/db/db_method.c
+++ b/src/db/db_method.c
@@ -243,8 +243,15 @@ __db_init(dbp, flags)
 	dbp->alt_close = NULL;
 	LOCK_INIT(dbp->handle_lock);
 
-	TAILQ_INIT(&dbp->free_queue);
-	TAILQ_INIT(&dbp->active_queue);
+	{
+		u_int32_t cqi;
+
+		for (cqi = 0; cqi < DB_CURSOR_NPART; cqi++) {
+			dbp->cq_parts[cqi].mutex = MUTEX_INVALID;
+			TAILQ_INIT(&dbp->cq_parts[cqi].free_queue);
+			TAILQ_INIT(&dbp->cq_parts[cqi].active_queue);
+		}
+	}
 	TAILQ_INIT(&dbp->join_queue);
 	LIST_INIT(&dbp->s_secondaries);
 

--- a/src/db/db_stati.c
+++ b/src/db/db_stati.c
@@ -382,6 +382,7 @@ __db_print_cursor(dbp)
 {
 	DBC *dbc;
 	ENV *env;
+	u_int32_t cq_i;
 	int ret, t_ret;
 
 	env = dbp->env;
@@ -390,20 +391,32 @@ __db_print_cursor(dbp)
 	__db_msg(env, "DB handle cursors:");
 
 	ret = 0;
-	MUTEX_LOCK(dbp->env, dbp->mutex);
 	__db_msg(env, "Active queue:");
-	TAILQ_FOREACH(dbc, &dbp->active_queue, links)
-		if ((t_ret = __db_print_citem(dbc)) != 0 && ret == 0)
-			ret = t_ret;
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++) {
+		struct __cq_part *cqp = &dbp->cq_parts[cq_i];
+
+		CQ_LOCK(dbp->env, cqp);
+		TAILQ_FOREACH(dbc, &cqp->active_queue, links)
+			if ((t_ret = __db_print_citem(dbc)) != 0 && ret == 0)
+				ret = t_ret;
+		CQ_UNLOCK(dbp->env, cqp);
+	}
+	MUTEX_LOCK(dbp->env, dbp->mutex);
 	__db_msg(env, "Join queue:");
 	TAILQ_FOREACH(dbc, &dbp->join_queue, links)
 		if ((t_ret = __db_print_citem(dbc)) != 0 && ret == 0)
 			ret = t_ret;
-	__db_msg(env, "Free queue:");
-	TAILQ_FOREACH(dbc, &dbp->free_queue, links)
-		if ((t_ret = __db_print_citem(dbc)) != 0 && ret == 0)
-			ret = t_ret;
 	MUTEX_UNLOCK(dbp->env, dbp->mutex);
+	__db_msg(env, "Free queue:");
+	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++) {
+		struct __cq_part *cqp = &dbp->cq_parts[cq_i];
+
+		CQ_LOCK(dbp->env, cqp);
+		TAILQ_FOREACH(dbc, &cqp->free_queue, links)
+			if ((t_ret = __db_print_citem(dbc)) != 0 && ret == 0)
+				ret = t_ret;
+		CQ_UNLOCK(dbp->env, cqp);
+	}
 
 	return (ret);
 }

--- a/src/db/partition.c
+++ b/src/db/partition.c
@@ -274,7 +274,7 @@ __partition_open(dbp, ip, txn, fname, type, flags, mode, do_open)
 	DB_PARTITION *part;
 	DBC *dbc;
 	ENV *env;
-	u_int32_t part_id;
+	u_int32_t cq_i, part_id;
 	int ret;
 	char *name, *sp;
 	const char **dirp, *np;
@@ -357,9 +357,12 @@ __partition_open(dbp, ip, txn, fname, type, flags, mode, do_open)
 	}
 
 	/* Get rid of the cursor used to open the database its the wrong type */
-done:	while ((dbc = TAILQ_FIRST(&dbp->free_queue)) != NULL)
-		if ((ret = __dbc_destroy(dbc)) != 0)
-			break;
+done:	for (cq_i = 0; cq_i < DB_CURSOR_NPART; cq_i++)
+		while ((dbc =
+		    TAILQ_FIRST(&dbp->cq_parts[cq_i].free_queue)) != NULL)
+			if ((ret = __dbc_destroy(dbc)) != 0)
+				goto donebreak;
+donebreak:
 
 	if (0) {
 err:		(void)__partition_close(dbp, txn, 0);

--- a/src/dbinc/db.in
+++ b/src/dbinc/db.in
@@ -1419,6 +1419,15 @@ typedef enum {
 #define	DB_TXN_CKP		(-30888)/* Encountered ckp record in log. */
 #define	DB_VERIFY_FATAL		(-30887)/* DB->verify cannot proceed. */
 
+/*
+ * Number of partitions the per-handle cursor free/active queues are sharded
+ * into.  Must be a power of two so the partition index can be a mask of the
+ * thread id.  A threaded (DB_THREAD) handle allocates this many extra
+ * process-only mutexes; non-threaded handles allocate none (the queues are
+ * accessed without locking, as before).
+ */
+#define	DB_CURSOR_NPART		8
+
 /* Database handle. */
 struct __db {
 	/*******************************************************
@@ -1505,20 +1514,33 @@ struct __db {
 	/*
 	 * Cursor queues.
 	 *
+	 * The free and active cursor queues are sharded into DB_CURSOR_NPART
+	 * partitions, each with its own mutex, so concurrent cursor alloc/free
+	 * on a shared (DB_THREAD) handle does not serialize on a single mutex.
+	 * A cursor records its partition (DBC->part) at allocation so it is
+	 * always returned to the same partition, even when closed by a
+	 * different thread than allocated it.  The join queue is not sharded
+	 * (join cursors are rare and not on the hot path); it stays under
+	 * dbp->mutex.
+	 *
 	 * !!!
 	 * Explicit representations of structures from queue.h.
-	 * TAILQ_HEAD(__cq_fq, __dbc) free_queue;
-	 * TAILQ_HEAD(__cq_aq, __dbc) active_queue;
+	 * Per partition:
+	 *   TAILQ_HEAD(__cq_fq, __dbc) free_queue;
+	 *   TAILQ_HEAD(__cq_aq, __dbc) active_queue;
 	 * TAILQ_HEAD(__cq_jq, __dbc) join_queue;
 	 */
-	struct __cq_fq {
-		struct __dbc *tqh_first;
-		struct __dbc **tqh_last;
-	} free_queue;
-	struct __cq_aq {
-		struct __dbc *tqh_first;
-		struct __dbc **tqh_last;
-	} active_queue;
+	struct __cq_part {
+		db_mutex_t mutex;		/* Partition mutex (or INVALID). */
+		struct __cq_fq {
+			struct __dbc *tqh_first;
+			struct __dbc **tqh_last;
+		} free_queue;
+		struct __cq_aq {
+			struct __dbc *tqh_first;
+			struct __dbc **tqh_last;
+		} active_queue;
+	} cq_parts[DB_CURSOR_NPART];
 	struct __cq_jq {
 		struct __dbc *tqh_first;
 		struct __dbc **tqh_last;
@@ -2024,10 +2046,17 @@ struct __dbc {
 	/*
 	 * Active/free cursor queues.
 	 *
+	 * "part" is the index of the DB handle cursor-queue partition this
+	 * cursor belongs to (DB->cq_parts[part]).  It is assigned when the
+	 * cursor is allocated and never changes, so the cursor is returned to
+	 * the same partition when freed -- even if it is closed by a different
+	 * thread than allocated it.
+	 *
 	 * !!!
 	 * Explicit representations of structures from queue.h.
 	 * TAILQ_ENTRY(__dbc) links;
 	 */
+	u_int32_t part;		/* Cursor-queue partition index. */
 	struct {
 		DBC *tqe_next;
 		DBC **tqe_prev;

--- a/src/dbinc/db_am.h
+++ b/src/dbinc/db_am.h
@@ -12,6 +12,32 @@
 extern "C" {
 #endif
 
+/*
+ * Cursor-queue partition selection.
+ *
+ * Choose a partition for a cursor from the allocating thread so that threads
+ * sharing a DB handle spread their cursor alloc/free across the per-handle
+ * partitions instead of serializing on one mutex.  The thread id (pid) is
+ * mixed and masked to [0, DB_CURSOR_NPART).  When there is no thread info
+ * (non-threaded handle or an internal path), partition 0 is used; a
+ * non-threaded handle does no locking anyway.  DB_CURSOR_NPART is a power of
+ * two so the mask is exact.
+ *
+ * DB_CURSOR_PART(dbc)  -- the partition struct a cursor belongs to.
+ * CQ_LOCK/CQ_UNLOCK    -- lock/unlock a partition's mutex (no-op when the
+ *                         handle is not threaded, i.e. the mutex is INVALID,
+ *                         exactly as the old single dbp->mutex behaved).
+ */
+#define	DB_CURSOR_PART_PICK(dbp, ip)					\
+	((u_int32_t)(((ip) == NULL ? 0 :				\
+	    ((uintptr_t)(ip)->dbth_pid * 2654435761U)) >> 16) &		\
+	    (DB_CURSOR_NPART - 1))
+
+#define	DB_CURSOR_PART(dbc)	(&(dbc)->dbp->cq_parts[(dbc)->part])
+
+#define	CQ_LOCK(env, part)	MUTEX_LOCK(env, (part)->mutex)
+#define	CQ_UNLOCK(env, part)	MUTEX_UNLOCK(env, (part)->mutex)
+
 struct __db_foreign_info; \
 			typedef struct __db_foreign_info DB_FOREIGN_INFO;
 

--- a/src/dbinc/db_am.h
+++ b/src/dbinc/db_am.h
@@ -17,21 +17,36 @@ extern "C" {
  *
  * Choose a partition for a cursor from the allocating thread so that threads
  * sharing a DB handle spread their cursor alloc/free across the per-handle
- * partitions instead of serializing on one mutex.  The thread id (pid) is
- * mixed and masked to [0, DB_CURSOR_NPART).  When there is no thread info
- * (non-threaded handle or an internal path), partition 0 is used; a
- * non-threaded handle does no locking anyway.  DB_CURSOR_NPART is a power of
- * two so the mask is exact.
+ * partitions instead of serializing on one mutex.
  *
+ * The partition must be derived from the THREAD identity, not the process
+ * identity, and must not depend on the optional thread-info block:
+ *
+ *   - DB_THREAD_INFO.dbth_pid is the *process* id (dbenv->thread_id defaults
+ *     to __os_id, which returns env->pid_cache), so every thread in a process
+ *     hashes alike -- the sharding would degenerate to a single partition,
+ *     which is exactly the mutex this code exists to relieve.
+ *   - ip is NULL entirely unless the application called set_thread_count()
+ *     (ENV_ENTER yields NULL when env->thr_hashtab == NULL), so ip cannot be
+ *     the source of the identity either.
+ *
+ * So call dbenv->thread_id for the thread id directly.  DB_CURSOR_NPART is a
+ * power of two; the id is mixed by a Knuth multiplicative hash and the HIGH
+ * bits are taken, because the low/middle bits of a db_threadid_t are poorly
+ * distributed (a pthread_t is typically a stack address, so bits below the
+ * per-thread stack stride are constant).
+ *
+ * DB_CURSOR_PART_PICK  -- partition index for the calling thread.
  * DB_CURSOR_PART(dbc)  -- the partition struct a cursor belongs to.
  * CQ_LOCK/CQ_UNLOCK    -- lock/unlock a partition's mutex (no-op when the
  *                         handle is not threaded, i.e. the mutex is INVALID,
  *                         exactly as the old single dbp->mutex behaved).
  */
-#define	DB_CURSOR_PART_PICK(dbp, ip)					\
-	((u_int32_t)(((ip) == NULL ? 0 :				\
-	    ((uintptr_t)(ip)->dbth_pid * 2654435761U)) >> 16) &		\
+#define	DB_CURSOR_PART_HASH(v)						\
+	((u_int32_t)(((u_int32_t)(uintptr_t)(v) * 2654435761U) >> 29) &	\
 	    (DB_CURSOR_NPART - 1))
+
+#define	DB_CURSOR_PART_PICK(dbp, ip)	__db_cursor_part(dbp)
 
 #define	DB_CURSOR_PART(dbc)	(&(dbc)->dbp->cq_parts[(dbc)->part])
 

--- a/src/dbinc_auto/db_ext.h
+++ b/src/dbinc_auto/db_ext.h
@@ -31,6 +31,7 @@ int __db_testcopy __P((ENV *, DB *, const char *));
 #endif
 int __db_testdocopy __P((ENV *, const char *));
 int __db_cursor_int __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBTYPE, db_pgno_t, int, DB_LOCKER *, DBC **));
+int __db_cq_active_any __P((DB *));
 int __db_put __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBT *, DBT *, u_int32_t));
 int __db_del __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBT *, u_int32_t));
 int __db_sync __P((DB *));

--- a/src/dbinc_auto/db_ext.h
+++ b/src/dbinc_auto/db_ext.h
@@ -31,6 +31,7 @@ int __db_testcopy __P((ENV *, DB *, const char *));
 #endif
 int __db_testdocopy __P((ENV *, const char *));
 int __db_cursor_int __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBTYPE, db_pgno_t, int, DB_LOCKER *, DBC **));
+u_int32_t __db_cursor_part __P((DB *));
 int __db_cq_active_any __P((DB *));
 int __db_put __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBT *, DBT *, u_int32_t));
 int __db_del __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBT *, u_int32_t));

--- a/src/dbinc_auto/int_def.in
+++ b/src/dbinc_auto/int_def.in
@@ -31,6 +31,8 @@
 #endif
 #define	__db_testdocopy __db_testdocopy@DB_VERSION_UNIQUE_NAME@
 #define	__db_cursor_int __db_cursor_int@DB_VERSION_UNIQUE_NAME@
+#define	__db_cursor_part __db_cursor_part@DB_VERSION_UNIQUE_NAME@
+#define	__db_cq_active_any __db_cq_active_any@DB_VERSION_UNIQUE_NAME@
 #define	__db_put __db_put@DB_VERSION_UNIQUE_NAME@
 #define	__db_del __db_del@DB_VERSION_UNIQUE_NAME@
 #define	__db_sync __db_sync@DB_VERSION_UNIQUE_NAME@

--- a/test/bench/CURSOR-SHARD-RESULTS.md
+++ b/test/bench/CURSOR-SHARD-RESULTS.md
@@ -1,0 +1,113 @@
+# Cursor-queue sharding: measurement
+
+`DB->get` allocates and frees a transient cursor per operation, and
+`__db_cursor_int` / `__dbc_close` take `dbp->mutex` to move it between the
+handle's free and active queues. When many threads share one `DB` handle that
+mutex serializes every `get`. This directory records what sharding those queues
+is actually worth, measured rather than asserted.
+
+## Result
+
+Idle EC2 `c7i.24xlarge` (96 vCPU, Xeon Platinum 8488C, 1 NUMA node, THP never,
+numa_balancing off), 5 reps per point, `scale_bench` `rrand`, medians in ops/s.
+Raw data: `results/cursor-shard-sweep-c7i.24xlarge.tsv`.
+
+| threads | master | sharded, as first written | sharded + thread-id fix |
+|--------:|-------:|--------------------------:|------------------------:|
+|       1 | 926867 |                    924332 |                  916862 |
+|       8 | 556739 |            396060 (−29 %) |         2456548 (4.4×)  |
+|      16 | 292833 |            167177 (−43 %) |         3294383 (11.3×) |
+|      24 | 174288 |            118063 (−32 %) |         3706043 (21.3×) |
+|      48 |  79234 |                    106842 |         3590889 (45.3×) |
+|      96 |  51872 |                    131336 |         2028715 (39.1×) |
+
+Coefficient of variation across reps was 1.2–12.8 %, so the effect is far outside
+run-to-run noise. Single-threaded throughput is unchanged, which is the expected
+shape: with one thread there is no contention to remove, and the added hash plus
+per-partition mutexes cost nothing measurable.
+
+**As first written, the change was a 29–43 % regression.** The idea is sound; the
+partition selection was not.
+
+## Why the first version made things worse
+
+Partition selection degenerated two independent ways. Both were confirmed in the
+source and then instrumented in a real library driving 480 000 threaded
+`DB->get` calls on a shared `DB_THREAD` handle across 24 threads.
+
+1. **It hashed the process id.** `DB_CURSOR_PART_PICK` used `ip->dbth_pid`, and
+   `__os_id` returns `env->pid_cache` / `getpid()` (`src/os/os_pid.c`);
+   `src/env/env_failchk.c` sets `dbth_pid` from `id.pid` separately from
+   `dbth_tid` from `id.tid`. Every thread in a process therefore hashes to the
+   same partition. Instrumented: `part[5] = 480000`, every other partition 0.
+
+2. **On a default environment the thread-info block does not exist at all.**
+   `ENV_ENTER` sets `ip = NULL` when `env->thr_hashtab == NULL`
+   (`src/dbinc/db_int.in`), and `thr_hashtab` is NULL whenever `thr_max == 0`
+   (`src/env/env_failchk.c`) — that is, unless the application called
+   `DB_ENV->set_thread_count()`. The macro's `(ip) == NULL ? 0` arm then pins
+   everything to partition 0 and the pid is never even hashed. Instrumented:
+   `part[0] = 480000`, with `ip == NULL` on 480000 of 480000 calls.
+
+So the sharded build paid for a hash and eight mutexes per handle while still
+funnelling every allocation through one partition — strictly worse than the
+single mutex it replaced.
+
+**A trap for anyone benchmarking this area:** none of `scale_bench.c`,
+`scale_iso.c` or `lock_bench.c` calls `set_thread_count`, so a benchmark of the
+original change exercises path 2. The result is pure overhead with zero sharding,
+which is indistinguishable from "sharding does not help" unless you check the
+partition distribution.
+
+## The fix
+
+`__db_cursor_part()` asks `dbenv->thread_id()` for the real thread id and hashes
+it with `DB_CURSOR_PART_HASH`, taking the **high** bits after Knuth
+multiplicative mixing. The high bits matter: `db_threadid_t` is `pthread_t`,
+typically a stack address, so bits below the per-thread stack stride are constant
+and the original `(v * 2654435761U) >> 16 & 7` collides even after substituting
+the correct field. Swapping `dbth_pid` for `dbth_tid` alone is not sufficient.
+Thread types that are not simple integers are folded through `__ham_func5` first.
+
+## Why a 45× gain is credible
+
+A number that large invites suspicion, so it was checked against a workload that
+should *not* benefit.
+
+On `rhot` — hot-key reads, where every thread contends for the same few pages —
+the fix gains only **1.18×** (188 272 → 222 216 at 24 threads), and the lock
+partition becomes the bottleneck instead: `lockpart_pct` rises from about 9 % to
+74 %. A change that removes the cursor-allocation mutex should help uniform
+random reads enormously and hot-key reads barely, and that is the observed
+asymmetry.
+
+It also agrees with an independent earlier experiment: giving each thread its own
+`DB` handle, which sidesteps `dbp->mutex` entirely, ran +49 % faster at 24
+threads. Sharding recovers far more than that because it removes the serialization
+without duplicating per-handle state, and the bottleneck moves to
+`__memp_fget` / `__memp_fput` — exactly where that study predicted it would land.
+
+## Correctness
+
+On the rebased branch: 9/9 `test/db` regression runners; `test/isolation`,
+`test/lockmatrix` and `test/soak` (5 workloads, 0 unexpected); TCL `lock001`,
+`txn001`, `ssi001`, `ssi002`, and — the cursor-lifetime cases that sharding could
+plausibly break — `test001`, `test003`, `test011` (duplicates and off-page
+duplicates), `test026` (cursor delete) across btree and hash, plus `jointest`
+(join cursors). All pass.
+
+An AddressSanitizer build is clean with **zero** sanitizer findings. Three
+apparent ASan failures were harness artifacts, not defects: the `test/db` runners
+compile their driver without `-fsanitize=address`, so the link fails on
+`__asan_report_load4`, and `run_qam_readpath_bound` reports `rc=124` purely from
+ASan's 5–7× slowdown against its timing threshold (it passes with
+`QAM_DOS_LIMIT_SECS=800`).
+
+## What is not measured here
+
+Write workloads (`wrand` is fsync-bound and not cursor-limited), multi-socket
+NUMA effects (the instance has a single node), and cross-engine comparison. The
+sweep used a standalone driver rather than `run_bench.sh`, so there is no
+`bench_cmp.py` verdict against `baseline-c7i.24xlarge.tsv`; the committed baseline
+does not include a shared-handle threaded-`get` case, which is the workload this
+change targets.

--- a/test/bench/results/cursor-shard-sweep-c7i.24xlarge.tsv
+++ b/test/bench/results/cursor-shard-sweep-c7i.24xlarge.tsv
@@ -1,0 +1,145 @@
+# libdb cursor-shard sweep  variants=master,shard,fixed  suffix=''
+# reps=5 secs=10 nkeys=100000 primary_threads='1 8 16 24 48 96' ctrl_threads='24'
+# hw=
+# cpu=Intel(R) Xeon(R) Platinum 8488C vcpus=96
+# numa_nodes=1 kernel=6.18.44-99.149.amzn2023.x86_64 gcc=11
+# thp=always madvise [never] numa_bal=0
+# mutex_tier=1
+# loadavg_start=2.78 5.09 3.87
+variant	workload	threads	rep	ops_per_sec	lockpart_pct	mpoolhash_pct	lockers_pct
+master	rrand	1	1	926867	0.0	0.0	0.0
+shard	rrand	1	1	907639	0.0	0.0	0.0
+fixed	rrand	1	1	916862	0.0	0.0	0.0
+master	rrand	8	1	584310	0.0	0.0	7.1
+shard	rrand	8	1	391126	0.0	0.0	28.6
+fixed	rrand	8	1	2177839	0.1	0.0	14.3
+master	rrand	16	1	297170	0.0	0.0	7.4
+shard	rrand	16	1	161127	0.0	0.0	56.7
+fixed	rrand	16	1	4027968	0.1	0.0	7.1
+master	rrand	24	1	200823	0.0	0.0	46.2
+shard	rrand	24	1	121854	0.0	0.0	46.2
+fixed	rrand	24	1	3603558	0.1	0.0	70.7
+master	rrand	48	1	81392	0.0	0.0	0.0
+shard	rrand	48	1	104994	0.0	0.0	58.0
+fixed	rrand	48	1	3506431	0.1	0.0	63.6
+master	rrand	96	1	52254	0.0	0.0	37.8
+shard	rrand	96	1	128392	0.0	0.0	64.4
+fixed	rrand	96	1	2015789	0.1	0.0	67.6
+master	rhot	24	1	188272	9.0	0.0	47.4
+shard	rhot	24	1	101559	1.4	0.0	16.2
+fixed	rhot	24	1	215984	74.1	0.0	0.0
+master	sepdb	24	1	2696272	0.1	0.0	95.2
+shard	sepdb	24	1	2712495	0.1	0.0	92.3
+fixed	sepdb	24	1	3014592	0.1	0.0	53.8
+master	none	24	1	0			
+shard	none	24	1	0			
+fixed	none	24	1	0			
+master	rrand	1	2	921555	0.0	0.0	0.0
+shard	rrand	1	2	934910	0.0	0.0	0.0
+fixed	rrand	1	2	925619	0.0	0.0	0.0
+master	rrand	8	2	594687	0.0	0.0	42.9
+shard	rrand	8	2	400830	0.0	0.0	0.0
+fixed	rrand	8	2	2283016	0.1	0.0	57.1
+master	rrand	16	2	259637	0.0	0.0	72.4
+shard	rrand	16	2	167177	0.0	0.0	11.1
+fixed	rrand	16	2	3294383	0.1	0.0	25.9
+master	rrand	24	2	172573	0.0	0.0	16.2
+shard	rrand	24	2	96208	0.0	0.0	16.2
+fixed	rrand	24	2	3885661	0.1	0.0	8.1
+master	rrand	48	2	76016	0.0	0.0	69.8
+shard	rrand	48	2	105973	0.0	0.0	61.8
+fixed	rrand	48	2	3590889	0.1	0.0	53.2
+master	rrand	96	2	51872	0.0	0.0	82.7
+shard	rrand	96	2	131336	0.0	0.0	71.4
+fixed	rrand	96	2	2096054	0.1	0.0	64.3
+master	rhot	24	2	185112	10.5	0.0	81.4
+shard	rhot	24	2	97523	1.3	0.0	10.8
+fixed	rhot	24	2	221078	34.4	0.0	18.9
+master	sepdb	24	2	2494215	0.1	0.0	97.5
+shard	sepdb	24	2	2752211	0.1	0.0	95.0
+fixed	sepdb	24	2	2792159	0.1	0.0	21.6
+master	none	24	2	0			
+shard	none	24	2	0			
+fixed	none	24	2	0			
+master	rrand	1	3	928816	0.0	0.0	0.0
+shard	rrand	1	3	919396	0.0	0.0	0.0
+fixed	rrand	1	3	925415	0.0	0.0	0.0
+master	rrand	8	3	537347	0.0	0.0	28.6
+shard	rrand	8	3	396060	0.0	0.0	21.4
+fixed	rrand	8	3	2533914	0.1	0.0	42.9
+master	rrand	16	3	303648	0.0	0.0	18.5
+shard	rrand	16	3	174873	0.0	0.0	14.8
+fixed	rrand	16	3	3288057	0.1	0.0	11.1
+master	rrand	24	3	193605	0.0	0.0	48.7
+shard	rrand	24	3	94541	0.0	0.0	16.2
+fixed	rrand	24	3	3706043	0.1	0.0	63.2
+master	rrand	48	3	79911	0.0	0.0	0.0
+shard	rrand	48	3	106842	0.0	0.0	66.7
+fixed	rrand	48	3	3674854	0.1	0.0	65.1
+master	rrand	96	3	51317	0.0	0.0	65.5
+shard	rrand	96	3	132457	0.0	0.0	75.5
+fixed	rrand	96	3	2051262	0.1	0.0	29.7
+master	rhot	24	3	181232	9.6	0.0	85.7
+shard	rhot	24	3	106182	1.4	0.0	25.0
+fixed	rhot	24	3	222216	76.7	0.0	56.1
+master	sepdb	24	3	2902010	0.1	0.0	94.7
+shard	sepdb	24	3	3144621	0.1	0.0	92.7
+fixed	sepdb	24	3	2650679	0.1	0.0	30.6
+master	none	24	3	0			
+shard	none	24	3	0			
+fixed	none	24	3	0			
+master	rrand	1	4	929395	0.0	0.0	0.0
+shard	rrand	1	4	932383	0.0	0.0	0.0
+fixed	rrand	1	4	908569	0.0	0.0	0.0
+master	rrand	8	4	553147	0.0	0.0	64.3
+shard	rrand	8	4	384296	0.0	0.0	21.4
+fixed	rrand	8	4	2484324	0.1	0.0	50.0
+master	rrand	16	4	280728	0.0	0.0	0.0
+shard	rrand	16	4	157403	0.0	0.0	3.7
+fixed	rrand	16	4	3251460	0.1	0.0	0.0
+master	rrand	24	4	171393	0.0	0.0	10.8
+shard	rrand	24	4	118063	0.0	0.0	17.9
+fixed	rrand	24	4	3420285	0.1	0.0	61.5
+master	rrand	48	4	79234	0.0	0.0	47.4
+shard	rrand	48	4	108738	0.0	0.0	0.0
+fixed	rrand	48	4	3650038	0.1	0.0	10.8
+master	rrand	96	4	53035	0.0	0.0	79.6
+shard	rrand	96	4	132070	0.0	0.0	75.5
+fixed	rrand	96	4	1951594	0.1	0.0	28.4
+master	rhot	24	4	198735	9.9	0.0	79.5
+shard	rhot	24	4	90214	1.1	0.0	0.0
+fixed	rhot	24	4	245412	75.5	0.0	36.8
+master	sepdb	24	4	2779482	0.1	0.0	88.9
+shard	sepdb	24	4	2969764	0.1	0.0	94.7
+fixed	sepdb	24	4	2813993	0.1	0.0	43.6
+master	none	24	4	0			
+shard	none	24	4	0			
+fixed	none	24	4	0			
+master	rrand	1	5	920247	0.0	0.0	0.0
+shard	rrand	1	5	924332	0.0	0.0	0.0
+fixed	rrand	1	5	905803	0.0	0.0	0.0
+master	rrand	8	5	556739	0.0	0.0	0.0
+shard	rrand	8	5	405276	0.0	0.0	14.3
+fixed	rrand	8	5	2456548	0.1	0.0	0.0
+master	rrand	16	5	292833	0.0	0.0	44.4
+shard	rrand	16	5	168034	0.0	0.0	29.6
+fixed	rrand	16	5	3654267	0.1	0.0	21.4
+master	rrand	24	5	174288	0.0	0.0	5.4
+shard	rrand	24	5	123296	0.0	0.0	35.9
+fixed	rrand	24	5	3726570	0.1	0.0	59.5
+master	rrand	48	5	76860	0.0	0.0	58.2
+shard	rrand	48	5	108988	0.0	0.0	0.0
+fixed	rrand	48	5	3473046	0.1	0.0	67.7
+master	rrand	96	5	51803	0.0	0.0	76.8
+shard	rrand	96	5	128166	0.0	0.0	72.6
+fixed	rrand	96	5	2028715	0.1	0.0	53.5
+master	rhot	24	5	268274	72.9	0.0	59.5
+shard	rhot	24	5	101898	1.3	0.0	68.3
+fixed	rhot	24	5	235679	74.5	0.0	10.8
+master	sepdb	24	5	2855904	0.1	0.0	97.5
+shard	sepdb	24	5	2699871	0.1	0.0	94.7
+fixed	sepdb	24	5	2855918	0.1	0.0	2.7
+master	none	24	5	0			
+shard	none	24	5	0			
+fixed	none	24	5	0			
+# loadavg_end=19.78 22.40 19.27


### PR DESCRIPTION
Resurrects `perf/cursor-shard` — a commit that sat unmerged for months, never had a PR, and shipped with **"At-scale measurement on the 24-core box pending"** in its own message. That measurement has now been done, and it changed the answer.

## The measurement

Idle EC2 `c7i.24xlarge` (96 vCPU, Xeon Platinum 8488C, 1 NUMA node), 5 reps per point, `scale_bench` `rrand`, medians in ops/s. CV 1.2–12.8 %, so far outside noise.

| threads | master | as first written | with the thread-id fix |
|--------:|-------:|-----------------:|-----------------------:|
|       1 | 926867 |           924332 |                 916862 |
|       8 | 556739 |   396060 (−29 %) |        2456548 (4.4×)  |
|      16 | 292833 |   167177 (−43 %) |        3294383 (11.3×) |
|      24 | 174288 |   118063 (−32 %) |        3706043 (21.3×) |
|      48 |  79234 |           106842 |        3590889 (45.3×) |
|      96 |  51872 |           131336 |        2028715 (39.1×) |

**As first written it was a 29–43 % regression.** The idea was right; the partition selection was broken two independent ways — both confirmed in source, then instrumented over 480 000 threaded `DB->get` calls:

1. It hashed **`ip->dbth_pid`**, the *process* id (`__os_id` returns `env->pid_cache`/`getpid()`), so every thread in a process picked the same partition. Measured: `part[5] = 480000`, all others 0.
2. Worse — on a **default** environment `ip` is NULL entirely. `ENV_ENTER` sets `ip = NULL` when `env->thr_hashtab == NULL`, which holds unless the application called `set_thread_count()`. The macro's `(ip) == NULL ? 0` arm then pinned everything to partition 0 and never hashed at all. Measured: `part[0] = 480000`, `ip == NULL` on 480000/480000.

So it paid for a hash and eight mutexes per handle while still funnelling every allocation through one partition — strictly worse than the single mutex it replaced.

**A trap for future work here:** none of `scale_bench.c`, `scale_iso.c` or `lock_bench.c` calls `set_thread_count`, so benchmarking the original change exercises path 2 — pure overhead, zero sharding, *indistinguishable from "sharding doesn't help"* unless you check the partition distribution.

## The fix (`25bede803`)

`__db_cursor_part()` asks `dbenv->thread_id()` for the real thread id and hashes it taking the **high** bits after Knuth mixing. The high bits matter: `db_threadid_t` is `pthread_t`, typically a stack address, so bits below the per-thread stack stride are constant and the original `(v * 2654435761U) >> 16 & 7` collides *even after* substituting the correct field. A field swap alone is not enough. Non-simple thread types fold through `__ham_func5`.

## Why 45× is credible

A number that large deserves suspicion, so it was checked against a workload that should **not** benefit. On `rhot` (hot-key reads) the fix gains only **1.18×**, and the lock partition takes over as the bottleneck (`lockpart_pct` ≈ 9 % → 74 %). Helping uniform random reads enormously while barely helping hot-key reads is exactly the right shape for removing the cursor-allocation mutex.

It also agrees with an independent earlier experiment: per-thread handles, which sidestep `dbp->mutex` entirely, ran +49 % at 24 threads. Sharding beats that because it removes the serialization without duplicating per-handle state, and the bottleneck moves to `__memp_fget`/`__memp_fput` — where that study predicted it would land.

## Correctness

9/9 `test/db` runners · `test/isolation` · `test/lockmatrix` · `test/soak` (5 workloads, 0 unexpected) · TCL `lock001`, `txn001`, `ssi001`, `ssi002`, and the cursor-lifetime cases sharding could plausibly break: **`test001`, `test003`, `test011`** (duplicates + off-page duplicates), **`test026`** (cursor delete) across btree *and* hash, plus **`jointest`** (join cursors). All pass.

ASan build clean, **zero** sanitizer findings. Three apparent ASan failures were harness artifacts: the `test/db` runners compile their driver without `-fsanitize=address` so the link dies on `__asan_report_load4`, and `run_qam_readpath_bound` hits `rc=124` purely from ASan's 5–7× slowdown against its timing threshold (passes with `QAM_DOS_LIMIT_SECS=800`).

## Honest limits

`wrand` is fsync-bound and not cursor-limited, so writes are unmeasured. Single NUMA node, so no NUMA effects. The sweep used a standalone driver, so there is **no `bench_cmp.py` verdict** against `baseline-c7i.24xlarge.tsv` — the committed baseline has no shared-handle threaded-`get` case, which is precisely the workload this targets. Adding one is the obvious follow-up.

Raw sweep committed with full hardware provenance (`test/bench/results/`) so the numbers can be re-derived rather than trusted.
