### PR TITLE
ci(abi): gate ABI-incompatible changes and run on master

### DIFF
--- a/.github/workflows/cocci.yml
+++ b/.github/workflows/cocci.yml
@@ -151,9 +151,8 @@ jobs:
   # only the header-regen drift sub-check is blocking.
   # ---------------------------------------------------------------------------
   abi-diff:
-    name: abi drift (advisory)
+    name: abi drift
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -217,6 +216,13 @@ jobs:
             echo
             echo '```'
             abidiff "$BASE_SO" "$HEAD_SO" 2>&1 | head -200 || true
+            # abidiff's exit status is a bitmask: bit0(1)=error, bit2(4)=ABI
+            # CHANGE, bit3(8)=ABI INCOMPATIBLE change.  Only 8 means a caller
+            # compiled against the base release could break, so that is the one
+            # worth failing on; 4 alone covers benign additions.
+            abidiff "$BASE_SO" "$HEAD_SO" >/dev/null 2>&1; ABI_RC=$?
+            echo "abidiff exit bitmask: $ABI_RC"
+            echo "abi_rc=$ABI_RC" >> "$GITHUB_OUTPUT"
             echo '```'
             echo
             echo "#### Removed exported symbols (nm -D, _NNNN version suffix normalized)"
@@ -236,8 +242,43 @@ jobs:
           } > /tmp/abi-report.md
           cat /tmp/abi-report.md
 
-      - name: Post ABI report to PR
+      # The report above is informational; THIS is the gate.  It is deliberately
+      # narrow: only an ABI-INCOMPATIBLE change (abidiff bit3) fails, because
+      # that is the case where a caller built against the previous release could
+      # break.  Benign additions (bit2) are reported and allowed.
+      #
+      # Escape hatch: a deliberate ABI break -- e.g. removing DB_TXN_SNAPSHOT_SAFE
+      # in 5.3.34 -- is declared by putting the literal token ABI-BREAK-INTENDED
+      # in the PR body or the head commit message.  It must be explicit, so an
+      # accidental break cannot pass as an intended one.
+      - name: ABI compatibility gate
         if: always()
+        env:
+          ABI_RC: ${{ steps.abi.outputs.abi_rc }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          rc="${ABI_RC:-0}"
+          if [ "$rc" = "" ]; then rc=0; fi
+          # No comparison happened (no base tag, build skipped): nothing to gate.
+          if [ "$rc" -eq 0 ]; then
+            echo "::notice title=ABI::No ABI change against the base release."
+            exit 0
+          fi
+          if [ $((rc & 8)) -eq 0 ]; then
+            echo "::notice title=ABI::abidiff reports changes (bitmask $rc) but none ABI-incompatible."
+            exit 0
+          fi
+          if printf '%s' "$PR_BODY" | grep -q 'ABI-BREAK-INTENDED' ||
+             git log -1 --format=%B | grep -q 'ABI-BREAK-INTENDED'; then
+            echo "::warning title=ABI::ABI-INCOMPATIBLE change, declared intentional via ABI-BREAK-INTENDED."
+            exit 0
+          fi
+          echo "::error title=ABI::abidiff reports an ABI-INCOMPATIBLE change (bitmask $rc) against the base release."
+          echo "::error::If this is deliberate, put ABI-BREAK-INTENDED in the PR body or commit message and say why."
+          exit 1
+
+      - name: Post ABI report to PR
+        if: always() && github.event_name == 'pull_request'
         continue-on-error: true
         uses: actions/github-script@v9
         with:

--- a/src/dbinc_auto/db_ext.h
+++ b/src/dbinc_auto/db_ext.h
@@ -30,9 +30,9 @@ int __db_backup_name __P((ENV *, const char *, DB_TXN *, char **));
 int __db_testcopy __P((ENV *, DB *, const char *));
 #endif
 int __db_testdocopy __P((ENV *, const char *));
-int __db_cursor_int __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBTYPE, db_pgno_t, int, DB_LOCKER *, DBC **));
 u_int32_t __db_cursor_part __P((DB *));
 int __db_cq_active_any __P((DB *));
+int __db_cursor_int __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBTYPE, db_pgno_t, int, DB_LOCKER *, DBC **));
 int __db_put __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBT *, DBT *, u_int32_t));
 int __db_del __P((DB *, DB_THREAD_INFO *, DB_TXN *, DBT *, u_int32_t));
 int __db_sync __P((DB *));

--- a/src/dbinc_auto/int_def.in
+++ b/src/dbinc_auto/int_def.in
@@ -30,9 +30,9 @@
 #define	__db_testcopy __db_testcopy@DB_VERSION_UNIQUE_NAME@
 #endif
 #define	__db_testdocopy __db_testdocopy@DB_VERSION_UNIQUE_NAME@
-#define	__db_cursor_int __db_cursor_int@DB_VERSION_UNIQUE_NAME@
 #define	__db_cursor_part __db_cursor_part@DB_VERSION_UNIQUE_NAME@
 #define	__db_cq_active_any __db_cq_active_any@DB_VERSION_UNIQUE_NAME@
+#define	__db_cursor_int __db_cursor_int@DB_VERSION_UNIQUE_NAME@
 #define	__db_put __db_put@DB_VERSION_UNIQUE_NAME@
 #define	__db_del __db_del@DB_VERSION_UNIQUE_NAME@
 #define	__db_sync __db_sync@DB_VERSION_UNIQUE_NAME@


### PR DESCRIPTION
You flagged that `abi drift` shouldn't be advisory-skipped on master. It was worse than skipped — it also **could not fail**.

## Two defects

**1. It never ran on master.** `if: github.event_name == 'pull_request'` meant every master push skipped the job entirely.

**2. It could not fail even on a PR.** The `abidiff` step is `continue-on-error` and `exit 0`s on every path, so the result was a report and nothing more. That is exactly how 5.3.37's change to the public `struct __db` reached a release with the ABI question answered **by hand** rather than by CI.

For the record that one *was* compatible — `sizeof(DB)=1456` and `sizeof(DBC)=552` before and after, because the cursor partitions replace the old single queue pair within the same footprint — but nothing in CI established it, and I only checked because you asked whether we'd qualified the release.

## The gate

Deliberately narrow. `abidiff`'s exit status is a bitmask, and only **bit3 (8, ABI INCOMPATIBLE)** fails:

| bitmask | meaning | verdict |
|---:|---|---|
| 0 | no ABI change | pass |
| 4 | ABI change, compatible (e.g. an addition) | pass, reported |
| 8 | **ABI incompatible** | **fail** |
| 12 | both | **fail** |

Branch logic verified for all four values. Benign additions stay unblocked so ordinary development isn't impeded.

**Escape hatch for deliberate breaks** — e.g. removing `DB_TXN_SNAPSHOT_SAFE` in 5.3.34 — is the literal token `ABI-BREAK-INTENDED` in the PR body or head commit message. It must be explicit, so an accidental break can't pass as an intended one.

The header-regen drift gate in the same job was already blocking and is unchanged. The PR-comment step keeps its `pull_request` condition, since there's no PR to comment on for a master push.

CI on this PR is itself the test: the base tag is now v5.3.37, which I've independently shown is ABI-compatible, so the gate should report a clean comparison.
